### PR TITLE
Update feed share process to omit public key and store them on the backend

### DIFF
--- a/LiftLog.Api/Controllers/UserController.cs
+++ b/LiftLog.Api/Controllers/UserController.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography.X509Certificates;
 using FluentValidation;
 using LiftLog.Api.Db;
 using LiftLog.Api.Models;
@@ -38,6 +39,7 @@ public class UserController(UserDataContext db, PasswordService passwordService)
             Salt = salt,
             LastAccessed = DateTimeOffset.UtcNow,
             EncryptionIV = [],
+            RsaPublicKey = []
         };
 
         await db.Users.AddAsync(user);
@@ -62,7 +64,8 @@ public class UserController(UserDataContext db, PasswordService passwordService)
                 EncryptedCurrentPlan: user.EncryptedCurrentPlan,
                 EncryptedProfilePicture: user.EncryptedProfilePicture,
                 EncryptedName: user.EncryptedName,
-                EncryptionIV: user.EncryptionIV
+                EncryptionIV: user.EncryptionIV,
+                RsaPublicKey: user.RsaPublicKey
             )
         );
     }
@@ -124,6 +127,7 @@ public class UserController(UserDataContext db, PasswordService passwordService)
         user.EncryptedProfilePicture = request.EncryptedProfilePicture;
         user.EncryptedName = request.EncryptedName;
         user.EncryptionIV = request.EncryptionIV;
+        user.RsaPublicKey = request.RsaPublicKey;
         await db.SaveChangesAsync();
         return Ok();
     }

--- a/LiftLog.Api/Controllers/UsersController.cs
+++ b/LiftLog.Api/Controllers/UsersController.cs
@@ -37,7 +37,8 @@ public class UsersController(UserDataContext db) : ControllerBase
                         EncryptedCurrentPlan: x.EncryptedCurrentPlan,
                         EncryptedProfilePicture: x.EncryptedProfilePicture,
                         EncryptedName: x.EncryptedName,
-                        EncryptionIV: x.EncryptionIV
+                        EncryptionIV: x.EncryptionIV,
+                        RsaPublicKey: x.RsaPublicKey
                     )
                 )
             )

--- a/LiftLog.Api/Migrations/UserData/20240407022930_StorePublicKeys.Designer.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407022930_StorePublicKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LiftLog.Api.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LiftLog.Api.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20240407022930_StorePublicKeys")]
+    partial class StorePublicKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LiftLog.Api/Migrations/UserData/20240407022930_StorePublicKeys.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407022930_StorePublicKeys.cs
@@ -14,15 +14,14 @@ namespace LiftLog.Api.Migrations
                 name: "rsa_public_key",
                 table: "users",
                 type: "bytea",
-                nullable: true);
+                nullable: true
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "rsa_public_key",
-                table: "users");
+            migrationBuilder.DropColumn(name: "rsa_public_key", table: "users");
         }
     }
 }

--- a/LiftLog.Api/Migrations/UserData/20240407022930_StorePublicKeys.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407022930_StorePublicKeys.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LiftLog.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class StorePublicKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "rsa_public_key",
+                table: "users",
+                type: "bytea",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "rsa_public_key",
+                table: "users");
+        }
+    }
+}

--- a/LiftLog.Api/Models/User.cs
+++ b/LiftLog.Api/Models/User.cs
@@ -19,4 +19,6 @@ public class User
 
     // The IV can be considered public, as long as the encryption key is kept secret
     public byte[] EncryptionIV { get; set; } = null!;
+
+    public byte[]? RsaPublicKey { get; set; }
 }

--- a/LiftLog.Lib/Models/UserActions.cs
+++ b/LiftLog.Lib/Models/UserActions.cs
@@ -17,7 +17,8 @@ public record PutUserDataRequest(
     byte[]? EncryptedProfilePicture,
     byte[]? EncryptedName,
     // The IV can be considered public, as long as the encryption key is kept secret
-    byte[] EncryptionIV
+    byte[] EncryptionIV,
+    byte[] RsaPublicKey
 );
 
 public record GetUserResponse(
@@ -25,7 +26,8 @@ public record GetUserResponse(
     byte[]? EncryptedProfilePicture,
     byte[]? EncryptedName,
     // The IV can be considered public, as long as the encryption key is kept secret
-    byte[] EncryptionIV
+    byte[] EncryptionIV,
+    byte[]? RsaPublicKey
 );
 
 public record PutUserEventRequest(

--- a/LiftLog.Ui/Models/FeedStateDao.cs
+++ b/LiftLog.Ui/Models/FeedStateDao.cs
@@ -69,9 +69,8 @@ internal partial class FeedUserDaoV1
                     : new Lib.Services.AesKey(value.AesKey.ToByteArray()),
                 PublicKey: new Lib.Services.RsaPublicKey(value.PublicKey.ToByteArray()),
                 CurrentPlan: value
-                    .CurrentPlan?.Sessions.Select(sessionBlueprintDao =>
-                        sessionBlueprintDao.ToModel()
-                    )
+                    .CurrentPlan?.Sessions
+                    .Select(sessionBlueprintDao => sessionBlueprintDao.ToModel())
                     .ToImmutableList() ?? [],
                 ProfilePicture: value.ProfilePicture.IsEmpty
                     ? null
@@ -158,7 +157,8 @@ internal partial class FeedStateDaoV1
                 ActiveTab: "mainfeed-panel",
                 UnpublishedSessionIds: value
                     .UnpublishedSessionIds.Select(x => (Guid)x)
-                    .ToImmutableHashSet()
+                    .ToImmutableHashSet(),
+                HasPublishedRsaPublicKey: value.PublishedRsaKey
             );
 
     [return: NotNullIfNotNull(nameof(value))]
@@ -172,7 +172,8 @@ internal partial class FeedStateDaoV1
                 FollowedUsers = { value.FollowedUsers.Values.Select(x => (FeedUserDaoV1)x) },
                 FollowRequests = { value.FollowRequests.Select(x => (InboxMessageDao)x) },
                 Followers = { value.Followers.Values.Select(x => (FeedUserDaoV1)x) },
-                UnpublishedSessionIds = { value.UnpublishedSessionIds.Select(x => (UuidDao)x) }
+                UnpublishedSessionIds = { value.UnpublishedSessionIds.Select(x => (UuidDao)x) },
+                PublishedRsaKey = value.HasPublishedRsaPublicKey
             };
 }
 

--- a/LiftLog.Ui/Models/FeedStateDao.cs
+++ b/LiftLog.Ui/Models/FeedStateDao.cs
@@ -69,8 +69,9 @@ internal partial class FeedUserDaoV1
                     : new Lib.Services.AesKey(value.AesKey.ToByteArray()),
                 PublicKey: new Lib.Services.RsaPublicKey(value.PublicKey.ToByteArray()),
                 CurrentPlan: value
-                    .CurrentPlan?.Sessions
-                    .Select(sessionBlueprintDao => sessionBlueprintDao.ToModel())
+                    .CurrentPlan?.Sessions.Select(sessionBlueprintDao =>
+                        sessionBlueprintDao.ToModel()
+                    )
                     .ToImmutableList() ?? [],
                 ProfilePicture: value.ProfilePicture.IsEmpty
                     ? null

--- a/LiftLog.Ui/Models/FeedStateDao.proto
+++ b/LiftLog.Ui/Models/FeedStateDao.proto
@@ -56,4 +56,5 @@ message FeedStateDaoV1 {
     repeated LiftLog.Ui.Models.InboxMessageDao follow_requests = 4;
     repeated LiftLog.Ui.Models.FeedUserDaoV1 followers = 5;
     repeated LiftLog.Ui.Models.UuidDao unpublished_session_ids = 6;
+    bool published_rsa_key = 7;
 }

--- a/LiftLog.Ui/Pages/Feed/FeedSharePage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedSharePage.razor
@@ -51,7 +51,7 @@ else
 @code
 {
     [SupplyParameterFromQuery(Name = "pub")]
-    public string PublicKey { get; set; } = "";
+    public string? PublicKey { get; set; } = "";
 
     [SupplyParameterFromQuery(Name = "id")]
     public Guid id { get; set; }
@@ -63,28 +63,27 @@ else
 
     private AppStore phoneAppStore;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Subscribe to a feed"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/feed"));
-        if (String.IsNullOrEmpty(PublicKey) || id == Guid.Empty)
+        if (FeedState.Value.Identity is null)
+        {
+            Dispatcher.Dispatch(new NavigateAction("/feed/create-identity?from=" + Uri.EscapeDataString("/feed/share?pub=" + PublicKey + "&id=" + id + "&name=" + Name ?? "")));
+        }
+        else if (id == Guid.Empty)
         {
             Dispatcher.Dispatch(new NavigateAction("/feed"));
         }
-        else if (FeedState.Value.Identity is null)
+        else if (string.IsNullOrEmpty(PublicKey))
         {
-            Dispatcher.Dispatch(new NavigateAction("/feed/create-identity?from=" + Uri.EscapeDataString("/feed/share?pub=" + PublicKey + "&id=" + id + "&name=" + Name ?? "")));
+            Dispatcher.Dispatch(new FetchAndSetSharedFeedUserAction(id, Name));
         }
         else
         {
             Dispatcher.Dispatch(new SetSharedFeedUserAction(FeedUser.FromShared(id, new RsaPublicKey(PublicKey.FromUrlSafeHexString()), Name)));
         }
 
-        base.OnInitialized();
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
         await base.OnInitializedAsync();
         phoneAppStore = await GetAppStoreFromUserAgent();
     }

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -107,6 +107,7 @@ else
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(false));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new PublishUnpublishedSessionsAction());
+        Dispatcher.Dispatch(new PublishRsaPublicKeyIfNeededAction());
         await base.OnInitializedAsync();
     }
 

--- a/LiftLog.Ui/Services/FeedIdentityService.cs
+++ b/LiftLog.Ui/Services/FeedIdentityService.cs
@@ -108,7 +108,8 @@ public class FeedIdentityService(
                 EncryptedCurrentPlan: encryptedPlan,
                 EncryptedName: encryptedName,
                 EncryptedProfilePicture: encryptedProfilePicture,
-                EncryptionIV: iv.Value
+                EncryptionIV: iv.Value,
+                RsaPublicKey: rsaKeyPair.PublicKey.SpkiPublicKeyBytes
             )
         );
         if (!result.IsSuccess)

--- a/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
+++ b/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
@@ -27,8 +27,8 @@
 
     public static string GetShareUrl(Guid id, RsaPublicKey publicKey, string? name) =>
 #if DEBUG
-        $"https://0.0.0.0:5001/feed/share?pub={publicKey.SpkiPublicKeyBytes.ToUrlSafeHexString()}&id={id}{(name is null ? "" : $"&name={Uri.EscapeDataString(name)}")}";
+        $"https://0.0.0.0:5001/feed/share?id={id}{(name is null ? "" : $"&name={Uri.EscapeDataString(name)}")}";
 #else
-        $"https://app.liftlog.online/feed/share?pub={publicKey.SpkiPublicKeyBytes.ToUrlSafeHexString()}&id={id}{(name is null ? "" : $"&name={Uri.EscapeDataString(name)}")}";
+        $"https://app.liftlog.online/feed/share?id={id}{(name is null ? "" : $"&name={Uri.EscapeDataString(name)}")}";
 #endif
 }

--- a/LiftLog.Ui/Store/Feed/FeedActions.cs
+++ b/LiftLog.Ui/Store/Feed/FeedActions.cs
@@ -37,6 +37,8 @@ public record PutFollowedUsersAction(FeedUser User);
 
 public record SetSharedFeedUserAction(FeedUser? User);
 
+public record FetchAndSetSharedFeedUserAction(Guid Id, string? Name);
+
 public record PublishIdentityIfEnabledAction();
 
 public record SaveSharedFeedUserAction();
@@ -44,6 +46,10 @@ public record SaveSharedFeedUserAction();
 public record FetchSessionFeedItemsAction();
 
 public record PublishUnpublishedSessionsAction();
+
+public record SetHasPublishedRsaPublicKeyAction(bool HasPublishedRsaPublicKey);
+
+public record PublishRsaPublicKeyIfNeededAction();
 
 public record ReplaceFeedFollowedUsersAction(ImmutableListValue<FeedUser> FollowedUsers);
 

--- a/LiftLog.Ui/Store/Feed/FeedEffects.Following.cs
+++ b/LiftLog.Ui/Store/Feed/FeedEffects.Following.cs
@@ -28,6 +28,32 @@ public partial class FeedEffects(
 )
 {
     [EffectMethod]
+    public async Task HandleFetchAndSetSharedFeedUserAction(
+        FetchAndSetSharedFeedUserAction action,
+        IDispatcher dispatcher
+    )
+    {
+        var result = await feedApiService.GetUserAsync(action.Id);
+        if (result is { IsSuccess: true, Data.RsaPublicKey: not null })
+        {
+            dispatcher.Dispatch(
+                new SetSharedFeedUserAction(
+                    FeedUser.FromShared(
+                        action.Id,
+                        new RsaPublicKey(result.Data.RsaPublicKey),
+                        action.Name
+                    )
+                )
+            );
+        }
+        else
+        {
+            // TODO handle properly
+            logger.LogError("Failed to fetch shared feed user with error {Error}", result.Error);
+        }
+    }
+
+    [EffectMethod]
     public async Task HandleRequestFollowSharedUserAction(
         RequestFollowUserAction action,
         IDispatcher dispatcher

--- a/LiftLog.Ui/Store/Feed/FeedFeature.cs
+++ b/LiftLog.Ui/Store/Feed/FeedFeature.cs
@@ -18,6 +18,7 @@ public class FeedFeature : Feature<FeedState>
             FollowRequests: [],
             Followers: ImmutableDictionary<Guid, FeedUser>.Empty,
             ActiveTab: "mainfeed-panel",
-            UnpublishedSessionIds: []
+            UnpublishedSessionIds: [],
+            HasPublishedRsaPublicKey: false
         );
 }

--- a/LiftLog.Ui/Store/Feed/FeedState.cs
+++ b/LiftLog.Ui/Store/Feed/FeedState.cs
@@ -16,7 +16,8 @@ public record FeedState(
     ImmutableListValue<FollowRequest> FollowRequests,
     ImmutableDictionary<Guid, FeedUser> Followers,
     string ActiveTab,
-    ImmutableHashSet<Guid> UnpublishedSessionIds
+    ImmutableHashSet<Guid> UnpublishedSessionIds,
+    bool HasPublishedRsaPublicKey
 );
 
 public record FeedUser(


### PR DESCRIPTION
Public keys are generally considered safe to share and store.  Originally we tried to go with a zero knowledge of any encryption keys by having the share URL include the RSA public key as part of the query params.  This allowed LiftLog to not store any keys on the server, even if they were used just to send inbox messages (Read: follow requests, and negotiating AES encryption) to users.

This was flawed for a couple reasons:
1. Liftlog still ran the CDNs, so a share url could very easily end up leaking a user's public key to LiftLog anyway
2. It made the share urls just unweildy and massive.  Users would be scared to click or share such a URL.

This PR amends the server to allow for storing RSA public keys against a user, and they will be returned when fetching that user.  With this pattern, a share_url can omit the public key, and just fetch the user via their ID to get the public key.