### PR TITLE
Implement sharing plans

### DIFF
--- a/LiftLog.Api/Controllers/SharedItemController.cs
+++ b/LiftLog.Api/Controllers/SharedItemController.cs
@@ -4,6 +4,7 @@ using LiftLog.Api.Db;
 using LiftLog.Api.Models;
 using LiftLog.Api.Service;
 using LiftLog.Lib.Models;
+using LiftLog.Lib.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -42,8 +43,8 @@ public class SharedItemController(
         var sharedItem = new SharedItem
         {
             UserId = request.UserId,
-            EncryptedPayload = request.EncryptedPayload,
-            EncryptionIV = request.EncryptionIV,
+            EncryptedPayload = request.EncryptedPayload.EncryptedPayload,
+            EncryptionIV = request.EncryptedPayload.IV.Value,
             Expiry = request.Expiry,
         };
 
@@ -71,8 +72,10 @@ public class SharedItemController(
         return Ok(
             new GetSharedItemResponse(
                 RsaPublicKey: new Lib.Services.RsaPublicKey(sharedItem.User.RsaPublicKey),
-                EncryptedPayload: sharedItem.EncryptedPayload,
-                EncryptionIV: sharedItem.EncryptionIV
+                EncryptedPayload: new(
+                    sharedItem.EncryptedPayload,
+                    new AesIV(sharedItem.EncryptionIV)
+                )
             )
         );
     }

--- a/LiftLog.Api/Validators/SharedItemRequestValidators.cs
+++ b/LiftLog.Api/Validators/SharedItemRequestValidators.cs
@@ -12,10 +12,10 @@ public class CreateSharedItemRequestValidator : AbstractValidator<CreateSharedIt
     {
         RuleFor(x => x.UserId).NotEmpty();
         RuleFor(x => x.Password).NotEmpty().MaximumLength(40);
-        RuleFor(x => x.EncryptedPayload).NotEmpty();
-        RuleFor(x => x.EncryptedPayload.Length).InclusiveBetween(0, 5 * KB);
-        RuleFor(x => x.EncryptionIV).NotEmpty();
-        RuleFor(x => x.EncryptionIV.Length).Equal(16);
+        RuleFor(x => x.EncryptedPayload).NotNull();
+        RuleFor(x => x.EncryptedPayload.EncryptedPayload.Length).InclusiveBetween(0, 5 * KB);
+        RuleFor(x => x.EncryptedPayload.IV).NotEmpty();
+        RuleFor(x => x.EncryptedPayload.IV.Value.Length).Equal(16);
         RuleFor(x => x.Expiry).NotEmpty();
     }
 }

--- a/LiftLog.Lib/Models/ShareActions.cs
+++ b/LiftLog.Lib/Models/ShareActions.cs
@@ -5,8 +5,7 @@ namespace LiftLog.Lib.Models;
 public record CreateSharedItemRequest(
     Guid UserId,
     string Password,
-    byte[] EncryptedPayload,
-    byte[] EncryptionIV,
+    AesEncryptedAndRsaSignedData EncryptedPayload,
     DateTimeOffset Expiry
 );
 
@@ -14,6 +13,5 @@ public record CreateSharedItemResponse(string Id);
 
 public record GetSharedItemResponse(
     RsaPublicKey RsaPublicKey,
-    byte[] EncryptedPayload,
-    byte[] EncryptionIV
+    AesEncryptedAndRsaSignedData EncryptedPayload
 );

--- a/LiftLog.Ui/LiftLog.Ui.csproj
+++ b/LiftLog.Ui/LiftLog.Ui.csproj
@@ -64,6 +64,7 @@
         <Protobuf Include="Models\ExportedDataDao\ExportedDataDaoV2.proto" GrpcServices="None" AdditionalProtocArguments="--csharp_opt=internal_access=true" />
         <Protobuf Include="Models\CurrentSessionStateDao\CurrentSessionStateDaoV2.proto" GrpcServices="None" AdditionalProtocArguments="--csharp_opt=internal_access=true" />
         <Protobuf Include="Models\FeedStateDao.proto" GrpcServices="None" AdditionalProtocArguments="--csharp_opt=internal_access=true" />
+        <Protobuf Include="Models\SharedItem.proto" GrpcServices="None" AdditionalProtocArguments="--csharp_opt=internal_access=true" />
         <Protobuf Include="Models\ProgramBlueprintDao\ProgramBlueprintDaoV1.proto" GrpcServices="None" AdditionalProtocArguments="--csharp_opt=internal_access=true" />
     </ItemGroup>
 </Project>

--- a/LiftLog.Ui/Models/FeedStateDao.cs
+++ b/LiftLog.Ui/Models/FeedStateDao.cs
@@ -6,6 +6,7 @@ using LiftLog.Lib;
 using LiftLog.Lib.Models;
 using LiftLog.Ui.Models.SessionBlueprintDao;
 using LiftLog.Ui.Models.SessionHistoryDao;
+using LiftLog.Ui.Store;
 using LiftLog.Ui.Store.Feed;
 
 namespace LiftLog.Ui.Models;
@@ -161,7 +162,7 @@ internal partial class FeedStateDaoV1
                 UnpublishedSessionIds: value
                     .UnpublishedSessionIds.Select(x => (Guid)x)
                     .ToImmutableHashSet(),
-                HasPublishedRsaPublicKey: value.PublishedRsaKey
+                SharedItem: RemoteData.Loading()
             );
 
     [return: NotNullIfNotNull(nameof(value))]
@@ -176,7 +177,6 @@ internal partial class FeedStateDaoV1
                 FollowRequests = { value.FollowRequests.Select(x => (InboxMessageDao)x) },
                 Followers = { value.Followers.Values.Select(x => (FeedUserDaoV1)x) },
                 UnpublishedSessionIds = { value.UnpublishedSessionIds.Select(x => (UuidDao)x) },
-                PublishedRsaKey = value.HasPublishedRsaPublicKey
             };
 }
 

--- a/LiftLog.Ui/Models/FeedStateDao.proto
+++ b/LiftLog.Ui/Models/FeedStateDao.proto
@@ -58,5 +58,5 @@ message FeedStateDaoV1 {
     repeated LiftLog.Ui.Models.InboxMessageDao follow_requests = 4;
     repeated LiftLog.Ui.Models.FeedUserDaoV1 followers = 5;
     repeated LiftLog.Ui.Models.UuidDao unpublished_session_ids = 6;
-    bool published_rsa_key = 7;
+    reserved 7; // published rsa key
 }

--- a/LiftLog.Ui/Models/SharedItem.cs
+++ b/LiftLog.Ui/Models/SharedItem.cs
@@ -26,7 +26,10 @@ internal partial class SharedItemPayload
     {
         return this switch
         {
-            { SharedProgramBlueprint.ProgramBlueprint: { } programBlueprint }
+            {
+                PayloadCase: PayloadOneofCase.SharedProgramBlueprint,
+                SharedProgramBlueprint.ProgramBlueprint: { } programBlueprint
+            }
                 => new SharedProgramBlueprint(programBlueprint.ToModel()),
             _ => null
         };

--- a/LiftLog.Ui/Models/SharedItem.cs
+++ b/LiftLog.Ui/Models/SharedItem.cs
@@ -1,0 +1,34 @@
+using LiftLog.Ui.Store.Feed;
+
+namespace LiftLog.Ui.Models;
+
+internal partial class SharedItemPayload
+{
+    public static SharedItemPayload FromModel(SharedItem sharedItem)
+    {
+        return sharedItem switch
+        {
+            SharedProgramBlueprint sharedProgram
+                => new SharedItemPayload
+                {
+                    SharedProgramBlueprint = new SharedProgramBlueprintPayload
+                    {
+                        ProgramBlueprint = ProgramBlueprintDao.ProgramBlueprintDaoV1.FromModel(
+                            sharedProgram.ProgramBlueprint
+                        ),
+                    }
+                },
+            _ => throw new System.NotImplementedException()
+        };
+    }
+
+    public SharedItem? ToModel()
+    {
+        return this switch
+        {
+            { SharedProgramBlueprint.ProgramBlueprint: { } programBlueprint }
+                => new SharedProgramBlueprint(programBlueprint.ToModel()),
+            _ => null
+        };
+    }
+}

--- a/LiftLog.Ui/Models/SharedItem.proto
+++ b/LiftLog.Ui/Models/SharedItem.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package LiftLog.Ui.Models;
+
+import "Models/ProgramBlueprintDao/ProgramBlueprintDaoV1.proto";
+
+message SharedItemPayload {
+    // Note that messages shouldn't just be raw data, but should be a wrapper around the data
+    // so we can add additional fields in the future if needed
+    oneof payload {
+        SharedProgramBlueprintPayload shared_program_blueprint = 1;
+    }
+}
+
+message SharedProgramBlueprintPayload {
+    LiftLog.Ui.Models.ProgramBlueprintDao.ProgramBlueprintDaoV1 program_blueprint = 1;
+}

--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -270,7 +270,7 @@
 
     private void RedirectToFollowUserUrl(FeedUser user)
     {
-        NavigationManager.NavigateTo(FeedShareUrl.GetShareUrl(user.Id.ToString(), user.PublicKey, user.Name));
+        NavigationManager.NavigateTo(FeedShareUrl.GetShareUrl(user.Id.ToString(), user.Name));
     }
 
     private void SetPublishWorkouts(bool value)

--- a/LiftLog.Ui/Pages/Feed/FeedSharedItemPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedSharedItemPage.razor
@@ -1,0 +1,48 @@
+@page "/feed/shared-item/{id}"
+
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+@inject IState<FeedState> FeedState
+@inject IDispatcher Dispatcher
+
+@if(SharedItem is { IsLoading: true })
+{
+    <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
+        <div>
+            <md-circular-progress aria-label="Loading" indeterminate four-color></md-circular-progress>
+        </div>
+        <span>
+            <p>Loading...</p>
+        </span>
+    </div>
+}
+else if(SharedItem is { IsError: true })
+{
+    <p class="text-on-surface">@SharedItem.Error</p>
+}
+else if(SharedItem is { IsSuccess: true })
+{
+    <SharedItemComponent SharedItem="SharedItem.Data" />
+}
+
+
+@code {
+    [Parameter] public string Id { get; set; } = null!;
+
+    [SupplyParameterFromQuery(Name="k")] public string? Key { get; set; }
+
+    private RemoteData<SharedItem> SharedItem => FeedState.Value.SharedItem;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        if(Key.FromUrlSafeHexString() is {} key)
+        {
+            Dispatcher.Dispatch(new FetchSharedItemAction(Id, new AesKey(key)));
+        }
+        else
+        {
+            Dispatcher.Dispatch(new SetSharedItemAction(RemoteData.Errored("Could not load shared item. Bad key provided.")));
+        }
+    }
+}

--- a/LiftLog.Ui/Pages/Feed/FeedSharedItemPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedSharedItemPage.razor
@@ -5,26 +5,25 @@
 @inject IState<FeedState> FeedState
 @inject IDispatcher Dispatcher
 
-@if(SharedItem is { IsLoading: true })
+@switch(SharedItem)
 {
-    <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
-        <div>
-            <md-circular-progress aria-label="Loading" indeterminate four-color></md-circular-progress>
+    case { IsLoading: true }:
+        <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
+            <div>
+                <md-circular-progress aria-label="Loading" indeterminate four-color></md-circular-progress>
+            </div>
+            <span>
+                <p>Loading...</p>
+            </span>
         </div>
-        <span>
-            <p>Loading...</p>
-        </span>
-    </div>
+        break;
+    case { IsError: true }:
+        <p class="text-on-surface">@SharedItem.Error</p>
+        break;
+    case { IsSuccess: true }:
+        <SharedItemComponent SharedItem="SharedItem.Data" />
+        break;
 }
-else if(SharedItem is { IsError: true })
-{
-    <p class="text-on-surface">@SharedItem.Error</p>
-}
-else if(SharedItem is { IsSuccess: true })
-{
-    <SharedItemComponent SharedItem="SharedItem.Data" />
-}
-
 
 @code {
     [Parameter] public string Id { get; set; } = null!;

--- a/LiftLog.Ui/Pages/Settings/ProgramListPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ProgramListPage.razor
@@ -18,10 +18,12 @@
             @foreach (var (id, program) in orderedPrograms)
             {
                 <ProgramListItem
+                    @key="id"
                     ProgramBlueprint="@program"
                     OnClick=@(() => OpenEditProgram(id))
                     OnUse="@(() => SelectProgram(id))"
                     OnDuplicate="@(() => Dispatcher.Dispatch(new SavePlanAction(Guid.NewGuid(), program)))"
+                    OnShare="@(() => Dispatcher.Dispatch(new EncryptAndShareAction(new SharedProgramBlueprint(program))))"
                     OnRemove="()=>HandleRemove(id)"
                     IsActive="ProgramState.Value.ActivePlanId == id"
                     IsFocused="FocusPlanId == id"

--- a/LiftLog.Ui/Services/FeedApiService.cs
+++ b/LiftLog.Ui/Services/FeedApiService.cs
@@ -143,6 +143,19 @@ public class FeedApiService(HttpClient httpClient
         });
     }
 
+    public Task<ApiResult<CreateSharedItemResponse>> PostSharedItemAsync(
+        CreateSharedItemRequest request
+    )
+    {
+        return GetApiResultAsync(async () =>
+        {
+            var result = (
+                await httpClient.PostAsJsonAsync($"{baseUrl}shareditem", request)
+            ).EnsureSuccessStatusCode();
+            return (await result.Content.ReadFromJsonAsync<CreateSharedItemResponse>())!;
+        });
+    }
+
     private static async Task<ApiResult<T>> GetApiResultAsync<T>(Func<Task<T>> action)
     {
         try
@@ -174,10 +187,19 @@ public class FeedApiService(HttpClient httpClient
     private static async Task<ApiResult> GetApiResultAsync(Func<Task> action)
     {
         // Be explicit here with generic to avoid accidental recursion
-        return await GetApiResultAsync(async () =>
+        return await GetApiResultAsync<int>(async () =>
         {
             await action();
             return 1;
+        });
+    }
+
+    public Task<ApiResult<GetSharedItemResponse>> GetSharedItemAsync(string sharedItemId)
+    {
+        return GetApiResultAsync(async () =>
+        {
+            var response = await httpClient.GetAsync($"{baseUrl}shareditem/{sharedItemId}");
+            return (await response.Content.ReadFromJsonAsync<GetSharedItemResponse>())!;
         });
     }
 }

--- a/LiftLog.Ui/Shared/MainLayout.razor
+++ b/LiftLog.Ui/Shared/MainLayout.razor
@@ -31,7 +31,7 @@
                             </div>
                         </div>
                     </div>
-                    <div @ref="_contentElementRef" id="scrollingElement" class="pb-2 overflow-auto bg-surface" @onscroll="OnContentScroll" style="-webkit-overflow-scrolling: touch;">
+                    <div @ref="_contentElementRef" id="scrollingElement" class="pb-2 overflow-auto bg-surface scroll-smooth" @onscroll="OnContentScroll" style="-webkit-overflow-scrolling: touch;">
                         @if (StateIsHydrated)
                         {
                             @Body

--- a/LiftLog.Ui/Shared/Presentation/ProgramListItem.razor
+++ b/LiftLog.Ui/Shared/Presentation/ProgramListItem.razor
@@ -7,9 +7,10 @@
     <div slot="end" class="flex items-center">
         @RenderActiveBadge()
         <IconButton id="@_iconButtonId" Type="IconButtonType.Standard" Icon="more_horiz" OnClick=@(() => _menu?.Open())></IconButton>
-        <Menu  anchor="@_iconButtonId" @ref="_menu">
+        <Menu anchor="@_iconButtonId" @ref="_menu">
             <MenuItem Icon="delete" disabled="@IsActive" Label="Remove" OnClick="() => OnRemove.InvokeAsync()"/>
             <MenuItem Icon="content_copy" Label="Duplicate" OnClick="() => OnDuplicate.InvokeAsync()"/>
+            <MenuItem Icon="share" Label="Share" OnClick="() => OnShare.InvokeAsync()"/>
         </Menu>
     </div>
 </md-list-item>
@@ -36,12 +37,26 @@
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     [Parameter] public EventCallback OnUse { get; set; }
+
     [Parameter] public EventCallback OnRemove { get; set; }
+
     [Parameter] public EventCallback OnDuplicate { get; set; }
+
+    [Parameter] public EventCallback OnShare { get; set; }
 
     private string SupportingText => $"Edited: {ProgramBlueprint.LastEdited.ToShortDateString()}";
 
     private string FocusClass => IsFocused ? "bg-secondary-container text-on-secondary-container " : "";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        if (firstRender && IsFocused)
+        {
+            await Task.Delay(100);
+            await JSRuntime.InvokeVoidAsync("AppUtils.scrollIntoView", _listItem);
+        }
+    }
 
     private RenderFragment? RenderActiveBadge()
     {

--- a/LiftLog.Ui/Shared/Presentation/ProgramListItem.razor
+++ b/LiftLog.Ui/Shared/Presentation/ProgramListItem.razor
@@ -54,7 +54,7 @@
         if (firstRender && IsFocused)
         {
             await Task.Delay(100);
-            await JSRuntime.InvokeVoidAsync("AppUtils.scrollIntoView", _listItem);
+            await JSRuntime.InvokeVoidAsync("AppUtils.scrollIntoViewById", _iconButtonId);
         }
     }
 

--- a/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
+++ b/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
@@ -14,7 +14,7 @@
         if (FeedState.Value.Identity == null)
             return null;
         var identity = FeedState.Value.Identity;
-        return GetShareUrl(identity.Lookup, identity.RsaKeyPair.PublicKey, identity.Name);
+        return GetShareUrl(identity.Lookup, identity.Name);
     }
 
     private async Task HandleShareUrlClick()
@@ -25,7 +25,7 @@
         await StringSharer.ShareAsync(shareUrl);
     }
 
-    public static string GetShareUrl(string id, RsaPublicKey publicKey, string? name) =>
+    public static string GetShareUrl(string id, string? name) =>
 #if DEBUG
         $"https://0.0.0.0:5001/feed/share?id={id}{(name is null ? "" : $"&name={Uri.EscapeDataString(name)}")}";
 #else

--- a/LiftLog.Ui/Shared/Smart/SharedItemComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SharedItemComponent.razor
@@ -1,0 +1,9 @@
+@if(SharedItem is SharedProgramBlueprint sharedProgramBlueprint)
+{
+    <SharedProgramBlueprintComponent SharedProgramBlueprint="sharedProgramBlueprint" />
+}
+
+
+@code {
+    [Parameter][EditorRequired] public SharedItem SharedItem { get; set; } = null!;
+}

--- a/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
@@ -1,0 +1,45 @@
+@inject IDispatcher Dispatcher
+
+<div class="text-on-surface text-left">
+    <h2 class="text-xl font-bold text-primary mx-4">@ProgramBlueprint.Name</h2>
+    <p class=" mx-4">This plan has been shared with you.</p>
+    <CardList Items="ProgramBlueprint.Sessions">
+        <SplitCardControl>
+            <TitleContent>
+                <SessionSummaryTitle Session="context.GetEmptySession()" />
+            </TitleContent>
+            <MainContent>
+                <SessionSummary Session="context.GetEmptySession()" ShowSets="true" ShowWeight="false"/>
+            </MainContent>
+        </SplitCardControl>
+    </CardList>
+</div>
+
+@if(IsInActiveScreen)
+{
+    <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
+        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=OnImport >Import</AppButton>
+    </Microsoft.AspNetCore.Components.Sections.SectionContent>
+}
+@code {
+    [Parameter][EditorRequired] public SharedProgramBlueprint SharedProgramBlueprint { get; set; } = null!;
+
+    [CascadingParameter(Name = "IsInActiveScreen")]
+    public bool IsInActiveScreen { get; set; }
+
+    private ProgramBlueprint ProgramBlueprint => SharedProgramBlueprint.ProgramBlueprint;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        Dispatcher.Dispatch(new SetPageTitleAction("Shared Plan"));
+        Dispatcher.Dispatch(new SetBackNavigationUrlAction("/"));
+    }
+
+    private void OnImport()
+    {
+        var id = Guid.NewGuid();
+        Dispatcher.Dispatch(new SavePlanAction(id, ProgramBlueprint));
+        Dispatcher.Dispatch(new NavigateAction("/settings/program-list?focusPlanId=" + id));
+    }
+}

--- a/LiftLog.Ui/Store/Feed/FeedActions.cs
+++ b/LiftLog.Ui/Store/Feed/FeedActions.cs
@@ -1,5 +1,6 @@
 using LiftLog.Lib;
 using LiftLog.Lib.Models;
+using LiftLog.Lib.Services;
 
 namespace LiftLog.Ui.Store.Feed;
 
@@ -78,3 +79,9 @@ public record SetActiveTabAction(string TabId);
 public record AddUnpublishedSessionIdAction(Guid SessionId);
 
 public record RemoveUnpublishedSessionIdAction(Guid SessionId);
+
+public record EncryptAndShareAction(SharedItem SharedItem);
+
+public record SetSharedItemAction(RemoteData<SharedItem> SharedItem);
+
+public record FetchSharedItemAction(string Id, AesKey AesKey);

--- a/LiftLog.Ui/Store/Feed/FeedFeature.cs
+++ b/LiftLog.Ui/Store/Feed/FeedFeature.cs
@@ -19,6 +19,6 @@ public class FeedFeature : Feature<FeedState>
             Followers: ImmutableDictionary<Guid, FeedUser>.Empty,
             ActiveTab: "mainfeed-panel",
             UnpublishedSessionIds: [],
-            HasPublishedRsaPublicKey: false
+            SharedItem: RemoteData.Loading()
         );
 }

--- a/LiftLog.Ui/Store/Feed/FeedReducers.cs
+++ b/LiftLog.Ui/Store/Feed/FeedReducers.cs
@@ -134,4 +134,11 @@ public static class FeedReducers
         {
             UnpublishedSessionIds = state.UnpublishedSessionIds.Remove(action.SessionId)
         };
+
+    [ReducerMethod]
+    public static FeedState SetSharedItem(FeedState state, SetSharedItemAction action) =>
+        state with
+        {
+            SharedItem = action.SharedItem
+        };
 }

--- a/LiftLog.Ui/Store/Feed/FeedSharingEffects.cs
+++ b/LiftLog.Ui/Store/Feed/FeedSharingEffects.cs
@@ -1,0 +1,138 @@
+using System.Collections.Immutable;
+using System.Text;
+using Fluxor;
+using Google.Protobuf;
+using LiftLog.Lib.Models;
+using LiftLog.Lib.Services;
+using LiftLog.Ui.Models;
+using LiftLog.Ui.Models.SessionHistoryDao;
+using LiftLog.Ui.Services;
+using Microsoft.Extensions.Logging;
+using static LiftLog.Ui.Models.UserEventPayload;
+
+namespace LiftLog.Ui.Store.Feed;
+
+public class FeedSharingEffects(
+    IState<FeedState> feedState,
+    IEncryptionService encryptionService,
+    FeedApiService feedApiService,
+    IStringSharer stringSharer,
+    ILogger<FeedSharingEffects> logger
+)
+{
+    [EffectMethod]
+    public async Task HandleEncryptAndShareAction(
+        EncryptAndShareAction action,
+        IDispatcher dispatcher
+    )
+    {
+        var identity = feedState.Value.Identity;
+        if (identity is null)
+        {
+            logger.LogError("Failed to share feed item with error {Error}", "Identity not found");
+            return;
+        }
+
+        var aesKey = await encryptionService.GenerateAesKeyAsync();
+        var payload = SharedItemPayload.FromModel(action.SharedItem).ToByteArray();
+
+        var encrypted = await encryptionService.SignRsa256PssAndEncryptAesCbcAsync(
+            payload,
+            aesKey,
+            identity.RsaKeyPair.PrivateKey
+        );
+
+        var result = await feedApiService.PostSharedItemAsync(
+            new CreateSharedItemRequest(
+                identity.Id,
+                identity.Password,
+                encrypted,
+                DateTimeOffset.UtcNow + TimeSpan.FromDays(90)
+            )
+        );
+        if (!result.IsSuccess)
+        {
+            logger.LogError("Failed to share feed with error {Error}", result.Error);
+            return;
+        }
+
+        await stringSharer.ShareAsync(GetShareUrl(result.Data.Id, aesKey));
+    }
+
+    [EffectMethod]
+    public async Task HandleFetchSharedItemAction(
+        FetchSharedItemAction action,
+        IDispatcher dispatcher
+    )
+    {
+        dispatcher.Dispatch(new SetSharedItemAction(RemoteData.Loading()));
+        var result = await feedApiService.GetSharedItemAsync(action.Id);
+        if (!result.IsSuccess)
+        {
+            logger.LogError("Failed to fetch shared item with error {Error}", result.Error);
+            var errorMessage = result.Error.Type switch
+            {
+                ApiErrorType.NotFound => "Shared item not found",
+                ApiErrorType.Unauthorized => "Unauthorized to view shared item",
+                _ => "Error fetching shared item"
+            };
+            dispatcher.Dispatch(new SetSharedItemAction(RemoteData.Errored(errorMessage)));
+            return;
+        }
+
+        var decryptedPayload = await TryDecrypt(
+            result.Data.EncryptedPayload,
+            action.AesKey,
+            result.Data.RsaPublicKey
+        );
+        if (decryptedPayload is null)
+        {
+            dispatcher.Dispatch(
+                new SetSharedItemAction(RemoteData.Errored("Failed to decrypt shared item"))
+            );
+            return;
+        }
+        var sharedItemPayload = SharedItemPayload.Parser.ParseFrom(decryptedPayload);
+        var sharedItem = sharedItemPayload.ToModel();
+        if (sharedItem is null)
+        {
+            logger.LogError(
+                "Failed to parse shared item {PayloadCase}",
+                sharedItemPayload.PayloadCase
+            );
+            dispatcher.Dispatch(
+                new SetSharedItemAction(RemoteData.Errored("Failed to parse shared item"))
+            );
+            return;
+        }
+        dispatcher.Dispatch(new SetSharedItemAction(RemoteData.Success(sharedItem)));
+    }
+
+    private async Task<byte[]?> TryDecrypt(
+        AesEncryptedAndRsaSignedData encrypted,
+        AesKey aesKey,
+        RsaPublicKey rsaPublicKey
+    )
+    {
+        try
+        {
+            return await encryptionService.DecryptAesCbcAndVerifyRsa256PssAsync(
+                encrypted,
+                aesKey,
+                rsaPublicKey
+            );
+        }
+        catch (Exception e)
+        {
+            logger.LogError("Failed to decrypt shared item with error {Error}", e.Message);
+            return null;
+        }
+    }
+
+    private static string GetShareUrl(string sharedItemId, AesKey aesKey) =>
+#if DEBUG
+        $"https://0.0.0.0:5001/feed/shared-item/{sharedItemId}?k={aesKey.Value.ToUrlSafeHexString()}";
+#else
+        $"https://app.liftlog.online/feed/shared-item/{sharedItemId}?k={aesKey.Value.ToUrlSafeHexString()}";
+#endif
+}

--- a/LiftLog.Ui/Store/Feed/FeedState.cs
+++ b/LiftLog.Ui/Store/Feed/FeedState.cs
@@ -17,7 +17,7 @@ public record FeedState(
     ImmutableDictionary<Guid, FeedUser> Followers,
     string ActiveTab,
     ImmutableHashSet<Guid> UnpublishedSessionIds,
-    bool HasPublishedRsaPublicKey
+    RemoteData<SharedItem> SharedItem
 );
 
 public record FeedUser(
@@ -92,3 +92,7 @@ public record FollowResponse(
     AesKey? AesKey,
     string? FollowSecret
 );
+
+public abstract record SharedItem();
+
+public record SharedProgramBlueprint(ProgramBlueprint ProgramBlueprint) : SharedItem;

--- a/LiftLog.Ui/Store/RemoteData.cs
+++ b/LiftLog.Ui/Store/RemoteData.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace LiftLog.Ui.Store;
+
+public static class RemoteData
+{
+    public static RemoteLoading Loading() => new();
+
+    public static RemoteError Errored(string error) => new(error);
+
+    public static RemoteData<T> Success<T>(T data) => new RemoteSuccess<T>(data);
+}
+
+public abstract class RemoteData<T>
+{
+    public static implicit operator RemoteData<T>(RemoteLoading _) => new RemoteLoading<T>();
+
+    public static implicit operator RemoteData<T>(RemoteError err) => new RemoteError<T>(err.Error);
+
+    public abstract T? Data { get; }
+
+    public abstract string? Error { get; }
+
+    public abstract bool IsLoading { get; }
+
+    [MemberNotNullWhen(true, nameof(Error))]
+    public abstract bool IsError { get; }
+
+    [MemberNotNullWhen(true, nameof(Data))]
+    public abstract bool IsSuccess { get; }
+}
+
+public class RemoteSuccess<T>(T data) : RemoteData<T>
+{
+    public override T Data => data;
+    public override bool IsLoading => false;
+    public override bool IsError => false;
+    public override bool IsSuccess => true;
+
+    public override string? Error =>
+        throw new InvalidOperationException("Cannot access error on a successful RemoteData");
+}
+
+public readonly record struct RemoteError(string Error);
+
+public class RemoteError<T>(string error) : RemoteData<T>
+{
+    public override string Error => error;
+
+    public override T? Data =>
+        throw new InvalidOperationException("Cannot access data on an errored RemoteData");
+    public override bool IsLoading => false;
+    public override bool IsError => true;
+    public override bool IsSuccess => false;
+}
+
+public class RemoteLoading<T> : RemoteData<T>
+{
+    public override T? Data =>
+        throw new InvalidOperationException("Cannot access data on a loading RemoteData");
+
+    public override string? Error =>
+        throw new InvalidOperationException("Cannot access error on a loading RemoteData");
+
+    public override bool IsLoading => true;
+    public override bool IsError => false;
+    public override bool IsSuccess => false;
+}
+
+public readonly struct RemoteLoading { }

--- a/LiftLog.Ui/_Imports.razor
+++ b/LiftLog.Ui/_Imports.razor
@@ -18,6 +18,7 @@
 @using LiftLog.Ui.Models
 @using LiftLog.Ui.Services
 @using Fluxor
+@using LiftLog.Ui.Store
 @using LiftLog.Ui.Store.App
 @using LiftLog.Ui.Store.CurrentSession
 @using LiftLog.Ui.Store.Program

--- a/LiftLog.Ui/wwwroot/app-utils.js
+++ b/LiftLog.Ui/wwwroot/app-utils.js
@@ -136,13 +136,14 @@ AppUtils.onSliderChange = function (element) {
 
 /**
  *
- * @param {HTMLElement} element
+ * @param {string} id
  */
-AppUtils.scrollIntoView = function (element) {
-    element?.scrollIntoView({
-        block: 'center',
-        inline: 'center',
-    });
+AppUtils.scrollIntoViewById = function (id) {
+    const element = document.getElementById(id);
+    const scrollingElement = document.getElementById('scrollingElement');
+    // scroll to center
+    if (element && scrollingElement)
+        scrollingElement.scroll({ top: element.offsetTop - scrollingElement.clientHeight / 2, behavior: 'smooth' });
 }
 
 

--- a/LiftLog.Ui/wwwroot/app-utils.js
+++ b/LiftLog.Ui/wwwroot/app-utils.js
@@ -134,6 +134,17 @@ AppUtils.onSliderChange = function (element) {
     });
 }
 
+/**
+ *
+ * @param {HTMLElement} element
+ */
+AppUtils.scrollIntoView = function (element) {
+    element?.scrollIntoView({
+        block: 'center',
+        inline: 'center',
+    });
+}
+
 
 AppUtils.smoothScrollAndFocusLast = function (elementSelector) {
     const items = document.querySelectorAll(elementSelector);

--- a/LiftLog.Web/Properties/launchSettings.json
+++ b/LiftLog.Web/Properties/launchSettings.json
@@ -3,6 +3,7 @@
     "LiftLog.Web": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "https://0.0.0.0:5001/feed/shared-item/NsOZ7u?k=F632120748D66CA8B35D10DDD6222955",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/tests/LiftLog.Tests.Api/Integration/SharedItemIntegrationTests.cs
+++ b/tests/LiftLog.Tests.Api/Integration/SharedItemIntegrationTests.cs
@@ -29,8 +29,7 @@ public class SharedItemIntegrationTests(WebApplicationFactory<Program> factory)
         var sharedItemCreateRequest = new CreateSharedItemRequest(
             createUserResponse.Id,
             createUserResponse.Password,
-            encryptedPayload,
-            encryptionIV,
+            new(encryptedPayload, new(encryptionIV)),
             DateTimeOffset.UtcNow.AddDays(1)
         );
 
@@ -52,8 +51,10 @@ public class SharedItemIntegrationTests(WebApplicationFactory<Program> factory)
         getSharedItemResponse!
             .RsaPublicKey.SpkiPublicKeyBytes.Should()
             .BeEquivalentTo(rsaPublicKey);
-        getSharedItemResponse.EncryptedPayload.Should().BeEquivalentTo(encryptedPayload);
-        getSharedItemResponse.EncryptionIV.Should().BeEquivalentTo(encryptionIV);
+        getSharedItemResponse
+            .EncryptedPayload.EncryptedPayload.Should()
+            .BeEquivalentTo(encryptedPayload);
+        getSharedItemResponse.EncryptedPayload.IV.Should().BeEquivalentTo(encryptionIV);
     }
 
     [Fact]
@@ -65,8 +66,7 @@ public class SharedItemIntegrationTests(WebApplicationFactory<Program> factory)
         var sharedItemCreateRequest = new CreateSharedItemRequest(
             Guid.NewGuid(),
             "password",
-            encryptedPayload,
-            encryptionIV,
+            new(encryptedPayload, new(encryptionIV)),
             DateTimeOffset.UtcNow.AddDays(1)
         );
 
@@ -92,8 +92,7 @@ public class SharedItemIntegrationTests(WebApplicationFactory<Program> factory)
         var sharedItemCreateRequest = new CreateSharedItemRequest(
             createUserResponse.Id,
             new string('a', 29),
-            encryptedPayload,
-            encryptionIV,
+            new(encryptedPayload, new(encryptionIV)),
             DateTimeOffset.UtcNow.AddDays(1)
         );
 


### PR DESCRIPTION
A user of the app is now able to share their plans.  This will use the API created in #185 to publish an encrypted plan.  The encryption AES key and the ID returned from the API is used to create a URL which can be shared with other liftlog users. Similarly to how the feed sharing used to work, the AES key is not stored anywhere, and never touches the liftlog API servers.  

An example of a (non working) url:
```
https://app.liftlog.online/feed/shared-item/Xu5mjK?k=A9D914F00210B7BCB11E9E9F015CD933
```

On loading of that url, the app pulls the shared item with the given ID, then decrypts it with the key.  RSA validation is also done via the user who shared the item's public key (also returned in the api response).

In doing this, I've introduced a RemoteData type, which can be used to represent data in the state which is fetched from the server.  It has representations for errors, success, loading.  We should migrate some of the API actions which currently don't represent these states to it.


https://github.com/LiamMorrow/LiftLog/assets/13741016/5acb44b7-27df-49e7-b768-5a02b3d3d95b

