### PR TITLE
Add a bodyweight card to the end of sessions

### DIFF
--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -28,7 +28,8 @@ public record SessionBlueprint(string Name, ImmutableListValue<ExerciseBlueprint
             Guid.NewGuid(),
             this,
             Exercises.Select(GetNextExercise).ToImmutableList(),
-            DateOnly.FromDateTime(DateTime.Now)
+            DateOnly.FromDateTime(DateTime.Now),
+            null
         );
     }
 }

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -4,7 +4,8 @@ public record Session(
     Guid Id,
     SessionBlueprint Blueprint,
     ImmutableListValue<RecordedExercise> RecordedExercises,
-    DateOnly Date
+    DateOnly Date,
+    decimal? Bodyweight
 )
 {
     public RecordedExercise? NextExercise

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
@@ -22,7 +22,8 @@ internal record SessionDaoV1(
     [property: JsonPropertyName("Blueprint")] SessionBlueprintDaoV1 Blueprint,
     [property: JsonPropertyName("RecordedExercises")]
         ImmutableListValue<RecordedExerciseDaoV1> RecordedExercises,
-    [property: JsonPropertyName("Date")] DateTimeOffset Date
+    [property: JsonPropertyName("Date")] DateTimeOffset Date,
+    [property: JsonPropertyName("Bodyweight")] decimal? Bodyweight
 )
 {
     public static SessionDaoV1 FromModel(Lib.Models.Session model) =>
@@ -41,7 +42,8 @@ internal record SessionDaoV1(
                 0,
                 0,
                 TimeSpan.Zero
-            )
+            ),
+            model.Bodyweight
         );
 
     public Lib.Models.Session ToModel() =>
@@ -49,7 +51,8 @@ internal record SessionDaoV1(
             Id,
             Blueprint.ToModel(),
             RecordedExercises.Select(x => x.ToModel()).ToImmutableList(),
-            new DateOnly(Date.Year, Date.Month, Date.Day)
+            new DateOnly(Date.Year, Date.Month, Date.Day),
+            Bodyweight
         );
 }
 

--- a/LiftLog.Ui/Pages/History/HistoryEditPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryEditPage.razor
@@ -51,7 +51,8 @@
         SessionInPlan=@(ProgramState.Value.SessionBlueprints.Contains(CurrentSessionState.Value.HistorySession.Blueprint))
         SessionWithSameNameInPlan=@(ProgramState.Value.SessionBlueprints.Any(x=>x.Name == CurrentSessionState.Value.HistorySession.Blueprint.Name))
         AddSessionToPlan="AddSessionToPlan"
-        UpdateSessionInPlan="UpdateSessionInPlan" />
+        UpdateSessionInPlan="UpdateSessionInPlan"
+        UpdateBodyweight="UpdateBodyweight" />
 }
 
 @code
@@ -95,6 +96,9 @@
 
     private void UpdateNotesForExercise(int exerciseIndex, string? notes)
         => Dispatcher.Dispatch(new UpdateNotesForExerciseAction(SessionTarget.HistorySession, exerciseIndex, notes));
+
+    private void UpdateBodyweight(decimal? bodyweight)
+        => Dispatcher.Dispatch(new UpdateBodyweightAction(SessionTarget.WorkoutSession, bodyweight));
 
     private void AddSessionToPlan()
     {

--- a/LiftLog.Ui/Pages/History/HistoryEditPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryEditPage.razor
@@ -98,7 +98,7 @@
         => Dispatcher.Dispatch(new UpdateNotesForExerciseAction(SessionTarget.HistorySession, exerciseIndex, notes));
 
     private void UpdateBodyweight(decimal? bodyweight)
-        => Dispatcher.Dispatch(new UpdateBodyweightAction(SessionTarget.WorkoutSession, bodyweight));
+        => Dispatcher.Dispatch(new UpdateBodyweightAction(SessionTarget.HistorySession, bodyweight));
 
     private void AddSessionToPlan()
     {

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -103,7 +103,8 @@ else
 
     private void StartFreeformSession()
     {
-        selectedSession = new Session(Guid.NewGuid(), new SessionBlueprint("Freeform Session", []), [], DateOnly.FromDateTime(DateTime.Now));
+        var latestBodyweight = ProgramState.Value.UpcomingSessions.FirstOrDefault()?.Bodyweight;
+        selectedSession = new Session(Guid.NewGuid(), new SessionBlueprint("Freeform Session", []), [], DateOnly.FromDateTime(DateTime.Now), latestBodyweight);
         if (CurrentSessionState.Value.WorkoutSession is { IsStarted: true })
         {
             replaceCurrentSesisonDialog?.Open();

--- a/LiftLog.Ui/Pages/SessionPage.razor
+++ b/LiftLog.Ui/Pages/SessionPage.razor
@@ -41,7 +41,8 @@
         SessionInPlan=@(ProgramState.Value.SessionBlueprints.Contains(CurrentSessionState.Value.WorkoutSession.Blueprint))
         SessionWithSameNameInPlan=@(ProgramState.Value.SessionBlueprints.Any(x=>x.Name == CurrentSessionState.Value.WorkoutSession.Blueprint.Name))
         AddSessionToPlan="AddSessionToPlan"
-        UpdateSessionInPlan="UpdateSessionInPlan" />
+        UpdateSessionInPlan="UpdateSessionInPlan"
+        UpdateBodyweight="UpdateBodyweight" />
 }
 
 
@@ -93,6 +94,9 @@
     {
         Dispatcher.Dispatch(new RemoveExerciseFromActiveSessionAction(SessionTarget.WorkoutSession, exerciseIndex));
     }
+
+    private void UpdateBodyweight(decimal? bodyweight)
+        => Dispatcher.Dispatch(new UpdateBodyweightAction(SessionTarget.WorkoutSession, bodyweight));
 
     private void UpdateNotesForExercise(int exerciseIndex, string? notes)
         => Dispatcher.Dispatch(new UpdateNotesForExerciseAction(SessionTarget.WorkoutSession, exerciseIndex, notes));

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -47,9 +47,11 @@ else
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         var sessions=  await SessionService.GetLatestSessionsAsync().Where(x=>x.RecordedExercises.Any()).ToListAsync();
 
+        List<ExerciseStatistics> bodyweightStats = [ CreateBodyweightStatistic(sessions) ];
         var sessionStats = sessions.GroupBy(session=>session.Blueprint.Name).Select(CreateSessionStatistic);
 
-        _exerciseStats = sessionStats
+        _exerciseStats = bodyweightStats.Where(x=>x.RecordedExercises.Any())
+            .Concat(sessionStats)
             .Concat(sessions
                 .SelectMany(x=>x.RecordedExercises.Select(ex=>new DatedRecordedExercise(x.Date, ex)))
                 .GroupBy(x => NormalizeName(x.Exercise.Blueprint.Name))
@@ -78,6 +80,29 @@ else
         };
 
         return withoutPlural;
+    }
+
+
+    private ExerciseStatistics CreateBodyweightStatistic(IEnumerable<Session> sessions)
+    {
+        // Really stretching the definition of exercise statistics here
+        return new ExerciseStatistics(
+            Name: "Bodyweight",
+            CurrentWeight: 0,
+            MaxWeight: 0,
+            OneRepMax: 0,
+            TotalWeight: 0,
+            RecordedExercises: sessions.Where(x=>x.Bodyweight is not null).Select(
+                session =>
+                    new DatedRecordedExercise(session.Date, new RecordedExercise(
+                        Blueprint: session.RecordedExercises.First().Blueprint,
+                        Weight: session.Bodyweight!.Value,
+                        RecordedSets: [new RecordedSet(1, TimeOnly.MinValue)],
+                        null
+                        )
+                    )
+                ).ToImmutableList(),
+            ExpandOnClick: false);
     }
 
     private ExerciseStatistics CreateSessionStatistic(IGrouping<string,Session> sessions)

--- a/LiftLog.Ui/Services/SessionService.cs
+++ b/LiftLog.Ui/Services/SessionService.cs
@@ -85,7 +85,10 @@ public class SessionService
         return CreateNewSession(
             sessionBlueprints[(lastBlueprintIndex + 1) % sessionBlueprints.Count],
             latestRecordedExercises
-        );
+        ) with
+        {
+            Bodyweight = previousSession.Bodyweight
+        };
     }
 
     private Session CreateNewSession(
@@ -113,7 +116,8 @@ public class SessionService
             Guid.NewGuid(),
             sessionBlueprint,
             sessionBlueprint.Exercises.Select(GetNextExercise).ToImmutableList(),
-            DateOnly.FromDateTime(DateTime.Now)
+            DateOnly.FromDateTime(DateTime.Now),
+            null
         );
     }
 }

--- a/LiftLog.Ui/Shared/Presentation/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionComponent.razor
@@ -25,6 +25,15 @@ else
             OnRemoveExercise=@(()=> BeginRemoveExercise(context.Index)) />
     </CardList>
 }
+<div class="flex-col flex justify-center gap-2 mt-2">
+    <Card>
+        <div class="flex justify-between items-center">
+            <span class="text-xl">Bodyweight</span>
+            <WeightDisplay Weight=Session.Bodyweight UpdateWeight="UpdateBodyweight" Increment="0.1m" Label="Bodyweight" />
+        </div>
+    </Card>
+</div>
+
 <div class="flex  justify-center gap-2 mt-6">
     <AppButton OnClick="BeginAddExercise"><md-icon slot="icon">add</md-icon>Add Exercise</AppButton>
     @if (!SessionInPlan && Session.RecordedExercises.Any())
@@ -122,6 +131,10 @@ else
     [EditorRequired]
     [Parameter]
     public Action<int, string?> UpdateNotesForExercise { get; set; } = null!;
+
+    [EditorRequired]
+    [Parameter]
+    public Action<decimal?> UpdateBodyweight { get; set; } = null!;
 
     [EditorRequired]
     [Parameter]

--- a/LiftLog.Ui/Shared/Presentation/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionComponent.razor
@@ -29,7 +29,7 @@ else
     <Card>
         <div class="flex justify-between items-center">
             <span class="text-xl">Bodyweight</span>
-            <WeightDisplay Weight=Session.Bodyweight UpdateWeight="UpdateBodyweight" Increment="0.1m" Label="Bodyweight" />
+            <WeightDisplay AllowNull=true Weight=Session.Bodyweight UpdateWeight="UpdateBodyweight" Increment="0.1m" Label="Bodyweight" />
         </div>
     </Card>
 </div>

--- a/LiftLog.Ui/Shared/Presentation/WeightDisplay.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightDisplay.razor
@@ -10,7 +10,7 @@
         <span slot="headline">@Label</span>
         <div  slot="content">
             <div  class="flex flex-col gap-2">
-                <TextField label="@Label" required suffix-text="@WeightSuffix" TextFieldType="TextFieldType.Outline" Value=@(EditorWeight.ToString()) OnChange="HandleInputChange"  type="text" inputmode="decimal" step="@NonZeroIncrement" />
+                <TextField label="@Label" required=@(!AllowNull) suffix-text="@WeightSuffix" TextFieldType="TextFieldType.Outline" Value=@(EditorWeight.ToString()) OnChange="HandleInputChange"  type="text" inputmode="decimal" step="@NonZeroIncrement" />
                 <div class="flex justify-between">
                     <AppButton Type=AppButtonType.OutlineSecondary OnClick=OnWeightDecrementClick><md-icon slot="icon">remove</md-icon><WeightFormat Weight="NonZeroIncrement"  /></AppButton>
                     <AppButton data-cy="increment-weight" Type=AppButtonType.OutlineSecondary OnClick=OnWeightIncrementClick><md-icon slot="icon">add</md-icon><WeightFormat Weight="NonZeroIncrement" /></AppButton>
@@ -42,6 +42,9 @@
     [EditorRequired]
     [Parameter]
     public Action<decimal?> UpdateWeight { get; set; } = null!;
+
+    [Parameter]
+    public bool AllowNull { get; set; } = false;
 
     [CascadingParameter(Name = "UseImperial")]
     public bool UseImperialUnits { get; set; }
@@ -78,6 +81,11 @@
     }
 
     private void HandleInputChange(string? value){
+        if(string.IsNullOrWhiteSpace(value) && AllowNull)
+        {
+            EditorWeight = null;
+            return;
+        }
         if (decimal.TryParse(value, out var result))
         {
             EditorWeight = result;

--- a/LiftLog.Ui/Shared/Presentation/WeightDisplay.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightDisplay.razor
@@ -1,19 +1,19 @@
 <div>
     <AppButton data-cy="weight-display" Type="AppButtonType.OutlineSecondary" OnClick="OnOpenClick">
-        <WeightFormat Weight="Exercise.Weight"/>
+        <WeightFormat Weight="Weight"/>
     </AppButton>
 
     <Dialog
         @ref="dialog"
         style="--md-dialog-container-max-block-size: 500px;"
     >
-        <span slot="headline">Weight</span>
+        <span slot="headline">@Label</span>
         <div  slot="content">
             <div  class="flex flex-col gap-2">
-                <TextField label="Weight" required suffix-text="@WeightSuffix" TextFieldType="TextFieldType.Outline" Value=@(EditorWeight.ToString()) OnChange="HandleInputChange"  type="text" inputmode="decimal" step="@Increment" />
+                <TextField label="@Label" required suffix-text="@WeightSuffix" TextFieldType="TextFieldType.Outline" Value=@(EditorWeight.ToString()) OnChange="HandleInputChange"  type="text" inputmode="decimal" step="@NonZeroIncrement" />
                 <div class="flex justify-between">
-                    <AppButton Type=AppButtonType.OutlineSecondary OnClick=OnWeightDecrementClick><md-icon slot="icon">remove</md-icon><WeightFormat Weight="Increment"  /></AppButton>
-                    <AppButton data-cy="increment-weight" Type=AppButtonType.OutlineSecondary OnClick=OnWeightIncrementClick><md-icon slot="icon">add</md-icon><WeightFormat Weight="Increment" /></AppButton>
+                    <AppButton Type=AppButtonType.OutlineSecondary OnClick=OnWeightDecrementClick><md-icon slot="icon">remove</md-icon><WeightFormat Weight="NonZeroIncrement"  /></AppButton>
+                    <AppButton data-cy="increment-weight" Type=AppButtonType.OutlineSecondary OnClick=OnWeightIncrementClick><md-icon slot="icon">add</md-icon><WeightFormat Weight="NonZeroIncrement" /></AppButton>
                 </div>
             </div>
         </div>
@@ -30,22 +30,29 @@
 
     [EditorRequired]
     [Parameter]
-    public RecordedExercise Exercise { get; set; } = null!;
+    public decimal? Weight { get; set; } = null!;
+
+    [Parameter]
+    public string Label { get; set; } = "Weight";
 
     [EditorRequired]
     [Parameter]
-    public Action<decimal> UpdateWeightForExercise { get; set; } = null!;
+    public decimal Increment { get; set; } = 2.5m;
+
+    [EditorRequired]
+    [Parameter]
+    public Action<decimal?> UpdateWeight { get; set; } = null!;
 
     [CascadingParameter(Name = "UseImperial")]
     public bool UseImperialUnits { get; set; }
 
-    private decimal Increment => Exercise.Blueprint.WeightIncreaseOnSuccess == 0 ? 2.5m : Exercise.Blueprint.WeightIncreaseOnSuccess;
+    private decimal NonZeroIncrement => Increment == 0 ? 2.5m : Increment;
 
-    private decimal EditorWeight { get; set; }
+    private decimal? EditorWeight { get; set; }
 
     private void OnOpenClick()
     {
-        EditorWeight = Exercise.Weight;
+        EditorWeight = Weight;
         dialog?.Open();
     }
 
@@ -56,7 +63,7 @@
 
     private void OnSaveClick()
     {
-        UpdateWeightForExercise(EditorWeight);
+        UpdateWeight(EditorWeight);
         dialog?.Close();
     }
 

--- a/LiftLog.Ui/Shared/Presentation/WeightFormat.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightFormat.razor
@@ -1,11 +1,13 @@
-<span class="flex items-center">@(Weight.ToString("0.####"))<span class="text-sm">@Suffix</span></span>
+<span class="flex items-center">@WeightDisplay<span class="text-sm">@Suffix</span></span>
 @code {
     [EditorRequired]
     [Parameter]
-    public decimal Weight { get; set; }
+    public decimal? Weight { get; set; }
 
     [CascadingParameter(Name = "UseImperial")]
     public bool UseImperial { get; set; }
+
+    private string WeightDisplay => Weight?.ToString("0.####") ?? "-";
 
     private string Suffix => UseImperial ? "lbs" : "kg";
 }

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -14,8 +14,9 @@
                 <span class="text-xl">@RecordedExercise.Blueprint.Name</span>
                 <div class="flex gap-2">
                     <WeightDisplay
-                        Exercise="displayedExercise"
-                            UpdateWeightForExercise="UpdateWeightForExercise"/>
+                        Weight="displayedExercise.Weight"
+                        Increment="displayedExercise.Blueprint.WeightIncreaseOnSuccess"
+                            UpdateWeight="w => {if (w is not null) UpdateWeightForExercise(w.Value);}"/>
                     <IconButton data-cy="exercise-notes-btn" Icon="notes" OnClick="OnOpenNotesButtonClick" Type="IconButtonType.Outlined"/>
                 </div>
             </div>

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionActions.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionActions.cs
@@ -19,6 +19,8 @@ public record UpdateExerciseWeightAction(SessionTarget Target, int ExerciseIndex
 
 public record UpdateNotesForExerciseAction(SessionTarget Target, int ExerciseIndex, string? Notes);
 
+public record UpdateBodyweightAction(SessionTarget Target, decimal? Bodyweight);
+
 public record EditExerciseInActiveSessionAction(
     SessionTarget Target,
     int ExerciseIndex,

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
@@ -242,6 +242,22 @@ public static class Reducers
         );
     }
 
+    [ReducerMethod]
+    public static CurrentSessionState UpdateBodyweight(
+        CurrentSessionState state,
+        UpdateBodyweightAction action
+    ) =>
+        WithActiveSession(
+            state,
+            SessionTarget.WorkoutSession,
+            session =>
+                session switch
+                {
+                    null => session,
+                    _ => session with { Bodyweight = action.Bodyweight }
+                }
+        );
+
     private static RecordedSet? GetCycledRepCount(
         RecordedSet? recordedSet,
         ExerciseBlueprint exerciseBlueprint
@@ -271,6 +287,26 @@ public static class Reducers
         {
             SessionTarget.WorkoutSession => state with { WorkoutSession = session },
             SessionTarget.HistorySession => state with { HistorySession = session },
+            _ => throw new Exception()
+        };
+
+    private static CurrentSessionState WithActiveSession(
+        this CurrentSessionState state,
+        SessionTarget target,
+        Func<Session?, Session?> sessionMap
+    ) =>
+        target switch
+        {
+            SessionTarget.WorkoutSession
+                => state with
+                {
+                    WorkoutSession = sessionMap(state.WorkoutSession)
+                },
+            SessionTarget.HistorySession
+                => state with
+                {
+                    HistorySession = sessionMap(state.HistorySession)
+                },
             _ => throw new Exception()
         };
 

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
@@ -249,7 +249,7 @@ public static class Reducers
     ) =>
         WithActiveSession(
             state,
-            SessionTarget.WorkoutSession,
+            action.Target,
             session =>
                 session switch
                 {


### PR DESCRIPTION
This allows a user to add their bodyweight at the end of a session.  The weight carries over from previous sessions for ease of use, and is also allowed to be unset
<img width="396" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/5d711c44-2d2c-4af0-85ed-b3a9cc4a7fbc">
<img width="398" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/e985f016-f4f4-47b6-81d5-7f6116852d9b">
<img width="396" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/5d5eccfe-8674-40fe-9411-c88a98278ea8">

