### PR TITLE
Allow backup, except secure storage

### DIFF
--- a/LiftLog.App/LiftLog.App.csproj
+++ b/LiftLog.App/LiftLog.App.csproj
@@ -54,6 +54,10 @@
         <UseInterpreter>True</UseInterpreter>
     </PropertyGroup>
 
+    <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
+        <AndroidResource Include="Platforms\Android\Resources\xml\auto_backup_rules.xml"/>
+    </ItemGroup>
+
     <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
 
         <!-- For debugging, use '?mode=developer' for debug to bypass apple's CDN cache -->


### PR DESCRIPTION
Secure storage backups in android end up creating issues when a user reinstalls from a backup.

Following recommendations found here: https://learn.microsoft.com/en-us/dotnet/maui/platform-integration/storage/secure-storage?view=net-maui-8.0&tabs=android We can disable backup for secure storage prefs, while keeping app data

resolves: #155 