### PR TITLE
Add workaround for status bar covering buttons

### DIFF
--- a/LiftLog.App/Platforms/Android/MainActivity.cs
+++ b/LiftLog.App/Platforms/Android/MainActivity.cs
@@ -53,7 +53,6 @@ public class MainActivity : MauiAppCompatActivity
         : Java.Lang.Object,
             IOnApplyWindowInsetsListener
     {
-
         public WindowInsetsCompat OnApplyWindowInsets(
             Android.Views.View v,
             WindowInsetsCompat insets

--- a/LiftLog.App/Platforms/Android/MainActivity.cs
+++ b/LiftLog.App/Platforms/Android/MainActivity.cs
@@ -40,11 +40,11 @@ public class MainActivity : MauiAppCompatActivity
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
-        WindowCompat.SetDecorFitsSystemWindows(Window, false);
+        WindowCompat.SetDecorFitsSystemWindows(Window!, false);
         var insetsManager =
             IPlatformApplication.Current?.Services.GetRequiredService<InsetsManager>();
         ViewCompat.SetOnApplyWindowInsetsListener(
-            Window.DecorView,
+            Window!.DecorView,
             new WindowInsetsListener(insetsManager!, Resources!.DisplayMetrics!.Density)
         );
     }

--- a/LiftLog.Ui/Pages/Settings/SettingsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/SettingsPage.razor
@@ -58,6 +58,9 @@
             <div>
                 <Switch Label="Show feed" Value="@SettingsState.Value.ShowFeed" OnSwitched="SetShowFeed"/>
             </div>
+            <div>
+                <Switch Label="Status bar fix" Value="@SettingsState.Value.StatusBarFix" OnSwitched="SetStatusBarFix"/>
+            </div>
             <md-divider></md-divider>
             <div>
                 <Switch Label="Show tips" Value="@SettingsState.Value.ShowTips" OnSwitched="SetShowTips"/>
@@ -119,6 +122,9 @@
 
     private void SetShowTips(bool value)
         => Dispatcher.Dispatch(new SetShowTipsAction(value));
+
+    private void SetStatusBarFix(bool value)
+        => Dispatcher.Dispatch(new SetStatusBarFixAction(value));
 
     private void ResetTips()
         => Dispatcher.Dispatch(new SetTipToShowAction(1));

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -76,4 +76,14 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
     {
         return await preferenceStore.GetItemAsync("showFeed") is "True" or null;
     }
+
+    public async Task SetStatusBarFixAsync(bool statusBarFix)
+    {
+        await preferenceStore.SetItemAsync("statusBarFix", statusBarFix.ToString());
+    }
+
+    public async Task<bool> GetStatusBarFixAsync()
+    {
+        return await preferenceStore.GetItemAsync("statusBarFix") is "True";
+    }
 }

--- a/LiftLog.Ui/Shared/MainLayout.razor
+++ b/LiftLog.Ui/Shared/MainLayout.razor
@@ -20,7 +20,7 @@
             <section class="relative h-full content">
                 <div class="grid grid-cols-1 h-full grid-rows-[min-content_1fr_min-content]">
                     <div class="flex flex-col @_topNavColorClass transition-colors">
-                        <div style="height: @InsetsManager.SystemSafeInsetTop"></div>
+                        <div style="height: @TopInset"></div>
                         <div class="flex items-center gap-2 p-4 text-2xl">
                             @RenderBackButton()
                             <div class="h-[48px] flex items-center justify-center">
@@ -146,6 +146,8 @@
     }
 
     private string Justify => AppState.Value.BackNavigationUrl is null ? "justify-center" : "justify-start";
+
+    private string TopInset => SettingsState.Value.StatusBarFix ? "46px" : InsetsManager.SystemSafeInsetTop;
 
     private RenderFragment? RenderBackButton()
     {

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -33,3 +33,5 @@ public record SetShowTipsAction(bool ShowTips);
 public record SetTipToShowAction(int TipToShow);
 
 public record SetShowFeedAction(bool ShowFeed);
+
+public record SetStatusBarFixAction(bool StatusBarFix);

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -188,4 +188,10 @@ public class SettingsEffects(
     {
         await preferencesRepository.SetShowFeedAsync(action.ShowFeed);
     }
+
+    [EffectMethod]
+    public async Task HandleStatusBarFixAction(SetStatusBarFixAction action, IDispatcher dispatcher)
+    {
+        await preferencesRepository.SetStatusBarFixAsync(action.StatusBarFix);
+    }
 }

--- a/LiftLog.Ui/Store/Settings/SettingsFeature.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsFeature.cs
@@ -17,6 +17,7 @@ public class SettingsFeature : Feature<SettingsState>
             ShowBodyweight: true,
             ShowTips: true,
             TipToShow: 1,
-            ShowFeed: true
+            ShowFeed: true,
+            StatusBarFix: false
         );
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -72,9 +72,8 @@ public static class SettingsReducers
         };
 
     [ReducerMethod]
-    public static SettingsState SetStatusBarFix(SettingsState state, SetStatusBarFixAction action) =>
-        state with
-        {
-            StatusBarFix = action.StatusBarFix
-        };
+    public static SettingsState SetStatusBarFix(
+        SettingsState state,
+        SetStatusBarFixAction action
+    ) => state with { StatusBarFix = action.StatusBarFix };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -70,4 +70,11 @@ public static class SettingsReducers
         {
             ShowFeed = action.ShowFeed
         };
+
+    [ReducerMethod]
+    public static SettingsState SetStatusBarFix(SettingsState state, SetStatusBarFixAction action) =>
+        state with
+        {
+            StatusBarFix = action.StatusBarFix
+        };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -13,5 +13,6 @@ public record SettingsState(
     bool ShowBodyweight,
     bool ShowTips,
     int TipToShow,
-    bool ShowFeed
+    bool ShowFeed,
+    bool StatusBarFix
 );

--- a/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
@@ -24,6 +24,8 @@ public class SettingsStateInitMiddleware(
             dispatch.Dispatch(new SetTipToShowAction(tipToShow));
             var showFeed = await preferencesRepository.GetShowFeedAsync();
             dispatch.Dispatch(new SetShowFeedAction(showFeed));
+            var statusBarFix = await preferencesRepository.GetStatusBarFixAsync();
+            dispatch.Dispatch(new SetStatusBarFixAction(statusBarFix));
             dispatch.Dispatch(new SetSettingsIsHydratedAction());
         }
         catch (Exception e)


### PR DESCRIPTION
resolves: #156 

This PR adds a new toggle in the settings "Status Bar fix" which when enabled, forces the top of the app to be offset by a static amount (46 px, which seems close to the offset from a hole punchout on a pixel 4a).

Ideally this setting can be removed, but I cannot seem to reproduce the issue on an emulator or my real devices...

<img width="358" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/232043a9-a818-45b4-bc59-9210af392730">
