### PR TITLE
Fix issue where android keyboard covers input

### DIFF
--- a/LiftLog.App/Platforms/Android/WebViewSoftInputPatch.cs
+++ b/LiftLog.App/Platforms/Android/WebViewSoftInputPatch.cs
@@ -1,0 +1,86 @@
+using System.Runtime.Versioning;
+using Android.Content.Res;
+using Android.Views;
+using Android.Widget;
+using static Android.Resource;
+using Activity = Android.App.Activity;
+using Rect = Android.Graphics.Rect;
+using View = Android.Views.View;
+
+namespace LiftLog.App;
+
+[SupportedOSPlatform("Android")]
+public static class WebViewSoftInputPatch
+{
+    static Activity Activity =>
+        Microsoft.Maui.ApplicationModel.Platform.CurrentActivity
+        ?? throw new InvalidOperationException("Android Activity can't be null.");
+    static View MChildOfContent;
+    static FrameLayout.LayoutParams FrameLayoutParams;
+    static int UsableHeightPrevious = 0;
+
+    public static void Initialize()
+    {
+        FrameLayout content = (FrameLayout)Activity.FindViewById(Id.Content);
+        MChildOfContent = content.GetChildAt(0);
+        MChildOfContent.ViewTreeObserver.GlobalLayout += (s, o) => PossiblyResizeChildOfContent();
+        FrameLayoutParams = (FrameLayout.LayoutParams)MChildOfContent?.LayoutParameters;
+    }
+
+    static void PossiblyResizeChildOfContent()
+    {
+        int usableHeightNow = ComputeUsableHeight();
+        if (usableHeightNow != UsableHeightPrevious)
+        {
+            int usableHeightSansKeyboard = MChildOfContent.RootView.Height;
+            int heightDifference = usableHeightSansKeyboard - usableHeightNow;
+            if (heightDifference < 0)
+            {
+                usableHeightSansKeyboard = MChildOfContent.RootView.Width;
+                heightDifference = usableHeightSansKeyboard - usableHeightNow;
+            }
+
+            if (heightDifference > usableHeightSansKeyboard / 4)
+            {
+                FrameLayoutParams.Height = usableHeightSansKeyboard - heightDifference;
+            }
+            else
+            {
+                FrameLayoutParams.Height = usableHeightNow;
+            }
+        }
+
+        MChildOfContent.RequestLayout();
+        UsableHeightPrevious = usableHeightNow;
+    }
+
+    static int ComputeUsableHeight()
+    {
+        Rect rect = new Rect();
+        MChildOfContent.GetWindowVisibleDisplayFrame(rect);
+        return rect.Bottom + GetNavBarHeight();
+    }
+
+    public static int GetNavBarHeight()
+    {
+        int result = 0;
+        Resources resources = Activity.Resources;
+        int resourceId = resources.GetIdentifier("navigation_bar_height", "dimen", "android");
+        if (resourceId > 0)
+        {
+            result = resources.GetDimensionPixelSize(resourceId);
+        }
+        return result;
+    }
+
+    public static int GetStatusBarHeight()
+    {
+        int result = 0;
+        int resourceId = Activity.Resources.GetIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0)
+        {
+            result = Activity.Resources.GetDimensionPixelSize(resourceId);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
The android keyboard would cover inputs when it shows up.  This PR uses a modified fix from https://github.com/dotnet/maui/issues/14197#issuecomment-1535561632
to ensure that the viewport shrinks when the keyboard is shown.

It also amends the initial safe insets to take into account the status bar and navigation bar.  This might fix https://github.com/LiamMorrow/LiftLog/issues/156

Before:

https://github.com/LiamMorrow/LiftLog/assets/13741016/637ea2e5-61a6-4729-9244-bf1e2f5da42e

After:

https://github.com/LiamMorrow/LiftLog/assets/13741016/c7c0a358-0a2d-4da4-b2a4-615aaf465702



