### PR TITLE
Add a lookup field to users for shorter share urls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
   "azureFunctions.projectRuntime": "~4",
   "debug.internalConsoleOptions": "neverOpen",
   "azureFunctions.preDeployTask": "publish (functions)",
-  "cSpell.words": ["Fluxor"]
+  "cSpell.words": ["Fluxor", "Sqids"]
 }

--- a/Docs/FeedProcess.md
+++ b/Docs/FeedProcess.md
@@ -43,7 +43,7 @@ Using this identity, the client can create a `SHARE_URL`. This url consists of 2
 An example share url could look like this (note this is non functional):
 
 ```
-https://app.liftlog.online/feed/share?id=95e80409-dd6e-4cdb-b382-fb85b154350f&name=Liam
+https://app.liftlog.online/feed/share?id=aDf00f&name=Liam
 ```
 
 The structure of the url being:

--- a/LiftLog.Api/Controllers/UserController.cs
+++ b/LiftLog.Api/Controllers/UserController.cs
@@ -63,7 +63,7 @@ public class UserController(
         else
         {
             var userNumber = idEncodingService.DecodeId(idOrLookup);
-            user = await db.Users.FirstOrDefaultAsync(x => x.UserNumber == userNumber);
+            user = await db.Users.FirstOrDefaultAsync(x => x.UserLookup == userNumber);
         }
         if (user == null)
         {
@@ -75,7 +75,7 @@ public class UserController(
         return Ok(
             new GetUserResponse(
                 Id: user.Id,
-                Lookup: idEncodingService.EncodeId(user.UserNumber),
+                Lookup: idEncodingService.EncodeId(user.UserLookup),
                 EncryptedCurrentPlan: user.EncryptedCurrentPlan,
                 EncryptedProfilePicture: user.EncryptedProfilePicture,
                 EncryptedName: user.EncryptedName,

--- a/LiftLog.Api/Controllers/UserController.cs
+++ b/LiftLog.Api/Controllers/UserController.cs
@@ -48,7 +48,12 @@ public class UserController(
 
         await db.Users.AddAsync(user);
         await db.SaveChangesAsync();
-        return Ok(new CreateUserResponse(password));
+        return Ok(
+            new CreateUserResponse(
+                Lookup: idEncodingService.EncodeId(user.UserLookup),
+                Password: password
+            )
+        );
     }
 
     [Route("[controller]/{id}")]

--- a/LiftLog.Api/Controllers/UserController.cs
+++ b/LiftLog.Api/Controllers/UserController.cs
@@ -56,7 +56,7 @@ public class UserController(
         );
     }
 
-    [Route("[controller]/{id}")]
+    [Route("[controller]/{idOrLookup}")]
     [HttpGet]
     public async Task<IActionResult> GetUser(string idOrLookup)
     {

--- a/LiftLog.Api/Controllers/UsersController.cs
+++ b/LiftLog.Api/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using LiftLog.Api.Db;
+using LiftLog.Api.Service;
 using LiftLog.Lib.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -7,7 +8,8 @@ using Microsoft.EntityFrameworkCore;
 namespace LiftLog.Api.Controllers;
 
 [ApiController]
-public class UsersController(UserDataContext db) : ControllerBase
+public class UsersController(UserDataContext db, IdEncodingService idEncodingService)
+    : ControllerBase
 {
     [HttpPost]
     [Route("[controller]")]
@@ -34,6 +36,8 @@ public class UsersController(UserDataContext db) : ControllerBase
                 users.ToDictionary(
                     x => x.Id,
                     x => new GetUserResponse(
+                        Id: x.Id,
+                        Lookup: idEncodingService.EncodeId(x.UserLookup),
                         EncryptedCurrentPlan: x.EncryptedCurrentPlan,
                         EncryptedProfilePicture: x.EncryptedProfilePicture,
                         EncryptedName: x.EncryptedName,

--- a/LiftLog.Api/Db/UserDataContext.cs
+++ b/LiftLog.Api/Db/UserDataContext.cs
@@ -15,6 +15,13 @@ public class UserDataContext(DbContextOptions<UserDataContext> options) : DbCont
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.HasSequence<int>("user_number_sequence");
+
+        modelBuilder
+            .Entity<User>()
+            .Property(x => x.UserNumber)
+            .HasDefaultValueSql("nextval('user_number_sequence')");
+
         modelBuilder
             .Entity<User>()
             .HasMany<UserEvent>()

--- a/LiftLog.Api/Db/UserDataContext.cs
+++ b/LiftLog.Api/Db/UserDataContext.cs
@@ -15,12 +15,12 @@ public class UserDataContext(DbContextOptions<UserDataContext> options) : DbCont
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.HasSequence<int>("user_number_sequence");
+        modelBuilder.HasSequence<int>("user_lookup_sequence");
 
         modelBuilder
             .Entity<User>()
-            .Property(x => x.UserNumber)
-            .HasDefaultValueSql("nextval('user_number_sequence')");
+            .Property(x => x.UserLookup)
+            .HasDefaultValueSql("nextval('user_lookup_sequence')");
 
         modelBuilder
             .Entity<User>()

--- a/LiftLog.Api/LiftLog.Api.csproj
+++ b/LiftLog.Api/LiftLog.Api.csproj
@@ -10,20 +10,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\LiftLog.Lib\LiftLog.Lib.csproj"/>
+        <ProjectReference Include="..\LiftLog.Lib\LiftLog.Lib.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="EFCore.NamingConventions" Version="8.0.3"/>
-        <PackageReference Include="FluentValidation" Version="11.9.0"/>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0"/>
+        <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+        <PackageReference Include="FluentValidation" Version="11.9.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2"/>
-        <PackageReference Include="OpenAI-DotNet" Version="7.7.6"/>
-        <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.67.0.3373"/>
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
+        <PackageReference Include="OpenAI-DotNet" Version="7.7.6" />
+        <PackageReference Include="Google.Apis.AndroidPublisher.v3" Version="1.67.0.3373" />
+        <PackageReference Include="Sqids" Version="3.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/LiftLog.Api/Migrations/UserData/20240407111718_AddUserIndex.Designer.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407111718_AddUserIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LiftLog.Api.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LiftLog.Api.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    partial class UserDataContextModelSnapshot : ModelSnapshot
+    [Migration("20240407111718_AddUserIndex")]
+    partial class AddUserIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LiftLog.Api/Migrations/UserData/20240407111718_AddUserIndex.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407111718_AddUserIndex.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LiftLog.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateSequence<int>(
+                name: "user_number_sequence");
+
+            migrationBuilder.AddColumn<int>(
+                name: "user_number",
+                table: "users",
+                type: "integer",
+                nullable: false,
+                defaultValueSql: "nextval('user_number_sequence')");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_users_user_number",
+                table: "users",
+                column: "user_number",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_users_user_number",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "user_number",
+                table: "users");
+
+            migrationBuilder.DropSequence(
+                name: "user_number_sequence");
+        }
+    }
+}

--- a/LiftLog.Api/Migrations/UserData/20240407113536_AddUserLookup.Designer.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407113536_AddUserLookup.Designer.cs
@@ -12,8 +12,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LiftLog.Api.Migrations
 {
     [DbContext(typeof(UserDataContext))]
-    [Migration("20240407111718_AddUserIndex")]
-    partial class AddUserIndex
+    [Migration("20240407113536_AddUserLookup")]
+    partial class AddUserLookup
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -25,7 +25,7 @@ namespace LiftLog.Api.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.HasSequence<int>("user_number_sequence");
+            modelBuilder.HasSequence<int>("user_lookup_sequence");
 
             modelBuilder.Entity("LiftLog.Api.Models.User", b =>
                 {
@@ -69,18 +69,18 @@ namespace LiftLog.Api.Migrations
                         .HasColumnType("bytea")
                         .HasColumnName("salt");
 
-                    b.Property<int>("UserNumber")
+                    b.Property<int>("UserLookup")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .HasColumnName("user_number")
-                        .HasDefaultValueSql("nextval('user_number_sequence')");
+                        .HasColumnName("user_lookup")
+                        .HasDefaultValueSql("nextval('user_lookup_sequence')");
 
                     b.HasKey("Id")
                         .HasName("pk_users");
 
-                    b.HasIndex("UserNumber")
+                    b.HasIndex("UserLookup")
                         .IsUnique()
-                        .HasDatabaseName("ix_users_user_number");
+                        .HasDatabaseName("ix_users_user_lookup");
 
                     b.ToTable("users", (string)null);
                 });

--- a/LiftLog.Api/Migrations/UserData/20240407113536_AddUserLookup.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407113536_AddUserLookup.cs
@@ -5,25 +5,25 @@
 namespace LiftLog.Api.Migrations
 {
     /// <inheritdoc />
-    public partial class AddUserIndex : Migration
+    public partial class AddUserLookup : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateSequence<int>(
-                name: "user_number_sequence");
+                name: "user_lookup_sequence");
 
             migrationBuilder.AddColumn<int>(
-                name: "user_number",
+                name: "user_lookup",
                 table: "users",
                 type: "integer",
                 nullable: false,
-                defaultValueSql: "nextval('user_number_sequence')");
+                defaultValueSql: "nextval('user_lookup_sequence')");
 
             migrationBuilder.CreateIndex(
-                name: "ix_users_user_number",
+                name: "ix_users_user_lookup",
                 table: "users",
-                column: "user_number",
+                column: "user_lookup",
                 unique: true);
         }
 
@@ -31,15 +31,15 @@ namespace LiftLog.Api.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropIndex(
-                name: "ix_users_user_number",
+                name: "ix_users_user_lookup",
                 table: "users");
 
             migrationBuilder.DropColumn(
-                name: "user_number",
+                name: "user_lookup",
                 table: "users");
 
             migrationBuilder.DropSequence(
-                name: "user_number_sequence");
+                name: "user_lookup_sequence");
         }
     }
 }

--- a/LiftLog.Api/Migrations/UserData/20240407113536_AddUserLookup.cs
+++ b/LiftLog.Api/Migrations/UserData/20240407113536_AddUserLookup.cs
@@ -10,36 +10,32 @@ namespace LiftLog.Api.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateSequence<int>(
-                name: "user_lookup_sequence");
+            migrationBuilder.CreateSequence<int>(name: "user_lookup_sequence");
 
             migrationBuilder.AddColumn<int>(
                 name: "user_lookup",
                 table: "users",
                 type: "integer",
                 nullable: false,
-                defaultValueSql: "nextval('user_lookup_sequence')");
+                defaultValueSql: "nextval('user_lookup_sequence')"
+            );
 
             migrationBuilder.CreateIndex(
                 name: "ix_users_user_lookup",
                 table: "users",
                 column: "user_lookup",
-                unique: true);
+                unique: true
+            );
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "ix_users_user_lookup",
-                table: "users");
+            migrationBuilder.DropIndex(name: "ix_users_user_lookup", table: "users");
 
-            migrationBuilder.DropColumn(
-                name: "user_lookup",
-                table: "users");
+            migrationBuilder.DropColumn(name: "user_lookup", table: "users");
 
-            migrationBuilder.DropSequence(
-                name: "user_lookup_sequence");
+            migrationBuilder.DropSequence(name: "user_lookup_sequence");
         }
     }
 }

--- a/LiftLog.Api/Migrations/UserData/UserDataContextModelSnapshot.cs
+++ b/LiftLog.Api/Migrations/UserData/UserDataContextModelSnapshot.cs
@@ -22,7 +22,7 @@ namespace LiftLog.Api.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.HasSequence<int>("user_number_sequence");
+            modelBuilder.HasSequence<int>("user_lookup_sequence");
 
             modelBuilder.Entity("LiftLog.Api.Models.User", b =>
                 {
@@ -66,18 +66,18 @@ namespace LiftLog.Api.Migrations
                         .HasColumnType("bytea")
                         .HasColumnName("salt");
 
-                    b.Property<int>("UserNumber")
+                    b.Property<int>("UserLookup")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .HasColumnName("user_number")
-                        .HasDefaultValueSql("nextval('user_number_sequence')");
+                        .HasColumnName("user_lookup")
+                        .HasDefaultValueSql("nextval('user_lookup_sequence')");
 
                     b.HasKey("Id")
                         .HasName("pk_users");
 
-                    b.HasIndex("UserNumber")
+                    b.HasIndex("UserLookup")
                         .IsUnique()
-                        .HasDatabaseName("ix_users_user_number");
+                        .HasDatabaseName("ix_users_user_lookup");
 
                     b.ToTable("users", (string)null);
                 });

--- a/LiftLog.Api/Models/User.cs
+++ b/LiftLog.Api/Models/User.cs
@@ -1,8 +1,14 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
 namespace LiftLog.Api.Models;
 
+[Index(nameof(UserNumber), IsUnique = true)]
 public class User
 {
     public Guid Id { get; set; }
+
+    public int UserNumber { get; set; }
 
     // Hashed and salted password used for authentication
     public string HashedPassword { get; set; } = null!;

--- a/LiftLog.Api/Models/User.cs
+++ b/LiftLog.Api/Models/User.cs
@@ -3,12 +3,12 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LiftLog.Api.Models;
 
-[Index(nameof(UserNumber), IsUnique = true)]
+[Index(nameof(UserLookup), IsUnique = true)]
 public class User
 {
     public Guid Id { get; set; }
 
-    public int UserNumber { get; set; }
+    public int UserLookup { get; set; }
 
     // Hashed and salted password used for authentication
     public string HashedPassword { get; set; } = null!;

--- a/LiftLog.Api/Program.cs
+++ b/LiftLog.Api/Program.cs
@@ -44,6 +44,11 @@ var openAiApiKey =
     ?? throw new Exception("OpenAiApiKey configuration is not set.");
 builder.Services.RegisterGptAiWorkoutPlanner(openAiApiKey);
 
+builder.Services.Configure<IdEncodingServiceConfiguration>(
+    builder.Configuration.GetSection("IdEncodingService")
+);
+builder.Services.AddSingleton<IdEncodingService>();
+
 builder.Services.AddSingleton<PasswordService>();
 builder.Services.AddHttpClient<AppleAppStorePurchaseVerificationService>();
 builder.Services.AddScoped<RateLimitService>();

--- a/LiftLog.Api/Service/IdEncodingService.cs
+++ b/LiftLog.Api/Service/IdEncodingService.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Options;
+using Sqids;
+
+namespace LiftLog.Api.Service;
+
+public class IdEncodingServiceConfiguration
+{
+    public string Alphabet { get; set; } = null!;
+}
+
+public class IdEncodingService
+{
+    private readonly SqidsEncoder<int> encoder;
+
+    public IdEncodingService(IOptions<IdEncodingServiceConfiguration> options)
+    {
+        var alphabet = options.Value.Alphabet;
+        encoder = new SqidsEncoder<int>(new() { Alphabet = alphabet, MinLength = 6 });
+    }
+
+    public string EncodeId(int id)
+    {
+        return encoder.Encode(id);
+    }
+
+    public int DecodeId(string encodedId)
+    {
+        return encoder.Decode(encodedId)[0];
+    }
+}

--- a/LiftLog.Lib/Models/UserActions.cs
+++ b/LiftLog.Lib/Models/UserActions.cs
@@ -8,7 +8,7 @@ public record DeleteUserRequest(Guid Id, string Password);
 
 public record GetUsersResponse(Dictionary<Guid, GetUserResponse> Users);
 
-public record CreateUserResponse(string Password);
+public record CreateUserResponse(string Lookup, string Password);
 
 public record PutUserDataRequest(
     Guid Id,

--- a/LiftLog.Lib/Models/UserActions.cs
+++ b/LiftLog.Lib/Models/UserActions.cs
@@ -22,6 +22,8 @@ public record PutUserDataRequest(
 );
 
 public record GetUserResponse(
+    Guid Id,
+    string Lookup,
     byte[]? EncryptedCurrentPlan,
     byte[]? EncryptedProfilePicture,
     byte[]? EncryptedName,

--- a/LiftLog.Ui/Models/FeedStateDao.cs
+++ b/LiftLog.Ui/Models/FeedStateDao.cs
@@ -18,6 +18,7 @@ internal partial class FeedIdentityDaoV1
             ? null
             : new FeedIdentity(
                 Id: value.Id,
+                Lookup: value.Lookup,
                 AesKey: new Lib.Services.AesKey(value.AesKey.ToByteArray()),
                 RsaKeyPair: new Lib.Services.RsaKeyPair(
                     new Lib.Services.RsaPublicKey(value.PublicKey.ToByteArray()),
@@ -40,6 +41,7 @@ internal partial class FeedIdentityDaoV1
             : new FeedIdentityDaoV1
             {
                 Id = value.Id,
+                Lookup = value.Lookup,
                 AesKey = ByteString.CopyFrom(value.AesKey.Value),
                 PrivateKey = ByteString.CopyFrom(value.RsaKeyPair.PrivateKey.Pkcs8PrivateKeyBytes),
                 PublicKey = ByteString.CopyFrom(value.RsaKeyPair.PublicKey.SpkiPublicKeyBytes),
@@ -69,9 +71,8 @@ internal partial class FeedUserDaoV1
                     : new Lib.Services.AesKey(value.AesKey.ToByteArray()),
                 PublicKey: new Lib.Services.RsaPublicKey(value.PublicKey.ToByteArray()),
                 CurrentPlan: value
-                    .CurrentPlan?.Sessions.Select(sessionBlueprintDao =>
-                        sessionBlueprintDao.ToModel()
-                    )
+                    .CurrentPlan?.Sessions
+                    .Select(sessionBlueprintDao => sessionBlueprintDao.ToModel())
                     .ToImmutableList() ?? [],
                 ProfilePicture: value.ProfilePicture.IsEmpty
                     ? null

--- a/LiftLog.Ui/Models/FeedStateDao.cs
+++ b/LiftLog.Ui/Models/FeedStateDao.cs
@@ -71,8 +71,9 @@ internal partial class FeedUserDaoV1
                     : new Lib.Services.AesKey(value.AesKey.ToByteArray()),
                 PublicKey: new Lib.Services.RsaPublicKey(value.PublicKey.ToByteArray()),
                 CurrentPlan: value
-                    .CurrentPlan?.Sessions
-                    .Select(sessionBlueprintDao => sessionBlueprintDao.ToModel())
+                    .CurrentPlan?.Sessions.Select(sessionBlueprintDao =>
+                        sessionBlueprintDao.ToModel()
+                    )
                     .ToImmutableList() ?? [],
                 ProfilePicture: value.ProfilePicture.IsEmpty
                     ? null

--- a/LiftLog.Ui/Models/FeedStateDao.proto
+++ b/LiftLog.Ui/Models/FeedStateDao.proto
@@ -10,6 +10,7 @@ import "Models/UserEvent.proto";
 
 message FeedIdentityDaoV1 {
     LiftLog.Ui.Models.UuidDao id = 1;
+    google.protobuf.StringValue lookup = 12;
     bytes aes_key = 2;
     bytes public_key = 9;
     bytes private_key = 10;
@@ -23,6 +24,7 @@ message FeedIdentityDaoV1 {
 
 message FeedUserDaoV1 {
     LiftLog.Ui.Models.UuidDao id = 1;
+    google.protobuf.StringValue lookup = 9;
     bytes public_key = 8;
 
     optional google.protobuf.StringValue name = 2;

--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -248,7 +248,7 @@
 
     private void RedirectToFollowUserUrl(FeedUser user)
     {
-        NavigationManager.NavigateTo(FeedShareUrl.GetShareUrl(user.Id, user.PublicKey, user.Name));
+        NavigationManager.NavigateTo(FeedShareUrl.GetShareUrl(user.Id.ToString(), user.PublicKey, user.Name));
     }
 
     protected override void Dispose(bool disposing)

--- a/LiftLog.Ui/Pages/Feed/FeedSharePage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedSharePage.razor
@@ -115,6 +115,7 @@ else
 
         Dispatcher.Dispatch(new RequestFollowUserAction());
         Dispatcher.Dispatch(new SetSharedFeedUserAction(null));
+        Dispatcher.Dispatch(new NavigateAction("/feed"));
     }
 
     private void UpdateNickname(string value)

--- a/LiftLog.Ui/Pages/Feed/FeedSharePage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedSharePage.razor
@@ -51,10 +51,10 @@ else
 @code
 {
     [SupplyParameterFromQuery(Name = "pub")]
-    public string? PublicKey { get; set; } = "";
+    public string? PublicKey { get; set; }
 
     [SupplyParameterFromQuery(Name = "id")]
-    public Guid id { get; set; }
+    public string? id { get; set; }
 
     [SupplyParameterFromQuery(Name = "name")]
     public string? Name { get; set; }
@@ -71,17 +71,13 @@ else
         {
             Dispatcher.Dispatch(new NavigateAction("/feed/create-identity?from=" + Uri.EscapeDataString("/feed/share?pub=" + PublicKey + "&id=" + id + "&name=" + Name ?? "")));
         }
-        else if (id == Guid.Empty)
+        else if (string.IsNullOrWhiteSpace(id))
         {
             Dispatcher.Dispatch(new NavigateAction("/feed"));
         }
-        else if (string.IsNullOrEmpty(PublicKey))
-        {
-            Dispatcher.Dispatch(new FetchAndSetSharedFeedUserAction(id, Name));
-        }
         else
         {
-            Dispatcher.Dispatch(new SetSharedFeedUserAction(FeedUser.FromShared(id, new RsaPublicKey(PublicKey.FromUrlSafeHexString()), Name)));
+            Dispatcher.Dispatch(new FetchAndSetSharedFeedUserAction(id, Name, PublicKey?.FromUrlSafeHexString()));
         }
 
         await base.OnInitializedAsync();
@@ -96,7 +92,7 @@ else
             _alertWebAppDialog?.Open();
         }
 
-        if (FeedState.Value.FollowedUsers.ContainsKey(id))
+        if (Guid.TryParse(id, out var idGuid) && FeedState.Value.FollowedUsers.ContainsKey(idGuid))
         {
             Dispatcher.Dispatch(new NavigateAction("/feed"));
         }

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -108,6 +108,7 @@ else
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new PublishUnpublishedSessionsAction());
         Dispatcher.Dispatch(new PublishRsaPublicKeyIfNeededAction());
+        Dispatcher.Dispatch(new GetLookupIfNeededAction());
         await base.OnInitializedAsync();
     }
 

--- a/LiftLog.Ui/Services/FeedApiService.cs
+++ b/LiftLog.Ui/Services/FeedApiService.cs
@@ -45,12 +45,12 @@ public class FeedApiService(HttpClient httpClient
         });
     }
 
-    public Task<ApiResult<GetUserResponse>> GetUserAsync(Guid id)
+    public Task<ApiResult<GetUserResponse>> GetUserAsync(string idOrLookup)
     {
         return GetApiResultAsync(async () =>
         {
             var result = (
-                await httpClient.GetAsync($"{baseUrl}user/{id}")
+                await httpClient.GetAsync($"{baseUrl}user/{idOrLookup}")
             ).EnsureSuccessStatusCode();
             return (await result.Content.ReadFromJsonAsync<GetUserResponse>())!;
         });

--- a/LiftLog.Ui/Services/FeedIdentityService.cs
+++ b/LiftLog.Ui/Services/FeedIdentityService.cs
@@ -35,6 +35,7 @@ public class FeedIdentityService(
         var rsaKeyPair = await encryptionService.GenerateRsaKeysAsync();
         return await UpdateFeedIdentityAsync(
             id: id,
+            lookup: response.Data.Lookup,
             password: response.Data.Password,
             aesKey: aesKey,
             rsaKeyPair: rsaKeyPair,
@@ -49,6 +50,7 @@ public class FeedIdentityService(
 
     public async Task<ApiResult<FeedIdentity>> UpdateFeedIdentityAsync(
         Guid id,
+        string lookup,
         string password,
         AesKey aesKey,
         RsaKeyPair rsaKeyPair,
@@ -60,7 +62,6 @@ public class FeedIdentityService(
         ImmutableListValue<SessionBlueprint> currentPlan
     )
     {
-        var publicKey = rsaKeyPair.PublicKey;
         var privateKey = rsaKeyPair.PrivateKey;
         var (_, iv) = await encryptionService.SignRsa256PssAndEncryptAesCbcAsync(
             [1],
@@ -125,6 +126,7 @@ public class FeedIdentityService(
         return ApiResult.Success(
             new FeedIdentity(
                 Id: id,
+                Lookup: lookup,
                 AesKey: aesKey,
                 RsaKeyPair: rsaKeyPair,
                 Password: password,

--- a/LiftLog.Ui/Services/UrlSafeConverter.cs
+++ b/LiftLog.Ui/Services/UrlSafeConverter.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace LiftLog.Ui.Services;
 
 public static class UrlSafeConverter
@@ -7,8 +9,12 @@ public static class UrlSafeConverter
         return Convert.ToHexString(bytes).Replace("-", "");
     }
 
-    public static byte[] FromUrlSafeHexString(this string hexString)
+    public static byte[]? FromUrlSafeHexString(this string? hexString)
     {
+        if (string.IsNullOrEmpty(hexString))
+        {
+            return null;
+        }
         return Enumerable
             .Range(0, hexString.Length)
             .Where(x => x % 2 == 0)

--- a/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
+++ b/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
@@ -14,7 +14,7 @@
         if (FeedState.Value.Identity == null)
             return null;
         var identity = FeedState.Value.Identity;
-        return GetShareUrl(identity.Id, identity.RsaKeyPair.PublicKey, identity.Name);
+        return GetShareUrl(identity.Lookup, identity.RsaKeyPair.PublicKey, identity.Name);
     }
 
     private async Task HandleShareUrlClick()
@@ -25,7 +25,7 @@
         await StringSharer.ShareAsync(shareUrl);
     }
 
-    public static string GetShareUrl(Guid id, RsaPublicKey publicKey, string? name) =>
+    public static string GetShareUrl(string id, RsaPublicKey publicKey, string? name) =>
 #if DEBUG
         $"https://0.0.0.0:5001/feed/share?id={id}{(name is null ? "" : $"&name={Uri.EscapeDataString(name)}")}";
 #else

--- a/LiftLog.Ui/Store/Feed/FeedActions.cs
+++ b/LiftLog.Ui/Store/Feed/FeedActions.cs
@@ -37,7 +37,11 @@ public record PutFollowedUsersAction(FeedUser User);
 
 public record SetSharedFeedUserAction(FeedUser? User);
 
-public record FetchAndSetSharedFeedUserAction(string IdOrLookup, string? Name);
+public record FetchAndSetSharedFeedUserAction(
+    string IdOrLookup,
+    string? Name,
+    byte[]? RsaPublicKey
+);
 
 public record PublishIdentityIfEnabledAction();
 

--- a/LiftLog.Ui/Store/Feed/FeedActions.cs
+++ b/LiftLog.Ui/Store/Feed/FeedActions.cs
@@ -37,7 +37,7 @@ public record PutFollowedUsersAction(FeedUser User);
 
 public record SetSharedFeedUserAction(FeedUser? User);
 
-public record FetchAndSetSharedFeedUserAction(Guid Id, string? Name);
+public record FetchAndSetSharedFeedUserAction(string IdOrLookup, string? Name);
 
 public record PublishIdentityIfEnabledAction();
 

--- a/LiftLog.Ui/Store/Feed/FeedActions.cs
+++ b/LiftLog.Ui/Store/Feed/FeedActions.cs
@@ -55,6 +55,8 @@ public record SetHasPublishedRsaPublicKeyAction(bool HasPublishedRsaPublicKey);
 
 public record PublishRsaPublicKeyIfNeededAction();
 
+public record GetLookupIfNeededAction();
+
 public record ReplaceFeedFollowedUsersAction(ImmutableListValue<FeedUser> FollowedUsers);
 
 public record UnfollowFeedUserAction(FeedUser FeedUser);

--- a/LiftLog.Ui/Store/Feed/FeedEffects.Following.cs
+++ b/LiftLog.Ui/Store/Feed/FeedEffects.Following.cs
@@ -33,13 +33,13 @@ public partial class FeedEffects(
         IDispatcher dispatcher
     )
     {
-        var result = await feedApiService.GetUserAsync(action.Id);
+        var result = await feedApiService.GetUserAsync(action.IdOrLookup);
         if (result is { IsSuccess: true, Data.RsaPublicKey: not null })
         {
             dispatcher.Dispatch(
                 new SetSharedFeedUserAction(
                     FeedUser.FromShared(
-                        action.Id,
+                        result.Data.Id,
                         new RsaPublicKey(result.Data.RsaPublicKey),
                         action.Name
                     )

--- a/LiftLog.Ui/Store/Feed/FeedEffects.Following.cs
+++ b/LiftLog.Ui/Store/Feed/FeedEffects.Following.cs
@@ -34,13 +34,16 @@ public partial class FeedEffects(
     )
     {
         var result = await feedApiService.GetUserAsync(action.IdOrLookup);
-        if (result is { IsSuccess: true, Data.RsaPublicKey: not null })
+        if (
+            result is { IsSuccess: true }
+            && new[] { result.Data.RsaPublicKey, action.RsaPublicKey }.Any(x => x != null)
+        )
         {
             dispatcher.Dispatch(
                 new SetSharedFeedUserAction(
                     FeedUser.FromShared(
                         result.Data.Id,
-                        new RsaPublicKey(result.Data.RsaPublicKey),
+                        new RsaPublicKey(result.Data.RsaPublicKey ?? action.RsaPublicKey!),
                         action.Name
                     )
                 )

--- a/LiftLog.Ui/Store/Feed/FeedEffects.Identity.cs
+++ b/LiftLog.Ui/Store/Feed/FeedEffects.Identity.cs
@@ -104,6 +104,31 @@ public partial class FeedEffects
         });
 
     [EffectMethod]
+    public async Task HandleGetLookupIfNeededAction(
+        GetLookupIfNeededAction _,
+        IDispatcher dispatcher
+    )
+    {
+        var identity = state.Value.Identity;
+        if (identity is null || identity is not { Lookup: null or "" })
+        {
+            return;
+        }
+
+        var result = await feedApiService.GetUserAsync(identity.Id.ToString());
+        if (!result.IsSuccess)
+        {
+            // TODO handle properly
+            logger.LogError("Failed to get user with error {Error}", result.Error);
+            return;
+        }
+
+        dispatcher.Dispatch(
+            new PutFeedIdentityAction(identity with { Lookup = result.Data.Lookup })
+        );
+    }
+
+    [EffectMethod]
     public async Task HandlePublishIdentityIfEnabledAction(
         PublishIdentityIfEnabledAction _,
         IDispatcher dispatcher

--- a/LiftLog.Ui/Store/Feed/FeedEffects.Identity.cs
+++ b/LiftLog.Ui/Store/Feed/FeedEffects.Identity.cs
@@ -82,6 +82,7 @@ public partial class FeedEffects
         {
             var result = await feedIdentityService.UpdateFeedIdentityAsync(
                 identity.Id,
+                identity.Lookup,
                 identity.Password,
                 identity.AesKey,
                 identity.RsaKeyPair,
@@ -115,6 +116,7 @@ public partial class FeedEffects
 
         var result = await feedIdentityService.UpdateFeedIdentityAsync(
             state.Value.Identity.Id,
+            state.Value.Identity.Lookup,
             state.Value.Identity.Password,
             state.Value.Identity.AesKey,
             state.Value.Identity.RsaKeyPair,

--- a/LiftLog.Ui/Store/Feed/FeedState.cs
+++ b/LiftLog.Ui/Store/Feed/FeedState.cs
@@ -69,6 +69,7 @@ public record RemovedSessionFeedItem(
 
 public record FeedIdentity(
     Guid Id,
+    string Lookup,
     AesKey AesKey,
     RsaKeyPair RsaKeyPair,
     string Password,


### PR DESCRIPTION
The share URLs are a bit big, even after doing the work to remove the public key from them.  This PR addresses this by adding a new field to the User model, `Lookup`.  At the database level, this is an auto incrementing integer.  However over the API we use the SqIds encoded form of the int, which gives a nice six(ish) character string representing that number, without exposing an API which would allow someone to easily enumerate over the users.

A new share url looks like:
https://app.liftlog.online/feed/share?id=JuG2jd&name=Lime

Which is super nice, and less overwhelming to recipients of share urls.

Old share urls will continue to work with this change.