### PR TITLE
Only scroll repcount into view on first render

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/PotentialSetCounter.razor
+++ b/LiftLog.Ui/Shared/Presentation/PotentialSetCounter.razor
@@ -107,8 +107,6 @@
 
     private string scale => ShowWeight ? "p-2 h-8 w-14" : "h-0 w-0 p-0";
 
-    private bool _prevToStartNext;
-
     private string BoxShadowFill => RepCountValue is not null  ? "0" : "2rem";
 
 // Realistically the bg should not be seen when there is a rep count, but there are mild artifacts when keeping it as bg-primary
@@ -128,11 +126,6 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if(_prevToStartNext != ToStartNext && ToStartNext)
-        {
-            await JSRuntime.InvokeVoidAsync("AppUtils.scrollIntoView", _button);
-        }
-        _prevToStartNext = ToStartNext;
         await base.OnParametersSetAsync();
     }
 


### PR DESCRIPTION
It was behaving annoyingly sometimes where the page would scroll unexpectedly when you finished a set.

Lets make it so it only scrolls it into view on the initial render
