### PR TITLE
Switch to gpt-4 for ai generation

### DIFF
--- a/LiftLog.Api/Service/GptAiWorkoutPlanner.cs
+++ b/LiftLog.Api/Service/GptAiWorkoutPlanner.cs
@@ -59,7 +59,7 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient) : IAiWorkoutPlanner
         };
         var chatRequest = new ChatRequest(
             messages,
-            model: "gpt-3.5-turbo-0613",
+            model: OpenAI.Models.Model.GPT4,
             toolChoice: "auto",
             tools: tools
         );
@@ -152,7 +152,7 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient) : IAiWorkoutPlanner
         };
         var chatRequest = new ChatRequest(
             messages,
-            model: "gpt-3.5-turbo-0613",
+            model: OpenAI.Models.Model.GPT4,
             toolChoice: "auto",
             tools: tools
         );


### PR DESCRIPTION
Open AI changed their pricing model, which means I had to prepurchase credits, which unlocked gpt-4.  It should still be cheap enough for me to run and might produce better results 🎉 

I'd like to look into locally hosting a model but not right now