### PR TITLE
Amend nav search behaviour to remember last settings page

### DIFF
--- a/LiftLog.Ui/Shared/Smart/NavBar.razor
+++ b/LiftLog.Ui/Shared/Smart/NavBar.razor
@@ -5,6 +5,7 @@
 @inject IState<AppState> AppState
 @inject IState<FeedState> FeedState
 @inject IState<SettingsState> SettingsState
+@inject IDispatcher Dispatcher
 @inject IThemeProvider ThemeProvider
 @inject InsetsManager InsetsManager
 
@@ -46,41 +47,50 @@
             && AppState.Value.ReopenCurrentSession
             && !IsRouteMatch("/session/?$"))
         {
-            NavigationManager.NavigateTo("/session");
+            Dispatcher.Dispatch(new NavigateAction("/session"));
             StateHasChanged();
             return;
         }
 
-        NavigationManager.NavigateTo("/");
+        Dispatcher.Dispatch(new NavigateAction("/"));
         StateHasChanged();
     }
 
     private void NavigateToSettings()
     {
-        NavigationManager.NavigateTo("/settings");
+        if (AppState.Value.LatestSettingsUrl != null && !IsRouteMatch("/settings.*"))
+        {
+            Dispatcher.Dispatch(new NavigateAction(AppState.Value.LatestSettingsUrl));
+            StateHasChanged();
+            return;
+        }
+        Dispatcher.Dispatch(new NavigateAction("/settings"));
         StateHasChanged();
     }
 
     private void NavigateToFeed()
     {
-        NavigationManager.NavigateTo("/feed");
+        Dispatcher.Dispatch(new NavigateAction("/feed"));
         StateHasChanged();
     }
 
     private void NavigateToHistory()
     {
-        NavigationManager.NavigateTo("/history");
+        Dispatcher.Dispatch(new NavigateAction("/history"));
         StateHasChanged();
     }
 
     private void NavigateToStats()
     {
-        NavigationManager.NavigateTo("/stats");
+        Dispatcher.Dispatch(new NavigateAction("/stats"));
         StateHasChanged();
     }
 
     private void LocationChanged(object? sender, LocationChangedEventArgs locationChangedEventArgs)
     {
+        if(locationChangedEventArgs.Location.Contains("settings")){
+            Dispatcher.Dispatch(new SetLatestSettingsUrlAction(locationChangedEventArgs.Location));
+        }
         InvokeAsync(StateHasChanged);
     }
 

--- a/LiftLog.Ui/Store/App/AppActions.cs
+++ b/LiftLog.Ui/Store/App/AppActions.cs
@@ -11,3 +11,5 @@ public record SetReopenCurrentSessionAction(bool ReopenCurrentSession);
 public record SetBackNavigationUrlAction(string? BackNavigationUrl);
 
 public record NavigateAction(string Path);
+
+public record SetLatestSettingsUrlAction(string? LatestSettingsUrl);

--- a/LiftLog.Ui/Store/App/AppFeature.cs
+++ b/LiftLog.Ui/Store/App/AppFeature.cs
@@ -14,6 +14,7 @@ public class AppFeature : Feature<AppState>
             Title: "LiftLog",
             ProState: new ProState(ProToken: null),
             ReopenCurrentSession: true,
-            BackNavigationUrl: null
+            BackNavigationUrl: null,
+            LatestSettingsUrl: null
         );
 }

--- a/LiftLog.Ui/Store/App/AppReducers.cs
+++ b/LiftLog.Ui/Store/App/AppReducers.cs
@@ -29,4 +29,10 @@ public static class AppReducers
         AppState state,
         SetBackNavigationUrlAction action
     ) => state with { BackNavigationUrl = action.BackNavigationUrl };
+
+    [ReducerMethod]
+    public static AppState SetLatestSettingsUrl(
+        AppState state,
+        SetLatestSettingsUrlAction action
+    ) => state with { LatestSettingsUrl = action.LatestSettingsUrl };
 }

--- a/LiftLog.Ui/Store/App/AppState.cs
+++ b/LiftLog.Ui/Store/App/AppState.cs
@@ -8,7 +8,8 @@ public record AppState(
     string Title,
     ProState ProState,
     bool ReopenCurrentSession,
-    string? BackNavigationUrl
+    string? BackNavigationUrl,
+    string? LatestSettingsUrl
 );
 
 public record ProState(string? ProToken)


### PR DESCRIPTION
This means that when a user navigates away from a page which is within the settings tree, if they navigate to the settings with nav, it will take them right back to that page, rather than the root of settings.

Clicking settings again will bring them to the root

https://github.com/LiamMorrow/LiftLog/assets/13741016/0ce5f94a-465a-43f9-830e-75507f7d54c1

