### PR TITLE
Fix visual artifacting

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/PotentialSetCounter.razor
+++ b/LiftLog.Ui/Shared/Presentation/PotentialSetCounter.razor
@@ -1,8 +1,11 @@
 @inject IJSRuntime JSRuntime
 
 <div class="flex flex-col items-center relative">
+
+    @* The box shadow is shown when the rep ISN'T completed.  The background colour is also animated to ensure that it remains visible in both transition directions *@
     <button
         @ref="_button"
+
         class="
             repcount
             flex-shrink-0
@@ -11,12 +14,11 @@
             @RepCountRounding
             relative
             text-center
-            bg-primary
             text-xl
             flex
             justify-center
             align-middle
-            transition-[box-shadow,_border-radius]
+            transition-[box-shadow,_border-radius,background-color]
             duration-150
             items-center
             @ColorClass
@@ -109,7 +111,8 @@
 
     private string BoxShadowFill => RepCountValue is not null  ? "0" : "2rem";
 
-    private string ColorClass =>  RepCountValue is not null ? "text-on-primary" : "text-on-secondary-container";
+// Realistically the bg should not be seen when there is a rep count, but there are mild artifacts when keeping it as bg-primary
+    private string ColorClass =>  RepCountValue is not null ? "text-on-primary bg-primary" : "text-on-secondary-container bg-secondary-container";
 
     private string? RepCountToStartClass => ToStartNext ? "" : null;
 


### PR DESCRIPTION
We use a box shadow to do some sweet sweet animating between rep count colours,
however when combined with border radius you can see a small amount of the background peek through on the corners.
Super minor, but this commit just makes it so that the background matches the box shadow colour when the box shadow is present.
Adding a transition on the background colour is necessary because we need it to still be there for the entire lengtth of the box shadow animation. Hacky but works

Before:
![image](https://github.com/LiamMorrow/LiftLog/assets/13741016/e3f80f7d-568b-4f07-8f05-3c78d3b1a1f3)

After:
![image](https://github.com/LiamMorrow/LiftLog/assets/13741016/73aa6dc5-2488-483c-ad90-461f1a2c6bff)
