### PR TITLE
Show the user an object from this world to compare how much they lifted to

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/RestTimer.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestTimer.razor
@@ -1,4 +1,5 @@
 <SnackBar>
+    <div class="flex justify-between">
     @if (Failed)
     {
         <span>Rest <span class="font-bold">@(Rest.FailureRest.ToString(TimespanFormatStr))</span></span>
@@ -13,6 +14,7 @@
         <span>Rest between <span class="font-bold">@(Rest.MinRest.ToString(TimespanFormatStr))</span> and <span class="font-bold">@(Rest.MaxRest.ToString(TimespanFormatStr))</span></span>
     }
     <span class="font-bold">@(TimeSinceStart.ToString(TimespanFormatStr))</span>
+    </div>
 </SnackBar>
 
 @code {

--- a/LiftLog.Ui/Shared/Presentation/RestTimer.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestTimer.razor
@@ -1,5 +1,5 @@
 <SnackBar>
-    <div class="flex justify-between">
+    <div class="flex items-center justify-between">
     @if (Failed)
     {
         <span>Rest <span class="font-bold">@(Rest.FailureRest.ToString(TimespanFormatStr))</span></span>

--- a/LiftLog.Ui/Shared/Presentation/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionComponent.razor
@@ -287,9 +287,16 @@ else
         }
         else if (Session.IsComplete)
         {
-            return @<SnackBar><span>This session you lifted </span><span class="font-bold">
-            <WeightFormat Weight="Session.TotalWeightLifted" />
-        </span></SnackBar>;
+            return @<SnackBar>
+                <span class="flex flex-col justify-start">
+                    <span class="flex justify-between">
+                        <span>This session you lifted </span><span class="font-bold"><WeightFormat Weight="Session.TotalWeightLifted" /></span>
+                    </span>
+                    <span class="flex justify-between">
+                        <WeightToObjectComparison Weight="Session.TotalWeightLifted"/>
+                    </span>
+                </span>
+                </SnackBar>;
         }
         return null;
     }

--- a/LiftLog.Ui/Shared/Presentation/SnackBar.razor
+++ b/LiftLog.Ui/Shared/Presentation/SnackBar.razor
@@ -1,4 +1,4 @@
-<div class="snackbar flex items-center justify-between p-4 rounded-md shadow-md pointer-events-auto bg-inverse-surface text-inverse-on-surface">
+<div class="snackbar p-4 rounded-md shadow-md pointer-events-auto bg-inverse-surface text-inverse-on-surface">
 @ChildContent
 </div>
 

--- a/LiftLog.Ui/Shared/Presentation/WeightToObjectComparison.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightToObjectComparison.razor
@@ -1,0 +1,57 @@
+<span>That's around <span class="font-bold">@GetWeightInObjects()</span> <span>@(weightToObjectMass[randomWeightIndex].Name)</span></span>
+
+@code{
+    private int randomWeightIndex = new Random().Next(weightToObjectMass.Count);
+    record WeightToObjectMass(string Name, decimal Kilograms);
+
+    [Parameter]
+    [EditorRequired]
+    public decimal Weight { get; set; }
+
+    [CascadingParameter(Name = "UseImperial")]
+    public bool UseImperial { get; set; }
+
+    static readonly ImmutableListValue<WeightToObjectMass> weightToObjectMass = [
+        new("elephants 🐘", 4000m),
+        new("cars 🚗", 1500m),
+        new("house cats 🐱", 4m),
+        new("human brains 🧠", 1.4m),
+        new("blue whale tongues 🐳", 2700m),
+        new("giraffes 🦒", 1200m),
+        new("pianos 🎹", 300m),
+        new("hot air balloons 🎈", 250m),
+        new("horses 🐴", 900m),
+        new("refrigerators ❄️", 50m),
+        new("bowling balls 🎳", 6.8m),
+        new("school buses 🚌", 12000m),
+        new("slices of bread 🍞", 0.03m),
+        new("African bull frogs 🐸", 1m),
+        new("motorcycles 🏍️", 200m),
+        new("basketballs 🏀", 0.62m),
+        new("sunflower seeds 🌻", 0.00005m),
+        new("macbook pros 💻", 1.4m),
+        new("golf balls ⛳", 0.045m),
+        new("air conditioners ❄️", 100m),
+        new("turtles 🐢", 0.9m),
+        new("baseballs ⚾", 0.145m),
+        new("apples 🍎", 0.2m),
+        new("bananas 🍌", 0.18m),
+        new("watermelons 🍉", 10m),
+        new("bricks 🧱", 2.3m),
+        new("cinder blocks 🧱", 18m),
+        new("hamsters 🐹", 0.14m),
+        new("chihuahuas 🐕", 4m),
+        new("honey bees 🐝", 0.00025m),
+        new("butterflies 🦋", 0.0003m),
+        new("medium dogs 🐶", 25m),
+        new("large dogs 🐶", 50m),
+        new("small dogs 🐶", 10m),
+    ];
+
+    private string GetWeightInObjects()
+    {
+        var convertedObjectWeight = UseImperial ? weightToObjectMass[randomWeightIndex].Kilograms * 2.205m : weightToObjectMass[randomWeightIndex].Kilograms;
+        var weightInObjects = Weight / convertedObjectWeight;
+        return weightInObjects.ToString("N0");
+    }
+}

--- a/LiftLog.Ui/Shared/Presentation/WeightToObjectComparison.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightToObjectComparison.razor
@@ -52,6 +52,11 @@
     {
         var convertedObjectWeight = UseImperial ? weightToObjectMass[randomWeightIndex].Kilograms * 2.205m : weightToObjectMass[randomWeightIndex].Kilograms;
         var weightInObjects = Weight / convertedObjectWeight;
+        if(weightInObjects is < 1 and >0)
+        {
+            randomWeightIndex = new Random().Next(weightToObjectMass.Count);
+            return GetWeightInObjects();
+        }
         return weightInObjects.ToString("N0");
     }
 }


### PR DESCRIPTION
This PR adds a list of objects ranging from elephants to sunflower seeds, which the app will pick a random one from at the end of each session.  It then shows the user how many of that object's this session  was
![image](https://github.com/LiamMorrow/LiftLog/assets/13741016/4be2b30e-1e69-47d3-98ca-46d1c72e36ed)
