### PR TITLE
Update Recorded Exercise Completion times to be TimeOnly

### DIFF
--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -27,7 +27,7 @@ public record SessionBlueprint(string Name, ImmutableListValue<ExerciseBlueprint
             Guid.NewGuid(),
             this,
             Exercises.Select(GetNextExercise).ToImmutableList(),
-            DateOnly.FromDateTime(DateTimeOffset.Now.LocalDateTime)
+            DateOnly.FromDateTime(DateTime.Now)
         );
     }
 }

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -84,4 +84,4 @@ public record RecordedExercise(
     public bool HasRemainingSets => RecordedSets.Any(x => x is null);
 }
 
-public record RecordedSet(int RepsCompleted, DateTimeOffset CompletionTime);
+public record RecordedSet(int RepsCompleted, TimeOnly CompletionTime);

--- a/LiftLog.Tests/Blueprints.cs
+++ b/LiftLog.Tests/Blueprints.cs
@@ -1,0 +1,36 @@
+using LiftLog.Lib;
+using LiftLog.Lib.Models;
+
+namespace LiftLog.Tests;
+
+public static class Blueprints
+{
+    public static ExerciseBlueprint CreateExerciseBlueprint(
+        Func<ExerciseBlueprint, ExerciseBlueprint>? transform = null
+    )
+    {
+        return (transform ?? (e => e)).Invoke(
+            new ExerciseBlueprint(
+                Name: "Test Exercise",
+                Sets: 3,
+                RepsPerSet: 10,
+                InitialKilograms: 20,
+                KilogramsIncreaseOnSuccess: 2.5m,
+                RestBetweenSets: Rest.Medium,
+                SupersetWithNext: false
+            )
+        );
+    }
+
+    public static SessionBlueprint CreateSessionBlueprint()
+    {
+        return new SessionBlueprint(
+            Name: "Test Session",
+            Exercises: ImmutableListValue.Of(
+                CreateExerciseBlueprint(),
+                CreateExerciseBlueprint(e => e with { Name = "Test Exercise 2", RepsPerSet = 4 }),
+                CreateExerciseBlueprint(e => e with { Name = "Test Exercise 3", Sets = 4 })
+            )
+        );
+    }
+}

--- a/LiftLog.Tests/GlobalUsings.cs
+++ b/LiftLog.Tests/GlobalUsings.cs
@@ -1,2 +1,3 @@
 global using Xunit;
 global using NSubstitute;
+global using System.Collections.Immutable;

--- a/LiftLog.Tests/LiftLog.Tests.csproj
+++ b/LiftLog.Tests/LiftLog.Tests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LiftLog.Backend.Functions\LiftLog_Backend_Functions.csproj" />
+    <ProjectReference Include="..\LiftLog.Ui\LiftLog.Ui.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LiftLog.Tests/Serialization/SerializationTests.cs
+++ b/LiftLog.Tests/Serialization/SerializationTests.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+using FluentAssertions;
+using LiftLog.Lib.Models;
+using LiftLog.Ui.Models.SessionHistoryDao;
+
+namespace LiftLog.Tests.Serialization;
+
+public class SerializationTests
+{
+    [Fact]
+    public void SessionHistoryDaoV1_SerializeDeserialize_RoundTrip()
+    {
+        var session = Sessions.CreateSession();
+        var sessionHistoryDao = SessionHistoryDaoV1.FromModel(
+            new SessionHistoryDaoContainer(
+                CompletedSessions: new Dictionary<Guid, Session>
+                {
+                    { session.Id, session }
+                }.ToImmutableDictionary()
+            )
+        );
+
+        var serialized = JsonSerializer.Serialize(
+            sessionHistoryDao,
+            StorageJsonContext.Context.SessionHistoryDaoV1
+        );
+        var deserialized = JsonSerializer.Deserialize(
+            serialized,
+            StorageJsonContext.Context.SessionHistoryDaoV1
+        );
+
+        deserialized!.Should().Be(sessionHistoryDao);
+        deserialized!.ToModel().CompletedSessions.First().Value.Should().Be(session);
+    }
+}

--- a/LiftLog.Tests/Sessions.cs
+++ b/LiftLog.Tests/Sessions.cs
@@ -1,0 +1,53 @@
+using LiftLog.Lib.Models;
+
+namespace LiftLog.Tests;
+
+public static class Sessions
+{
+    public static Session CreateSession(
+        SessionBlueprint? sessionBlueprint = null,
+        Func<Session, Session>? transform = null
+    )
+    {
+        sessionBlueprint ??= Blueprints.CreateSessionBlueprint();
+        return (transform ?? (s => s)).Invoke(
+            new Session(
+                Id: Guid.NewGuid(),
+                Blueprint: sessionBlueprint,
+                RecordedExercises: sessionBlueprint.Exercises
+                    .Select(x => CreateRecordedExercise(x))
+                    .ToImmutableList(),
+                Date: DateOnly.Parse("2021-04-05")
+            )
+        );
+    }
+
+    public static RecordedExercise CreateRecordedExercise(
+        ExerciseBlueprint? exerciseBlueprint = null,
+        Func<RecordedExercise, RecordedExercise>? transform = null
+    )
+    {
+        exerciseBlueprint ??= Blueprints.CreateExerciseBlueprint();
+        return (transform ?? (e => e)).Invoke(
+            new RecordedExercise(
+                Blueprint: exerciseBlueprint,
+                Kilograms: exerciseBlueprint.InitialKilograms,
+                RecordedSets: Enumerable
+                    .Range(0, exerciseBlueprint.Sets)
+                    .Select(
+                        (i) =>
+                            i switch
+                            {
+                                0
+                                    => new RecordedSet(
+                                        RepsCompleted: exerciseBlueprint.RepsPerSet,
+                                        CompletionTime: DateTime.Parse("2021-04-05T14:32:00")
+                                    ),
+                                _ => null
+                            }
+                    )
+                    .ToImmutableList()
+            )
+        );
+    }
+}

--- a/LiftLog.Tests/Sessions.cs
+++ b/LiftLog.Tests/Sessions.cs
@@ -41,7 +41,7 @@ public static class Sessions
                                 0
                                     => new RecordedSet(
                                         RepsCompleted: exerciseBlueprint.RepsPerSet,
-                                        CompletionTime: DateTime.Parse("2021-04-05T14:32:00")
+                                        CompletionTime: TimeOnly.Parse("14:32:00")
                                     ),
                                 _ => null
                             }

--- a/LiftLog.Ui/AssemblyInfo.cs
+++ b/LiftLog.Ui/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LiftLog.Tests")]

--- a/LiftLog.Ui/Models/ExerciseStatistics.cs
+++ b/LiftLog.Ui/Models/ExerciseStatistics.cs
@@ -9,6 +9,8 @@ public record ExerciseStatistics(
     decimal MaxKilograms,
     decimal OneRepMax,
     decimal TotalKilograms,
-    ImmutableListValue<RecordedExercise> RecordedExercises,
+    ImmutableListValue<DatedRecordedExercise> RecordedExercises,
     bool ExpandOnClick
 );
+
+public record DatedRecordedExercise(DateOnly Date, RecordedExercise Exercise);

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
@@ -7,40 +7,44 @@ namespace LiftLog.Ui.Models.SessionHistoryDao;
 
 internal record SessionHistoryDaoV1(
     [property: JsonPropertyName("CompletedSessions")]
-    ImmutableListValue<SessionDaoV1> CompletedSessions
+        ImmutableListValue<SessionDaoV1> CompletedSessions
 )
 {
-    public static SessionHistoryDaoV1 FromModel(SessionHistoryDaoContainer model)
-        => new(
-            model.CompletedSessions.Values.Select(SessionDaoV1.FromModel).ToImmutableList()
-        );
+    public static SessionHistoryDaoV1 FromModel(SessionHistoryDaoContainer model) =>
+        new(model.CompletedSessions.Values.Select(SessionDaoV1.FromModel).ToImmutableList());
 
-    public SessionHistoryDaoContainer ToModel()
-        => new(CompletedSessions.ToImmutableDictionary(x => x.Id, x => x.ToModel()));
+    public SessionHistoryDaoContainer ToModel() =>
+        new(CompletedSessions.ToImmutableDictionary(x => x.Id, x => x.ToModel()));
 }
 
 internal record SessionDaoV1(
-
-    [property: JsonPropertyName("Id")]
-    Guid Id,
-    [property: JsonPropertyName("Blueprint")]
-    SessionBlueprintDaoV1 Blueprint,
+    [property: JsonPropertyName("Id")] Guid Id,
+    [property: JsonPropertyName("Blueprint")] SessionBlueprintDaoV1 Blueprint,
     [property: JsonPropertyName("RecordedExercises")]
-    ImmutableListValue<RecordedExerciseDaoV1> RecordedExercises,
-    [property: JsonPropertyName("Date")]
-    DateTimeOffset Date
+        ImmutableListValue<RecordedExerciseDaoV1> RecordedExercises,
+    [property: JsonPropertyName("Date")] DateTimeOffset Date
 )
 {
-    public static SessionDaoV1 FromModel(Lib.Models.Session model)
-        => new(
+    public static SessionDaoV1 FromModel(Lib.Models.Session model) =>
+        new(
             model.Id,
             SessionBlueprintDaoV1.FromModel(model.Blueprint),
-            model.RecordedExercises.Select(RecordedExerciseDaoV1.FromModel).ToImmutableList(),
-            new DateTimeOffset(model.Date.Year, model.Date.Month, model.Date.Day, 0, 0, 0, TimeSpan.Zero)
+            model.RecordedExercises
+                .Select(x => RecordedExerciseDaoV1.FromModel(model.Date, x))
+                .ToImmutableList(),
+            new DateTimeOffset(
+                model.Date.Year,
+                model.Date.Month,
+                model.Date.Day,
+                0,
+                0,
+                0,
+                TimeSpan.Zero
+            )
         );
 
-    public Lib.Models.Session ToModel()
-        => new(
+    public Lib.Models.Session ToModel() =>
+        new(
             Id,
             Blueprint.ToModel(),
             RecordedExercises.Select(x => x.ToModel()).ToImmutableList(),
@@ -49,24 +53,25 @@ internal record SessionDaoV1(
 }
 
 internal record RecordedExerciseDaoV1(
-
-    [property: JsonPropertyName("Blueprint")]
-    ExerciseBlueprintDaoV1 Blueprint,
-    [property: JsonPropertyName("Kilograms")]
-    decimal Kilograms,
-    [property: JsonPropertyName("RecordedSets")]
-    ImmutableListValue<RecordedSetDaoV1?> RecordedSets
+    [property: JsonPropertyName("Blueprint")] ExerciseBlueprintDaoV1 Blueprint,
+    [property: JsonPropertyName("Kilograms")] decimal Kilograms,
+    [property: JsonPropertyName("RecordedSets")] ImmutableListValue<RecordedSetDaoV1?> RecordedSets
 )
 {
-    public static RecordedExerciseDaoV1 FromModel(Lib.Models.RecordedExercise model)
-        => new(
+    public static RecordedExerciseDaoV1 FromModel(
+        DateOnly sessionDate,
+        Lib.Models.RecordedExercise model
+    ) =>
+        new(
             ExerciseBlueprintDaoV1.FromModel(model.Blueprint),
             model.Kilograms,
-            model.RecordedSets.Select(RecordedSetDaoV1.FromModel).ToImmutableList()
+            model.RecordedSets
+                .Select(x => RecordedSetDaoV1.FromModel(sessionDate, x))
+                .ToImmutableList()
         );
 
-    public Lib.Models.RecordedExercise ToModel()
-        => new(
+    public Lib.Models.RecordedExercise ToModel() =>
+        new(
             Blueprint.ToModel(),
             Kilograms,
             RecordedSets.Select(x => x?.ToModel()).ToImmutableList()
@@ -74,20 +79,26 @@ internal record RecordedExerciseDaoV1(
 }
 
 internal record RecordedSetDaoV1(
-
-    [property: JsonPropertyName("RepsCompleted")]
-    int RepsCompleted,
-    [property: JsonPropertyName("CompletionTime")]
-    DateTimeOffset CompletionTime
+    [property: JsonPropertyName("RepsCompleted")] int RepsCompleted,
+    [property: JsonPropertyName("CompletionTime")] DateTimeOffset CompletionTime
 )
 {
-    public static RecordedSetDaoV1? FromModel(Lib.Models.RecordedSet? model)
-        => model is null
+    public static RecordedSetDaoV1? FromModel(
+        DateOnly sessionDate,
+        Lib.Models.RecordedSet? model
+    ) =>
+        model is null
             ? null
-            : new RecordedSetDaoV1(model.RepsCompleted, model.CompletionTime);
+            : new RecordedSetDaoV1(
+                model.RepsCompleted,
+                sessionDate.ToDateTime(model.CompletionTime)
+            );
 
-    public Lib.Models.RecordedSet? ToModel()
-        => RepsCompleted == 0
+    public Lib.Models.RecordedSet? ToModel() =>
+        RepsCompleted == 0
             ? null
-            : new Lib.Models.RecordedSet(RepsCompleted, CompletionTime);
+            : new Lib.Models.RecordedSet(
+                RepsCompleted,
+                TimeOnly.FromDateTime(CompletionTime.DateTime)
+            );
 }

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -47,33 +47,16 @@ else
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         var sessions=  await SessionService.GetLatestSessionsAsync().Where(x=>x.RecordedExercises.Any()).ToListAsync();
 
-        _exerciseStats = sessions.GroupBy(x=>x.Blueprint.Name).Select(sessions => new ExerciseStatistics(
-                Name: sessions.Key,
-                CurrentKilograms: 0,
-                MaxKilograms: 0,
-                OneRepMax: 0,
-                TotalKilograms: sessions.Sum(x=>x.TotalKilogramsLifted),
-                RecordedExercises: sessions.Select(x=>new RecordedExercise(
-                    Blueprint: x.RecordedExercises.First().Blueprint,
-                    Kilograms: x.TotalKilogramsLifted,
-                    RecordedSets: ImmutableListValue.Of<RecordedSet?>(new RecordedSet(1, TimeOnly.MinValue))
-                    )).ToImmutableList(),
-                ExpandOnClick: false))
+        var sessionStats = sessions.GroupBy(session=>session.Blueprint.Name).Select(CreateSessionStatistic);
+
+        _exerciseStats = sessionStats
             .Concat(sessions
-            .SelectMany(x=>x.RecordedExercises)
-            .GroupBy(x=>NormalizeName(x.Blueprint.Name))
-            .Select(x=>x.ToList())
-            .Where(x=>x.Count > 0)
-            .Select(exercises=>new ExerciseStatistics(
-                Name: exercises.First().Blueprint.Name,
-                CurrentKilograms: exercises.First().Kilograms,
-                MaxKilograms: exercises.Max(x=>x.Kilograms),
-                OneRepMax: exercises.First().OneRepMax,
-                TotalKilograms: exercises.Sum(x=>x.Kilograms),
-                RecordedExercises: exercises.ToImmutableList(),
-                ExpandOnClick: true
-            )))
-            .ToList();
+                .SelectMany(x=>x.RecordedExercises.Select(ex=>new DatedRecordedExercise(x.Date, ex)))
+                .GroupBy(x => NormalizeName(x.Exercise.Blueprint.Name))
+                .Select(x => x.ToList())
+                .Where(x => x.Count > 0)
+                .Select(CreateExerciseStatistic)
+            ).ToList();
     }
 
     private void HandleCardClick((ExerciseStatistics  exerciseStatistics, int Index) item)
@@ -95,5 +78,38 @@ else
         };
 
         return withoutPlural;
+    }
+
+    private ExerciseStatistics CreateSessionStatistic(IGrouping<string,Session> sessions)
+    {
+        return new ExerciseStatistics(
+            Name: sessions.Key,
+            CurrentKilograms: 0,
+            MaxKilograms: 0,
+            OneRepMax: 0,
+            TotalKilograms: sessions.Sum(session => session.TotalKilogramsLifted),
+            RecordedExercises: sessions.Select(
+                session =>
+                    new DatedRecordedExercise(session.Date, new RecordedExercise(
+                        Blueprint: session.RecordedExercises.First().Blueprint,
+                        Kilograms: session.TotalKilogramsLifted,
+                        RecordedSets: ImmutableListValue.Of<RecordedSet?>(new RecordedSet(1, TimeOnly.MinValue))
+                        )
+                    )
+                ).ToImmutableList(),
+            ExpandOnClick: false);
+    }
+
+    private ExerciseStatistics CreateExerciseStatistic(IEnumerable<DatedRecordedExercise> exercises)
+    {
+        return new ExerciseStatistics(
+            Name: exercises.First().Exercise.Blueprint.Name,
+            CurrentKilograms: exercises.First().Exercise.Kilograms,
+            MaxKilograms: exercises.Max(x=>x.Exercise.Kilograms),
+            OneRepMax: exercises.First().Exercise.OneRepMax,
+            TotalKilograms: exercises.Sum(x=>x.Exercise.Kilograms),
+            RecordedExercises: exercises.ToImmutableList(),
+            ExpandOnClick: true
+        );
     }
 }

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -56,8 +56,8 @@ else
                 RecordedExercises: sessions.Select(x=>new RecordedExercise(
                     Blueprint: x.RecordedExercises.First().Blueprint,
                     Kilograms: x.TotalKilogramsLifted,
-                    RecordedSets: ImmutableListValue.Of<RecordedSet?>(new RecordedSet(1, new DateTimeOffset(x.Date.ToDateTime(TimeOnly.MinValue))))))
-                        .ToImmutableList(),
+                    RecordedSets: ImmutableListValue.Of<RecordedSet?>(new RecordedSet(1, TimeOnly.MinValue))
+                    )).ToImmutableList(),
                 ExpandOnClick: false))
             .Concat(sessions
             .SelectMany(x=>x.RecordedExercises)

--- a/LiftLog.Ui/Shared/Presentation/RestTimer.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestTimer.razor
@@ -22,11 +22,11 @@
 
     [EditorRequired]
     [Parameter]
-    public DateTimeOffset StartTime { get; set; }
+    public TimeOnly StartTime { get; set; }
 
     [EditorRequired]
     [Parameter]
     public bool Failed { get; set; }
 
-    private TimeSpan TimeSinceStart => DateTimeOffset.UtcNow - StartTime;
+    private TimeSpan TimeSinceStart => TimeOnly.FromDateTime(DateTime.Now) - StartTime;
 }

--- a/LiftLog.Ui/Shared/Presentation/RestTimer.razor.cs
+++ b/LiftLog.Ui/Shared/Presentation/RestTimer.razor.cs
@@ -31,9 +31,6 @@ public partial class RestTimer : IDisposable
             {
                 _timer?.Dispose();
             }
-
-            // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-            // TODO: set large fields to null
             _disposedValue = true;
         }
     }

--- a/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
@@ -14,17 +14,17 @@
 </div>
 }else{
 <ApexChart
-    TItem="RecordedExercise"
+    TItem="DatedRecordedExercise"
     Title=""
     Options="options"
     XAxisType="XAxisType.Datetime">
 
-    <ApexPointSeries TItem="RecordedExercise"
-                        Items="ExerciseStatistics.RecordedExercises.Where(x=>x.LastRecordedSet != null)"
+    <ApexPointSeries TItem="DatedRecordedExercise"
+                        Items="ExerciseStatistics.RecordedExercises.Where(x=>x.Exercise.LastRecordedSet != null)"
                         Name="Weight"
                         SeriesType="SeriesType.Line"
-                        XValue="@(e => e.LastRecordedSet!.CompletionTime)"
-                        YAggregate="@(e => e.Max(e => e.Kilograms))"
+                        XValue="@(e => e.Date)"
+                        YAggregate="@(e => e.Max(e => e.Exercise.Kilograms))"
                         OrderByDescending="e=>e.X" />
 </ApexChart>
 }
@@ -41,12 +41,12 @@
     private bool IsLoading { get; set; } = true;
 
 
-    private ApexChartOptions<RecordedExercise> options = null!;
+    private ApexChartOptions<DatedRecordedExercise> options = null!;
 
     protected override void OnInitialized()
     {
         Task.Delay(RenderDelay).ContinueWith(_ => {IsLoading = false; InvokeAsync(StateHasChanged);});
-        options = new ApexChartOptions<RecordedExercise>
+        options = new ApexChartOptions<DatedRecordedExercise>
             {
                 Chart = new Chart
                 {

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
@@ -226,7 +226,11 @@ public static class Reducers
         return recordedSet switch
         {
             // When unset - we say the user completed all reps
-            null => new RecordedSet(exerciseBlueprint.RepsPerSet, DateTimeOffset.UtcNow),
+            null
+                => new RecordedSet(
+                    exerciseBlueprint.RepsPerSet,
+                    TimeOnly.FromDateTime(DateTime.Now)
+                ),
             // When they completed no reps, we transition back to unset
             { RepsCompleted: 0 } => null,
             // Otherwise, just decrement from the current

--- a/LiftLog.Web/Services/WebNotificationService.cs
+++ b/LiftLog.Web/Services/WebNotificationService.cs
@@ -25,7 +25,10 @@ public class WebNotificationService : INotificationService
         _notificationService = notificationService;
     }
 
-    public async Task ScheduleNextSetNotificationAsync(SessionTarget target, RecordedExercise exercise)
+    public async Task ScheduleNextSetNotificationAsync(
+        SessionTarget target,
+        RecordedExercise exercise
+    )
     {
         var rest = exercise switch
         {
@@ -39,7 +42,7 @@ public class WebNotificationService : INotificationService
         {
             await ScheduleNotificationAsync(
                 NextSetNotificationHandle,
-                DateTimeOffset.Now.Add(rest),
+                DateTime.Now.Add(rest),
                 "Rest Over",
                 "Start your next set now!"
             );
@@ -79,7 +82,7 @@ public class WebNotificationService : INotificationService
 
     private async Task ScheduleNotificationAsync(
         NotificationHandle handle,
-        DateTimeOffset scheduledFor,
+        DateTime scheduledFor,
         string title,
         string message
     )
@@ -99,7 +102,7 @@ public class WebNotificationService : INotificationService
         var source = new CancellationTokenSource();
         if (_scheduledNotifications.TryAdd(handle, source))
         {
-            var timeToWait = new[] { scheduledFor - DateTimeOffset.Now, TimeSpan.Zero }.Max();
+            var timeToWait = new[] { scheduledFor - DateTime.Now, TimeSpan.Zero }.Max();
             _ = Task.Delay(timeToWait, source.Token)
                 .ContinueWith(
                     (result) =>


### PR DESCRIPTION
Since sessions have dates (which are editable), and recorded exercises also had dates, it was possible to have exercises be recorded on a different date to the session, which meant that stats wouldn't update when you change the date of a session