### PR TITLE
Restyle the exercise editor

### DIFF
--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -12,7 +12,7 @@ describe('Completing a session', () => {
 
     it('can complete a freeform workout', () => {
       cy.containsA('Add Exercise', { includeShadowDom: true }).click()
-      cy.dialog().find('md-outlined-text-field').find('input', { includeShadowDom: true }).first().click().type('Squat')
+      cy.dialog().find('md-filled-text-field').find('input', { includeShadowDom: true }).first().click().type('Squat')
 
       cy.dialog().contains("Update").click()
 

--- a/LiftLog.Cypress/cypress/e2e/creating-a-plan.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/creating-a-plan.cy.js
@@ -19,7 +19,7 @@ describe('Creating a plan', () => {
       cy.dialog().find('[data-cy=exercise-reps]').should('contain.text', '10').find('[data-cy=fixed-decrement]').click()
       cy.dialog().find('[data-cy=exercise-auto-increase]').find('[data-cy=editable-field]').find('input', { includeShadowDom: true }).clear().type('4.5')
       cy.dialog().find('[data-cy=exercise-superset]').click()
-      cy.dialog().contains('Long', { includeShadowDom: true }).click().parent('md-filter-chip').should('have.class', 'selected')
+      cy.dialog().contains('Long', { includeShadowDom: true }).click().parent('md-outlined-segmented-button').should('have.attr', 'selected')
 
       cy.dialog().contains("Save").click()
 
@@ -35,7 +35,7 @@ describe('Creating a plan', () => {
 
       cy.dialog().find('[data-cy=exercise-auto-increase]').find('[data-cy=editable-field]').find('input', { includeShadowDom: true }).should('have.value', '4.5')
       cy.dialog().find('[data-cy=exercise-superset]').should('have.attr', 'selected')
-      cy.dialog().contains('Long', { includeShadowDom: true }).parent('md-filter-chip').should('have.class', 'selected')
+      cy.dialog().contains('Long', { includeShadowDom: true }).parent('md-outlined-segmented-button').should('have.attr', 'selected')
     })
 
   })

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -19,10 +19,10 @@
         <TextField
             class="w-full mb-4 text-start"
             Label="Session Name"
+            TextFieldType="TextFieldType.Filled"
             Value="@SessionEditorState.Value.SessionBlueprint.Name"
             OnChange="@((val) => SetName(val!))">
         </TextField>
-        <md-divider></md-divider>
         <ItemList Items="SessionEditorState.Value.SessionBlueprint.Exercises.IndexedTuples()">
             @{
                 var exercise = context.Item;

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -17,11 +17,12 @@
 {
     <div class="bg-surface pt-2">
         <TextField
-            class="w-full mb-4"
+            class="w-full mb-4 text-start"
             Label="Session Name"
             Value="@SessionEditorState.Value.SessionBlueprint.Name"
             OnChange="@((val) => SetName(val!))">
         </TextField>
+        <md-divider></md-divider>
         <ItemList Items="SessionEditorState.Value.SessionBlueprint.Exercises.IndexedTuples()">
             @{
                 var exercise = context.Item;

--- a/LiftLog.Ui/Shared/CustomEvents.cs
+++ b/LiftLog.Ui/Shared/CustomEvents.cs
@@ -26,4 +26,10 @@ namespace LiftLog.Ui.Shared;
     enableStopPropagation: false,
     enablePreventDefault: false
 )]
+[EventHandler(
+    "onsegmented-button-interaction",
+    typeof(object),
+    enableStopPropagation: false,
+    enablePreventDefault: false
+)]
 public static class EventHandlers { }

--- a/LiftLog.Ui/Shared/Presentation/EditableIncrementer.razor
+++ b/LiftLog.Ui/Shared/Presentation/EditableIncrementer.razor
@@ -1,11 +1,11 @@
 @typeparam T where T : System.Numerics.INumber<T>
 
-<div @attributes="AdditionalAttributes" class="flex flex-col gap-2 @(AdditionalAttributes?.GetValueOrDefault("class"))">
-    <label class="text-lg text-center">@Label</label>
-    <div class="flex items-center justify-center gap-2">
-        <IconButton data-cy="editable-decrement" Type="IconButtonType.FilledTonal" OnClick="@(() => { OnChange(Value - Increment); })" Icon="remove"/>
-        <TextField suffix-text="@Suffix" data-cy="editable-field" class="w-20" type="text" inputmode="decimal" Value="@(Value.ToString())" OnChange="@(value => OnChanged(value))"/>
-        <IconButton data-cy="editable-increment" Type="IconButtonType.FilledTonal" OnClick="@(() => { OnChange(Value + Increment); })" Icon="add"/>
+<div @attributes="AdditionalAttributes" class="flex justify-between items-center w-full @(AdditionalAttributes?.GetValueOrDefault("class"))">
+    <label class="text-lg text-start">@Label</label>
+    <div class="flex items-center justify-center">
+        <IconButton data-cy="editable-decrement" Type="IconButtonType.Standard" OnClick="@(() => { OnChange(Value - Increment); })" Icon="remove"/>
+        <TextField suffix-text="@Suffix" TextFieldType=TextFieldType.Filled data-cy="editable-field" class="w-20" type="text" inputmode="decimal" Value="@(Value.ToString())" OnChange="@(value => OnChanged(value))"/>
+        <IconButton data-cy="editable-increment" Type="IconButtonType.Standard" OnClick="@(() => { OnChange(Value + Increment); })" Icon="add"/>
     </div>
 </div>
 

--- a/LiftLog.Ui/Shared/Presentation/ExerciseBlueprintSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseBlueprintSummary.razor
@@ -9,15 +9,14 @@
                 <IconButton Type="IconButtonType.Standard" OnClick=OnRemove Icon="delete"/>
             </div>
         </div>
-        <div class="flex flex-col items-start">
-            <span class="text-lg"><span class="font-bold text-primary">@Blueprint.Sets</span> @(Pluralize(@Blueprint.Sets, "set")) of <span class="font-bold text-primary">@Blueprint.RepsPerSet</span> @(Pluralize(@Blueprint.RepsPerSet, "rep"))</span>
-            <span class="text-lg">Rest between <span class="font-bold text-primary">@(Blueprint.RestBetweenSets.MinRest.ToString(TimespanFormatStr))</span> and <span class="font-bold  text-primary">@(Blueprint.RestBetweenSets.MaxRest.ToString(TimespanFormatStr))</span></span>
+        <div class="flex gap-1 flex-col items-start">
+            <span class=""><span class="font-bold text-primary">@Blueprint.Sets</span> @(Pluralize(@Blueprint.Sets, "set")) of <span class="font-bold text-primary">@Blueprint.RepsPerSet</span> @(Pluralize(@Blueprint.RepsPerSet, "rep"))</span>
+            <RestFormat Rest=Blueprint.RestBetweenSets />
         </div>
     </div>
 </div>
 @code
 {
-    private const string TimespanFormatStr = @"m\:ss";
     [Parameter]
     [EditorRequired]
     public ExerciseBlueprint Blueprint { get; set; } = null!;

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -10,37 +10,39 @@
 </TextField>
 <div class="flex flex-wrap justify-around w-full gap-4">
     <div class="flex items-center w-full gap-4">
-
-    <Card Type=Card.CardType.Filled class="flex-grow  flex-shrink flex justify-center">
-        <FixedIncrementer
-            data-cy="exercise-sets"
-            Value="Exercise.Sets"
-            Increment="() => IncrementExerciseSets()"
-            Decrement="() => DecrementExerciseSets()"
-            Label="Sets"/>
-    </Card>
-    <Card Type=Card.CardType.Filled class="flex-grow flex-shrink flex  justify-center">
-        <FixedIncrementer
-            data-cy="exercise-reps"
-            Value="Exercise.RepsPerSet"
-            Increment="() => IncrementExerciseRepsPerSet()"
-            Decrement="() => DecrementExerciseRepsPerSet()"
-            Label="Reps"/>
-    </Card>
+        <Card Type=Card.CardType.Filled class="flex-grow  flex-shrink flex justify-center">
+            <FixedIncrementer
+                data-cy="exercise-sets"
+                Value="Exercise.Sets"
+                Increment="() => IncrementExerciseSets()"
+                Decrement="() => DecrementExerciseSets()"
+                Label="Sets"/>
+        </Card>
+        <Card Type=Card.CardType.Filled class="flex-grow flex-shrink flex  justify-center">
+            <FixedIncrementer
+                data-cy="exercise-reps"
+                Value="Exercise.RepsPerSet"
+                Increment="() => IncrementExerciseRepsPerSet()"
+                Decrement="() => DecrementExerciseRepsPerSet()"
+                Label="Reps"/>
+        </Card>
     </div>
     <Card Type=Card.CardType.Filled class="w-full flex flex-col gap-6 items-start">
-    <EditableIncrementer
-        Increment="0.1m"
-        Label="Progressive Overload"
-        data-cy="exercise-auto-increase"
-        Suffix=@WeightSuffix
-        Value="Exercise.WeightIncreaseOnSuccess"
-        OnChange="e => SetExerciseSuccessWeight(e)"/>
+        <div class="-mr-2">
+            <EditableIncrementer
+                Increment="0.1m"
+                Label="Progressive Overload"
+                data-cy="exercise-auto-increase"
+                Suffix=@WeightSuffix
+                Value="Exercise.WeightIncreaseOnSuccess"
+                OnChange="e => SetExerciseSuccessWeight(e)"/>
+        </div>
         <md-divider></md-divider>
+
         <div class="w-full">
             <Switch Label="Superset next exercise" data-cy="exercise-superset" Value="Exercise.SupersetWithNext" OnSwitched="supersets => SetExerciseSupersetsNext(supersets)"/>
         </div>
-        </Card>
+    </Card>
 
     <Card Type=Card.CardType.Filled class="w-full flex flex-col gap-6 items-start">
         <RestEditorGroup Rest="Exercise.RestBetweenSets" OnRestUpdated="rest => OnRestUpdated(rest)"/>

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -1,39 +1,51 @@
-
+<div class="flex flex-col gap-4">
 <TextField
     data-cy="exercise-name"
-    TextFieldType="TextFieldType.Outline"
-    class="w-full mb-2 text-xl"
+    TextFieldType="TextFieldType.Filled"
+    class="w-full mb-2 text-xl text-start"
     Label="Exercise"
     Value="@Exercise.Name"
     required
     OnChange="@(val => SetExerciseName(val!))">
 </TextField>
 <div class="flex flex-wrap justify-around w-full gap-4">
-    <div class="flex flex-col items-center gap-2">
+    <div class="flex items-center w-full gap-4">
+
+    <Card Type=Card.CardType.Filled class="flex-grow  flex-shrink flex justify-center">
         <FixedIncrementer
             data-cy="exercise-sets"
             Value="Exercise.Sets"
             Increment="() => IncrementExerciseSets()"
             Decrement="() => DecrementExerciseSets()"
             Label="Sets"/>
+    </Card>
+    <Card Type=Card.CardType.Filled class="flex-grow flex-shrink flex  justify-center">
         <FixedIncrementer
             data-cy="exercise-reps"
             Value="Exercise.RepsPerSet"
             Increment="() => IncrementExerciseRepsPerSet()"
             Decrement="() => DecrementExerciseRepsPerSet()"
             Label="Reps"/>
+    </Card>
     </div>
+    <Card Type=Card.CardType.Filled class="w-full flex flex-col gap-6 items-start">
     <EditableIncrementer
         Increment="0.1m"
-        Label="Progressive Overload Amount"
+        Label="Progressive Overload"
         data-cy="exercise-auto-increase"
         Suffix=@WeightSuffix
         Value="Exercise.WeightIncreaseOnSuccess"
         OnChange="e => SetExerciseSuccessWeight(e)"/>
+        <md-divider></md-divider>
+        <div class="w-full">
+            <Switch Label="Superset next exercise" data-cy="exercise-superset" Value="Exercise.SupersetWithNext" OnSwitched="supersets => SetExerciseSupersetsNext(supersets)"/>
+        </div>
+        </Card>
 
-    <Switch Label="Superset With Next Exercise" data-cy="exercise-superset" Value="Exercise.SupersetWithNext" OnSwitched="supersets => SetExerciseSupersetsNext(supersets)"/>
-
-    <RestEditorGroup Rest="Exercise.RestBetweenSets" OnRestUpdated="rest => OnRestUpdated(rest)"/>
+    <Card Type=Card.CardType.Filled class="w-full flex flex-col gap-6 items-start">
+        <RestEditorGroup Rest="Exercise.RestBetweenSets" OnRestUpdated="rest => OnRestUpdated(rest)"/>
+    </Card>
+</div>
 </div>
 
 @code

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -10,7 +10,7 @@
 </TextField>
 <div class="flex flex-wrap justify-around w-full gap-4">
     <div class="flex items-center w-full gap-4">
-        <Card Type=Card.CardType.Filled class="flex-grow  flex-shrink flex justify-center">
+        <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex-1 flex justify-center">
             <FixedIncrementer
                 data-cy="exercise-sets"
                 Value="Exercise.Sets"
@@ -18,7 +18,7 @@
                 Decrement="() => DecrementExerciseSets()"
                 Label="Sets"/>
         </Card>
-        <Card Type=Card.CardType.Filled class="flex-grow flex-shrink flex  justify-center">
+        <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex flex-1 justify-center">
             <FixedIncrementer
                 data-cy="exercise-reps"
                 Value="Exercise.RepsPerSet"

--- a/LiftLog.Ui/Shared/Presentation/FixedIncrementer.razor
+++ b/LiftLog.Ui/Shared/Presentation/FixedIncrementer.razor
@@ -1,9 +1,14 @@
 @typeparam T
 
-<div @attributes="@AdditionalAttributes" class="flex items-center @(AdditionalAttributes?.GetValueOrDefault("class"))">
-    <IconButton data-cy="fixed-decrement" Type="IconButtonType.FilledTonal" OnClick="Decrement" Icon="remove"/>
-    <span class="inline-block w-20 mx-2 text-center">@Value @Label</span>
-    <IconButton data-cy="fixed-increment" Type="IconButtonType.FilledTonal" OnClick="Increment" Icon="add"/>
+<div @attributes="@AdditionalAttributes" class="@(AdditionalAttributes?.GetValueOrDefault("class"))">
+    <div class="flex flex-col gap-2">
+        <label class="text-lg">@Label</label>
+        <div class="flex items-center ">
+            <IconButton data-cy="fixed-decrement" Type="IconButtonType.Standard" OnClick="Decrement" Icon="remove"/>
+            <span class="inline-block mx-2 text-center font-bold text-primary text-3xl">@Value</span>
+            <IconButton data-cy="fixed-increment" Type="IconButtonType.Standard" OnClick="Increment" Icon="add"/>
+        </div>
+    </div>
 </div>
 
 @code

--- a/LiftLog.Ui/Shared/Presentation/FullScreenDialog.razor
+++ b/LiftLog.Ui/Shared/Presentation/FullScreenDialog.razor
@@ -5,7 +5,7 @@
 {
     @* Put the dialog into a section in the main layout so that the scrim covers parent elements on ios *@
     <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="Dialog">
-        <div @ref=dialog class="@Animation fullscreen-dialog fixed top-0 bottom-0 left-0 right-0 bg-surface z-30 grid grid-cols-1 h-full grid-rows-[min-content_1fr_min-content]" data-open="@opened" @onclose=Close>
+        <div @ref=dialog class="@Animation text-on-surface fullscreen-dialog fixed top-0 bottom-0 left-0 right-0 bg-surface z-30 grid grid-cols-1 h-full grid-rows-[min-content_1fr_min-content]" data-open="@opened" @onclose=Close>
             <div class="@topNavColorClass flex justify-start items-center gap-2 p-2 transition-colors">
                 <div style="height: @InsetsManager.SystemSafeInsetTop"></div>
                 <IconButton Type="IconButtonType.Standard" Icon="close" OnClick="Close"/>

--- a/LiftLog.Ui/Shared/Presentation/RestEditorGroup.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestEditorGroup.razor
@@ -1,14 +1,16 @@
-<div class="flex flex-col gap-2">
-    <span class="text-lg text-center">Rest</span>
-    <div class="flex flex-wrap justify-center gap-2">
-        <FilterChip OnSelectedChange="HandleSelectedChanged(Rest.Short)" Label="Short" Selected="@(!_isCustom && Rest == Rest.Short)"/>
-        <FilterChip OnSelectedChange="HandleSelectedChanged(Rest.Medium)" Label="Medium" Selected="@(!_isCustom && Rest == Rest.Medium)"/>
-        <FilterChip OnSelectedChange="HandleSelectedChanged(Rest.Long)" Label="Long" Selected="@(!_isCustom && Rest == Rest.Long)"/>
-        <FilterChip OnSelectedChange="HandleCustomSelectedChanged" Label="Custom" Selected="@(_isCustom)"/>
+<div class="flex flex-col items-start gap-2 text-on-surface">
+    <span class="text-lg">Rest</span>
+    <div class="w-full flex justify-center">
+        <md-outlined-segmented-button-set>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Short)"  selected="@(!_isCustom && Rest == Rest.Short)" label="Short"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Medium)" selected="@(!_isCustom && Rest == Rest.Medium)" label="Medium"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Long)"   selected="@(!_isCustom && Rest == Rest.Long)" label="Long"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleCustomSelectedChanged"        selected="@(_isCustom)" label="Custom"></md-outlined-segmented-button>
+        </md-outlined-segmented-button-set>
     </div>
     @if (_isCustom)
     {
-        <div class="flex flex-col justify-between gap-2">
+        <div class="flex flex-col w-full items-center justify-between gap-2">
             <RestEditor Label="Min Rest" Rest="Rest.MinRest" OnRestUpdated="rest => OnRestUpdated(Rest with { MinRest = rest })"></RestEditor>
             <RestEditor Label="Max Rest" Rest="Rest.MaxRest" OnRestUpdated="rest => OnRestUpdated(Rest with { MaxRest = rest })"></RestEditor>
             <RestEditor Label="Failure Rest" Rest="Rest.FailureRest" OnRestUpdated="rest => OnRestUpdated(Rest with { FailureRest = rest })"></RestEditor>
@@ -16,13 +18,10 @@
     }
     else
     {
-        <div class="flex flex-col justify-between gap-2">
+        <div class="flex flex-col justify-between gap-2 w-full">
             <div class="flex flex-col items-start">
                 <div class="flex justify-between w-full">
-                    <span>Success:</span><span>@Rest.MinRest.ToString("m\\:ss") - @Rest.MaxRest.ToString("m\\:ss")</span>
-                </div>
-                <div class="flex justify-between w-full">
-                    <span>Failure:</span><span>@Rest.FailureRest.ToString("m\\:ss")</span>
+                    <RestFormat Rest="Rest" />
                 </div>
             </div>
         </div>

--- a/LiftLog.Ui/Shared/Presentation/RestEditorGroup.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestEditorGroup.razor
@@ -1,4 +1,4 @@
-<div class="flex flex-col items-start gap-2 text-on-surface">
+<div class="flex flex-col items-start gap-5 text-on-surface">
     <span class="text-lg">Rest</span>
     <div class="w-full flex justify-center">
         <md-outlined-segmented-button-set>
@@ -18,12 +18,8 @@
     }
     else
     {
-        <div class="flex flex-col justify-between gap-2 w-full">
-            <div class="flex flex-col items-start">
-                <div class="flex justify-between w-full">
-                    <RestFormat Rest="Rest" />
-                </div>
-            </div>
+        <div class="w-full text-start">
+            <RestFormat Rest="Rest" />
         </div>
     }
 </div>

--- a/LiftLog.Ui/Shared/Presentation/RestFormat.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestFormat.razor
@@ -1,0 +1,20 @@
+
+@if (Rest.MinRest >= Rest.MaxRest)
+{
+    <span>Rest <span class="font-bold @(Highlight ? "text-primary" :"")">@(Rest.MinRest.ToString(TimespanFormatStr))</span></span>
+}
+else
+{
+    <span>Rest between <span class="font-bold @(Highlight ? "text-primary" :"")">@(Rest.MinRest.ToString(TimespanFormatStr))</span> and <span class="font-bold @(Highlight ? "text-primary" :"")">@(Rest.MaxRest.ToString(TimespanFormatStr))</span></span>
+}
+@code {
+
+    private const string TimespanFormatStr = @"m\:ss";
+
+    [Parameter]
+    [EditorRequired]
+    public Rest Rest { get; set; } = null!;
+
+    [Parameter]
+    public bool Highlight { get; set; } = true;
+}

--- a/LiftLog.Ui/Shared/Presentation/RestTimer.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestTimer.razor
@@ -4,13 +4,8 @@
         {
             <span>Rest <span class="font-bold">@(Rest.FailureRest.ToString(TimespanFormatStr))</span></span>
         }
-        else if (Rest.MinRest >= Rest.MaxRest)
-        {
-            <span>Rest <span class="font-bold">@(Rest.MinRest.ToString(TimespanFormatStr))</span></span>
-        }
-        else
-        {
-            <span>Rest between <span class="font-bold">@(Rest.MinRest.ToString(TimespanFormatStr))</span> and <span class="font-bold">@(Rest.MaxRest.ToString(TimespanFormatStr))</span></span>
+        else {
+            <RestFormat Highlight=false Rest="@Rest" />
         }
         <span class="font-bold">@(TimeSinceStart.ToString(TimespanFormatStr))</span>
     </div>

--- a/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
@@ -172,6 +172,7 @@ else
             },
             Legend = new()
             {
+                Show = true,
                 Labels = new()
                 {
                     Colors = GetColorString(scheme.OnSurface)

--- a/LiftLog.Ui/Shared/Presentation/Switch.razor
+++ b/LiftLog.Ui/Shared/Presentation/Switch.razor
@@ -1,5 +1,5 @@
 @inject IJSRuntime JSRuntime
-<label class="flex justify-between gap-3 items-center">
+<label class="flex justify-between gap-3 items-center text-lg">
     @Label
     <md-switch @attributes="AdditionalAttributes" @ref="_switchRef" @onchange="HandleInput" selected="@Value"></md-switch>
 </label>

--- a/LiftLog.Ui/Store/Stats/StatsEffects.cs
+++ b/LiftLog.Ui/Store/Stats/StatsEffects.cs
@@ -89,7 +89,7 @@ public class StatsEffects(
                 .Aggregate(
                     (TimeSpan.Zero, 0),
                     (acc, x) => (acc.Item1 + x, acc.Item2 + 1),
-                    acc => acc.Item1 / acc.Item2
+                    acc => acc.Item2 != 0 ? acc.Item1 / acc.Item2 : TimeSpan.Zero
                 );
 
             var averageSessionLength = sessions
@@ -98,7 +98,7 @@ public class StatsEffects(
                 .Aggregate(
                     (TimeSpan.Zero, 0),
                     (acc, x) => (acc.Item1 + x, acc.Item2 + 1),
-                    acc => acc.Item1 / acc.Item2
+                    acc => acc.Item2 != 0 ? acc.Item1 / acc.Item2 : TimeSpan.Zero
                 );
 
             var exerciseMostTimeSpent = sessions

--- a/LiftLog.Ui/Styles/app.css
+++ b/LiftLog.Ui/Styles/app.css
@@ -1,8 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-input[type="text"],
-input[type="number"] {
-    @apply p-2 border-b rounded-sm caret-primary bg-surface-container-highest text-on-surface border-on-surface-variant focus:border-primary focus:outline-none;
-}

--- a/LiftLog.Ui/index.js
+++ b/LiftLog.Ui/index.js
@@ -1,6 +1,8 @@
 import '@material/web/all.js';
 
 import '@material/web/chips/chip-set.js';
+import '@material/web/labs/segmentedbutton/outlined-segmented-button.js';
+import '@material/web/labs/segmentedbuttonset/outlined-segmented-button-set.js';
 
 import 'element-internals-polyfill';
 

--- a/LiftLog.Web/Services/WebThemeProvider.cs
+++ b/LiftLog.Web/Services/WebThemeProvider.cs
@@ -51,7 +51,7 @@ public class WebThemeProvider(IJSRuntime jsRuntime, IPreferenceStore preferenceS
         BlazorJavascriptInitialization.Initialize(jsInProcessRuntime);
 
         var window = jsInProcessRuntime.GetWindow()!;
-        var windowThemePrefersDark = !window
+        var windowThemePrefersDark = window
             .matchMedia(jsInProcessRuntime.CreateString("(prefers-color-scheme: dark)"))
             .matches.ConvertToValue<bool>();
 

--- a/LiftLog.Web/Services/WebThemeProvider.cs
+++ b/LiftLog.Web/Services/WebThemeProvider.cs
@@ -51,7 +51,7 @@ public class WebThemeProvider(IJSRuntime jsRuntime, IPreferenceStore preferenceS
         BlazorJavascriptInitialization.Initialize(jsInProcessRuntime);
 
         var window = jsInProcessRuntime.GetWindow()!;
-        var windowThemePrefersDark = window
+        var windowThemePrefersDark = !window
             .matchMedia(jsInProcessRuntime.CreateString("(prefers-color-scheme: dark)"))
             .matches.ConvertToValue<bool>();
 


### PR DESCRIPTION
The new design uses cards to group content, and cleans up rests dramatically.

<details>
<summary>Old Design</summary>


<img width="375" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/d8ce5dd9-cf9a-47da-8ed1-42efd11f7108">


</details>
<details>
<summary>New Design</summary>

<img width="377" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/ca4f0848-1061-41da-a40c-220ee6b7876b">

</details>
