### PR TITLE
Fix issue dismissing keyboard resetting value

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/EditableIncrementer.razor
+++ b/LiftLog.Ui/Shared/Presentation/EditableIncrementer.razor
@@ -11,7 +11,6 @@
 
 @code
 {
-
     [Parameter] [EditorRequired] public T Value { get; set; } = default!;
 
     [Parameter] [EditorRequired] public T Increment { get; set; } = default!;
@@ -27,7 +26,7 @@
 
     private void OnChanged(string? value)
     {
-        if (value != null && T.TryParse(value, System.Globalization.NumberStyles.Any,
+        if (value != null && T.TryParse(value, System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.CurrentCulture, out var result))
         {
             OnChange(result);

--- a/LiftLog.Ui/Shared/Presentation/TextField.razor
+++ b/LiftLog.Ui/Shared/Presentation/TextField.razor
@@ -3,12 +3,12 @@
 @switch (TextFieldType)
 {
     case TextFieldType.Outline:
-        <md-outlined-text-field @ref="_textField" @attributes="AdditionalAttributes" value=@Value @onchange=@((e) => OnChange?.Invoke((string)e.Value!)) @onfocusin=SelectOnFocus @onclick=OnClick>
+        <md-outlined-text-field @ref="_textField" @attributes="AdditionalAttributes" value=@Value @oninput=@((e) => OnChange?.Invoke((string?)e.Value!)) @onfocusin=SelectOnFocus @onclick=OnClick @onblur=@(_=>SetValueOnElement())>
             @ChildContent
         </md-outlined-text-field>
         break;
     case TextFieldType.Filled:
-        <md-filled-text-field @ref="_textField" @attributes="AdditionalAttributes" value=@Value @onchange=@((e) => OnChange?.Invoke((string)e.Value!)) @onfocusin=SelectOnFocus @onclick=OnClick>
+        <md-filled-text-field @ref="_textField" @attributes="AdditionalAttributes" value=@Value @oninput=@((e) => OnChange?.Invoke((string?)e.Value!)) @onfocusin=SelectOnFocus @onclick=OnClick @onblur=@(_=>SetValueOnElement())>
             @ChildContent
         </md-filled-text-field>
         break;
@@ -33,13 +33,18 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        await JSRuntime.InvokeVoidAsync("AppUtils.setValue", _textField, Value);
+        await JSRuntime.InvokeVoidAsync("AppUtils.setValueIfNotFocused", _textField, Value);
         await base.OnParametersSetAsync();
     }
 
     private async Task SelectOnFocus(FocusEventArgs args)
     {
         await JSRuntime.InvokeVoidAsync("AppUtils.selectAllText", _textField);
+    }
+
+    private async Task SetValueOnElement()
+    {
+        await JSRuntime.InvokeVoidAsync("AppUtils.setValue", _textField, Value);
     }
 
 }

--- a/LiftLog.Ui/wwwroot/app-utils.js
+++ b/LiftLog.Ui/wwwroot/app-utils.js
@@ -58,6 +58,11 @@ AppUtils.setValue = function (element, value) {
         element.value = value;
 }
 
+AppUtils.setValueIfNotFocused = function (element, value) {
+    if (element && document.activeElement !== element)
+        element.value = value;
+}
+
 AppUtils.getValue = function (element) {
     return element.value;
 }


### PR DESCRIPTION
On android, when the keyboard was dismissed, it would reset the value of the textfield

This commit changes the behaviour of the textfields to emit their values on input rather than onchange, which ensures the state is always up to date.

This was an issue before because on inputs which used decimals, it would strip the decimal point during the state loop, meaning the user couldn't input them.  I fixed this by only updating the internal input's value from the props when it doesn't have focus

Before:

https://github.com/LiamMorrow/LiftLog/assets/13741016/db9587b2-a727-4037-9782-096780530ac6

After:

https://github.com/LiamMorrow/LiftLog/assets/13741016/8fd9dfae-26ad-4ef1-aba0-523def9ef79c

