### PR TITLE
Show tips to help users find their way around the app

### DIFF
--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -38,6 +38,8 @@ describe('Completing a session', () => {
   describe('When a user selects a pre-made program', () => {
     beforeEach(() => {
       cy.navigate('Settings')
+      // Disable tips
+      cy.containsA('Show tips').click()
       cy.containsA('Select a plan').click()
       cy.containsA("Starting Strength").click()
       cy.getA('[slot="actions"]').contains("Select").click()

--- a/LiftLog.Cypress/cypress/e2e/creating-a-plan.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/creating-a-plan.cy.js
@@ -8,6 +8,8 @@ describe('Creating a plan', () => {
   describe('When a user creates a plan', () => {
     beforeEach(() => {
       cy.navigate('Settings')
+      // Disable tips
+      cy.containsA('Show tips').click()
       cy.containsA('Manage workouts').click()
       cy.containsA('Add Session').click()
       cy.containsA('Session 1').click()

--- a/LiftLog.Cypress/cypress/e2e/settings.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/settings.cy.js
@@ -8,6 +8,8 @@ describe('Settings', () => {
   describe('When a user restores data', () => {
     beforeEach(() => {
       cy.navigate('Settings')
+      // Disable tips
+      cy.containsA('Show tips').click()
       cy.getA('[data-cy=restore-button]').click()
     })
 

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -40,6 +40,9 @@ else if (ProgramState.Value.UpcomingSessions.Count == 0)
 }
 else
 {
+    <div class="mb-2">
+        <Tips/>
+    </div>
 <CardList Items="ProgramState.Value.UpcomingSessions.IndexedTuples()" OnClick="x=>SelectSession(x.Item)"
     ShouldHighlight="session => session.Index == 0">
     <SessionSummary IsFilled="context.Item.IsStarted" Session="context.Item"></SessionSummary>

--- a/LiftLog.Ui/Pages/Settings/SettingsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/SettingsPage.razor
@@ -50,8 +50,10 @@
             <div>
                 <Switch Label="Show bodyweight" Value=@SettingsState.Value.ShowBodyweight OnSwitched="SetShowBodyweight"/>
             </div>
+            <md-divider></md-divider>
             <div>
                 <Switch Label="Show tips" Value=@SettingsState.Value.ShowTips OnSwitched="SetShowTips"/>
+                <AppButton Type=AppButtonType.OutlineSecondary OnClick=ResetTips>Reset tips</AppButton>
             </div>
             <md-divider></md-divider>
             <ThemeChooser
@@ -106,6 +108,9 @@
 
     private void SetShowTips(bool value)
         => Dispatcher.Dispatch(new SetShowTipsAction(value));
+
+    private void ResetTips()
+        => Dispatcher.Dispatch(new SetTipToShowAction(1));
 
     private async Task HandleThemeUpdate((uint? Seed, ThemePreference ThemePreference) value)
         {

--- a/LiftLog.Ui/Pages/Settings/SettingsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/SettingsPage.razor
@@ -50,6 +50,9 @@
             <div>
                 <Switch Label="Show bodyweight" Value=@SettingsState.Value.ShowBodyweight OnSwitched="SetShowBodyweight"/>
             </div>
+            <div>
+                <Switch Label="Show tips" Value=@SettingsState.Value.ShowTips OnSwitched="SetShowTips"/>
+            </div>
             <md-divider></md-divider>
             <ThemeChooser
                 Seed="@ThemeProvider.GetSeed()"
@@ -100,6 +103,9 @@
 
     private void SetShowBodyweight(bool value)
         => Dispatcher.Dispatch(new SetShowBodyweightAction(value));
+
+    private void SetShowTips(bool value)
+        => Dispatcher.Dispatch(new SetShowTipsAction(value));
 
     private async Task HandleThemeUpdate((uint? Seed, ThemePreference ThemePreference) value)
         {

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -52,4 +52,18 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
     {
         return await preferenceStore.GetItemAsync("showTips") is "True" or null;
     }
+
+    public async Task SetTipToShowAsync(int tipToShow)
+    {
+        await preferenceStore.SetItemAsync("tipToShow", tipToShow.ToString());
+    }
+
+    public async Task<int> GetTipToShowAsync()
+    {
+        var tipToShow = await preferenceStore.GetItemAsync("tipToShow");
+        if (int.TryParse(tipToShow, out var tipToShowInt))
+            return tipToShowInt;
+        else
+            return -1;
+    }
 }

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -64,6 +64,6 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
         if (int.TryParse(tipToShow, out var tipToShowInt))
             return tipToShowInt;
         else
-            return -1;
+            return 1;
     }
 }

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -42,4 +42,14 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
     {
         return await preferenceStore.GetItemAsync("showBodyweight") is "True" or null;
     }
+
+    public async Task SetShowTipsAsync(bool showTips)
+    {
+        await preferenceStore.SetItemAsync("showTips", showTips.ToString());
+    }
+
+    public async Task<bool> GetShowTipsAsync()
+    {
+        return await preferenceStore.GetItemAsync("showTips") is "True" or null;
+    }
 }

--- a/LiftLog.Ui/Shared/Smart/Tips/DisablingTipsTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/DisablingTipsTip.razor
@@ -1,0 +1,3 @@
+<div class="flex">
+    <span>These tips will show up when there are new features you might not know about. You can disable these tips by navigating to Settings and toggling the <span class="font-bold text-primary">Show tips</span> switch</span>
+</div>

--- a/LiftLog.Ui/Shared/Smart/Tips/DisablingTipsTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/DisablingTipsTip.razor
@@ -1,3 +1,4 @@
-<div class="flex">
-    <span>These tips will show up when there are new features you might not know about. You can disable these tips by navigating to Settings and toggling the <span class="font-bold text-primary">Show tips</span> switch</span>
+<div class="flex flex-col gap-2">
+    <span>These tips will show up when there are new features you might not know about. You can disable them by navigating to Settings and toggling the <span class="font-bold text-primary">Show tips</span> switch.</span>
+    <span>You can also see them all again by tapping the <span class="font-bold text-primary">Reset tips</span> button.</span>
 </div>

--- a/LiftLog.Ui/Shared/Smart/Tips/GeneralButtonInfoTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/GeneralButtonInfoTip.razor
@@ -1,0 +1,4 @@
+<div class="flex flex-col gap-2">
+    <span>All buttons are safe to press, and their actions can generally be undone. If a button will modify state in a destructive way, a confirmation will be shown before executing the action.</span>
+    <span>If you're unsure about what a button does, try tapping it!</span>
+</div>

--- a/LiftLog.Ui/Shared/Smart/Tips/HoldingRepCounterTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/HoldingRepCounterTip.razor
@@ -1,0 +1,40 @@
+<div class="flex gap-4">
+    <span>You can tap and hold on any set's rep counter to clear it.
+    Try it now!</span>
+    <PotentialSetCounter
+        Set="set"
+        ShowWeight=false
+        MaxReps="8"
+        WeightIncrement="0.25m"
+        CycleRepCount=@(() => CycleRepCountForSet())
+        ClearRepCount=@(() => ClearRepCountForSet())
+        UpdateWeight=@((_)=>{})
+        ToStartNext=false />
+</div>
+@code{
+    private PotentialSet set = new PotentialSet(new RecordedSet(8, TimeOnly.MinValue), 10m);
+
+    private void CycleRepCountForSet()
+    {
+        set = set with {
+            Set = set.Set switch
+            {
+                // When unset - we say the user completed all reps
+                null => new RecordedSet(8,TimeOnly.FromDateTime(DateTime.Now)),
+                // When they completed no reps, we transition back to unset
+                { RepsCompleted: 0 } => null,
+                // Otherwise, just decrement from the current
+                var reps => reps with { RepsCompleted = reps.RepsCompleted - 1 }
+            }
+        };
+        StateHasChanged();
+    }
+
+    private void ClearRepCountForSet()
+    {
+        set = set with { Set = null };
+        StateHasChanged();
+    }
+
+
+}

--- a/LiftLog.Ui/Shared/Smart/Tips/NotesButtonTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/NotesButtonTip.razor
@@ -1,0 +1,6 @@
+<div class="flex gap-2">
+    <span>You can click the <span class="font-bold text-primary">Notes</span> button on an exercise in any session to save some notes against that exercise.</span>
+    <div>
+        <IconButton Type="IconButtonType.Outlined" Icon="notes"/>
+    </div>
+</div>

--- a/LiftLog.Ui/Shared/Smart/Tips/PreviousButtonTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/PreviousButtonTip.razor
@@ -1,5 +1,5 @@
 <div class="flex gap-2">
-    <span>If you hold the <span class="font-bold text-primary">Previous</span> button on an exercise during a session, that exercise will temporarily show how you performed the last time you completed it, along with a graph of your progression.</span>
+    <span>If you <span class="font-bold text-primary">hold</span> the <span class="font-bold text-primary">Previous</span> button on an exercise during a session, that exercise will temporarily show how you performed the last time you completed it, along with a graph of your progression.</span>
     <div>
         <IconButton Type="IconButtonType.Outlined" Icon="history"/>
     </div>

--- a/LiftLog.Ui/Shared/Smart/Tips/PreviousButtonTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/PreviousButtonTip.razor
@@ -1,0 +1,6 @@
+<div class="flex gap-2">
+    <span>If you hold the <span class="font-bold text-primary">Previous</span> button on an exercise during a session, that exercise will temporarily show how you performed the last time you completed it, along with a graph of your progression.</span>
+    <div>
+        <IconButton Type="IconButtonType.Outlined" Icon="history"/>
+    </div>
+</div>

--- a/LiftLog.Ui/Shared/Smart/Tips/RestoringASessionTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/RestoringASessionTip.razor
@@ -1,0 +1,3 @@
+<div class="flex gap-2">
+    <span>Edited your plan, but want to restore a previous session you've completed? Just use history to open that session, then tap the <span class="font-bold text-primary">Update plan</span> button at the bottom.
+</div>

--- a/LiftLog.Ui/Shared/Smart/Tips/RestoringASessionTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/RestoringASessionTip.razor
@@ -1,3 +1,3 @@
 <div class="flex gap-2">
-    <span>Edited your plan, but want to restore a previous session you've completed? Just use history to open that session, then tap the <span class="font-bold text-primary">Update plan</span> button at the bottom.
+    <span>Edited your plan, but want to restore a previous session you've completed? Just use history to open that session, then tap the <span class="font-bold text-primary">Update plan</span> button at the bottom.</span>
 </div>

--- a/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
@@ -1,0 +1,31 @@
+@inject IState<SettingsState> SettingsState
+@inject IDispatcher Dispatcher
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+
+@if(SettingsState.Value.ShowTips && SettingsState.Value.TipToShow <= totalTips){
+    <Card class="flex flex-col gap-4">
+       <div class="flex justify-between"><h1 class="text-xl">Tip</h1><AppButton Type="AppButtonType.OutlineSecondary" OnClick="()=>HandleNextClick()">@NextText</AppButton></div>
+        @switch(SettingsState.Value.TipToShow)
+        {
+            case 1:
+                <DisablingTipsTip/>
+                break;
+            case 2:
+                <HoldingRepCounterTip/>
+                break;
+        }
+    </Card>
+}
+
+@code
+{
+    private static readonly int totalTips = 2;
+
+    private void HandleNextClick(){
+        Dispatcher.Dispatch(new SetTipToShowAction(SettingsState.Value.TipToShow+1));
+        StateHasChanged();
+    }
+
+    private string NextText => SettingsState.Value.TipToShow >= totalTips ? "Close" : "Next";
+}

--- a/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
@@ -4,7 +4,7 @@
 
 
 @if(SettingsState.Value.ShowTips && SettingsState.Value.TipToShow <= totalTips){
-    <Card class="flex flex-col gap-4">
+    <Card class="flex flex-col gap-4" IsHighlighted=true>
        <div class="flex justify-between"><h1 class="text-xl">Tip</h1><AppButton Type="AppButtonType.OutlineSecondary" OnClick="()=>HandleNextClick()">@NextText</AppButton></div>
         @switch(SettingsState.Value.TipToShow)
         {

--- a/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
@@ -12,7 +12,19 @@
                 <DisablingTipsTip/>
                 break;
             case 2:
+                <GeneralButtonInfoTip/>
+                break;
+            case 3:
                 <HoldingRepCounterTip/>
+                break;
+            case 4:
+                <NotesButtonTip/>
+                break;
+            case 5:
+                <PreviousButtonTip/>
+                break;
+            case 6:
+                <RestoringASessionTip/>
                 break;
         }
     </Card>
@@ -20,7 +32,7 @@
 
 @code
 {
-    private static readonly int totalTips = 2;
+    private static readonly int totalTips = 6;
 
     private void HandleNextClick(){
         Dispatcher.Dispatch(new SetTipToShowAction(SettingsState.Value.TipToShow+1));

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -25,3 +25,5 @@ public record SetThemeAction(uint? Seed, ThemePreference ThemePreference);
 public record SetUseImperialUnitsAction(bool UseImperialUnits);
 
 public record SetShowBodyweightAction(bool ShowBodyweight);
+
+public record SetShowTipsAction(bool ShowTips);

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -27,3 +27,5 @@ public record SetUseImperialUnitsAction(bool UseImperialUnits);
 public record SetShowBodyweightAction(bool ShowBodyweight);
 
 public record SetShowTipsAction(bool ShowTips);
+
+public record SetTipToShowAction(int TipToShow);

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -129,4 +129,10 @@ public class SettingsEffects(
     {
         await preferencesRepository.SetShowTipsAsync(action.ShowTips);
     }
+
+    [EffectMethod]
+    public async Task HandleSetTipToShowAction(SetTipToShowAction action, IDispatcher dispatcher)
+    {
+        await preferencesRepository.SetTipToShowAsync(action.TipToShow);
+    }
 }

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -123,4 +123,10 @@ public class SettingsEffects(
     {
         await preferencesRepository.SetShowBodyweightAsync(action.ShowBodyweight);
     }
+
+    [EffectMethod]
+    public async Task HandleSetShowTipsAction(SetShowTipsAction action, IDispatcher dispatcher)
+    {
+        await preferencesRepository.SetShowTipsAsync(action.ShowTips);
+    }
 }

--- a/LiftLog.Ui/Store/Settings/SettingsFeature.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsFeature.cs
@@ -14,6 +14,7 @@ public class SettingsFeature : Feature<SettingsState>
             AiPlan: null,
             UseImperialUnits: false,
             ShowBodyweight: true,
-            ShowTips: true
+            ShowTips: true,
+            TipToShow: 1
         );
 }

--- a/LiftLog.Ui/Store/Settings/SettingsFeature.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsFeature.cs
@@ -13,6 +13,7 @@ public class SettingsFeature : Feature<SettingsState>
             AiPlanError: null,
             AiPlan: null,
             UseImperialUnits: false,
-            ShowBodyweight: true
+            ShowBodyweight: true,
+            ShowTips: true
         );
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -43,4 +43,11 @@ public static class SettingsReducers
         SettingsState state,
         SetShowBodyweightAction action
     ) => state with { ShowBodyweight = action.ShowBodyweight };
+
+    [ReducerMethod]
+    public static SettingsState SetShowTips(SettingsState state, SetShowTipsAction action) =>
+        state with
+        {
+            ShowTips = action.ShowTips
+        };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -50,4 +50,11 @@ public static class SettingsReducers
         {
             ShowTips = action.ShowTips
         };
+
+    [ReducerMethod]
+    public static SettingsState SetSetTipToShow(SettingsState state, SetTipToShowAction action) =>
+        state with
+        {
+            TipToShow = action.TipToShow
+        };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -9,5 +9,6 @@ public record SettingsState(
     string? AiPlanError,
     AiWorkoutPlan? AiPlan,
     bool UseImperialUnits,
-    bool ShowBodyweight
+    bool ShowBodyweight,
+    bool ShowTips
 );

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -10,5 +10,6 @@ public record SettingsState(
     AiWorkoutPlan? AiPlan,
     bool UseImperialUnits,
     bool ShowBodyweight,
-    bool ShowTips
+    bool ShowTips,
+    int TipToShow
 );

--- a/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
@@ -12,5 +12,9 @@ public class SettingsStateInitMiddleware(PreferencesRepository preferencesReposi
         dispatch.Dispatch(new SetUseImperialUnitsAction(useImperialUnits));
         var showBodyweight = await preferencesRepository.GetShowBodyweightAsync();
         dispatch.Dispatch(new SetShowBodyweightAction(showBodyweight));
+        var showTips = await preferencesRepository.GetShowTipsAsync();
+        dispatch.Dispatch(new SetShowTipsAction(showTips));
+        var tipToShow = await preferencesRepository.GetTipToShowAsync();
+        dispatch.Dispatch(new SetTipToShowAction(tipToShow));
     }
 }

--- a/LiftLog.Ui/_Imports.razor
+++ b/LiftLog.Ui/_Imports.razor
@@ -26,3 +26,4 @@
 @using LiftLog.Ui.Store.Stats
 @using LiftLog.Ui.Store.AiSessionCreator
 @using BlazorTransitionableRoute
+@using LiftLog.Ui.Shared.Smart.Tips;


### PR DESCRIPTION
There's a bit of hidden complexity and power that can be missed if you don't about it.
This PR just adds tips that will get shown to users.  When the tips have been cleared, they stay away until more tips are added, or the user resets them

![image](https://github.com/LiamMorrow/LiftLog/assets/13741016/9a1904e3-85bc-420d-aa51-d2656b6ab4ac)

![image](https://github.com/LiamMorrow/LiftLog/assets/13741016/086c9b15-3788-4576-bb17-da8878fb62c0)
