### PR TITLE
Add notes to session/exercise blueprint

### DIFF
--- a/LiftLog.Api/AiSessionBlueprint.json
+++ b/LiftLog.Api/AiSessionBlueprint.json
@@ -2,14 +2,15 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "A session to perform.",
-  "required": [
-    "Name",
-    "Exercises"
-  ],
+  "required": ["Name", "Exercises"],
   "properties": {
     "Name": {
       "type": "string",
       "description": "The name of the session. (e.g. 'Legs')."
+    },
+    "Description": {
+      "type": "string",
+      "description": "A description of the session. (e.g. 'A session to work the legs')."
     },
     "Exercises": {
       "type": "array",
@@ -17,14 +18,7 @@
       "items": {
         "type": "object",
         "description": "An exercise to perform.",
-        "required": [
-          "Name",
-          "Sets",
-          "RepsPerSet",
-          "InitialKilograms",
-          "KilogramsIncreaseOnSuccess",
-          "Rest"
-        ],
+        "required": ["Name", "Sets", "RepsPerSet", "InitialKilograms", "KilogramsIncreaseOnSuccess", "Rest"],
         "properties": {
           "Name": {
             "type": "string",
@@ -49,11 +43,7 @@
           "RestBetweenSets": {
             "type": "object",
             "description": "The rest time to use for the exercise.",
-            "required": [
-              "MinRest",
-              "MaxRest",
-              "FailureRest"
-            ],
+            "required": ["MinRest", "MaxRest", "FailureRest"],
             "properties": {
               "MinRestSeconds": {
                 "type": "integer",

--- a/LiftLog.Api/AiWorkoutPlan.json
+++ b/LiftLog.Api/AiWorkoutPlan.json
@@ -20,6 +20,10 @@
             "type": "string",
             "description": "The name of the session.  This might relate to the day of the week, or the type of session (e.g. 'Legs')."
           },
+          "Description": {
+            "type": "string",
+            "description": "A description of the session. (e.g. 'A session to work the legs')."
+          },
           "Exercises": {
             "type": "array",
             "description": "An array of exercises to perform.",

--- a/LiftLog.Api/Service/GptAiWorkoutPlanner.cs
+++ b/LiftLog.Api/Service/GptAiWorkoutPlanner.cs
@@ -100,9 +100,11 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient, ILogger<GptAiWorkout
                                     TimeSpan.FromSeconds(e.RestBetweenSets.MaxRestSeconds),
                                     TimeSpan.FromSeconds(e.RestBetweenSets.FailureRestSeconds)
                                 ),
-                                false
+                                false,
+                                Notes: ""
                             ))
-                            .ToImmutableList()
+                            .ToImmutableList(),
+                        Notes: s.Description
                     ))
                     .ToImmutableList()
             );
@@ -189,9 +191,11 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient, ILogger<GptAiWorkout
                             TimeSpan.FromSeconds(e.RestBetweenSets.MaxRestSeconds),
                             TimeSpan.FromSeconds(e.RestBetweenSets.FailureRestSeconds)
                         ),
-                        false
+                        false,
+                        Notes: ""
                     ))
-                    .ToImmutableList()
+                    .ToImmutableList(),
+                Notes: gptPlan.Description
             );
         }
         catch (Exception e)
@@ -209,7 +213,8 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient, ILogger<GptAiWorkout
 
     private record GptSessionBlueprint(
         string Name,
-        ImmutableListValue<GptExerciseBlueprint> Exercises
+        ImmutableListValue<GptExerciseBlueprint> Exercises,
+        string Description
     );
 
     private record GptExerciseBlueprint(

--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -134,6 +134,7 @@ describe('Completing a session', () => {
         cy.getA('[data-cy=exercise-notes-btn]').first().click()
         cy.dialog().find('md-outlined-text-field').find('textarea', { includeShadowDom: true }).first().click().type('I am NoteTaker, master of notes')
         cy.dialog().find('[data-cy=notes-dialog-actions]').contains("Save").click()
+        cy.getA('.repcount').first().click().should('contain.text', '5/5')
 
         cy.contains('Finish').click()
 
@@ -152,9 +153,7 @@ describe('Completing a session', () => {
         cy.navigate('Workout')
         cy.containsA('Workout A').click()
 
-        // TODO: this is failing because it does not actually trigger a pointerdown properly in blazor
-        // cy.getA('[data-cy=prev-exercise-btn]').first().find('button', { includeShadowDom: true }).trigger('pointerdown')
-        // cy.getA('[data-cy=exercise-notes]').should('contain.text', 'I am NoteTaker, master of notes')
+        cy.getA('[data-cy=exercise-previous-notes]').should('contain.text', 'I am NoteTaker, master of notes')
       })
     })
   })

--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -8,9 +8,13 @@ public record ProgramBlueprint(
     DateOnly LastEdited
 );
 
-public record SessionBlueprint(string Name, ImmutableListValue<ExerciseBlueprint> Exercises)
+public record SessionBlueprint(
+    string Name,
+    ImmutableListValue<ExerciseBlueprint> Exercises,
+    string Notes
+)
 {
-    public static readonly SessionBlueprint Empty = new SessionBlueprint(string.Empty, []);
+    public static readonly SessionBlueprint Empty = new(string.Empty, [], string.Empty);
 
     public Session GetEmptySession()
     {
@@ -41,7 +45,8 @@ public record ExerciseBlueprint(
     int RepsPerSet,
     decimal WeightIncreaseOnSuccess,
     Rest RestBetweenSets,
-    bool SupersetWithNext
+    bool SupersetWithNext,
+    string Notes
 );
 
 public record KeyedExerciseBlueprint(string Name, int Sets, int RepsPerSet)

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -11,13 +11,18 @@ public record Session(
     decimal? Bodyweight
 )
 {
-    public static readonly Session Empty = new Session(
-        Guid.Empty,
-        SessionBlueprint.Empty,
-        [],
-        DateOnly.MinValue,
-        null
-    );
+    public static readonly Session Empty =
+        new(Guid.Empty, SessionBlueprint.Empty, [], DateOnly.MinValue, null);
+
+    public static Session FreeformSession(DateOnly date, decimal? bodyweight) =>
+        Empty with
+        {
+            Bodyweight = bodyweight,
+            Id = Guid.NewGuid(),
+            Blueprint = SessionBlueprint.Empty with { Name = "Freeform Session" },
+            Date = date
+        };
+
     public RecordedExercise? NextExercise
     {
         get

--- a/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV1.cs
+++ b/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV1.cs
@@ -19,17 +19,19 @@ internal record SessionBlueprintContainerDaoV1(
 
 internal record SessionBlueprintDaoV1(
     [property: JsonPropertyName("Name")] string Name,
-    [property: JsonPropertyName("Exercises")] ImmutableListValue<ExerciseBlueprintDaoV1> Exercises
+    [property: JsonPropertyName("Exercises")] ImmutableListValue<ExerciseBlueprintDaoV1> Exercises,
+    [property: JsonPropertyName("Notes")] string? Notes
 )
 {
     internal static SessionBlueprintDaoV1 FromModel(Lib.Models.SessionBlueprint blueprint) =>
         new(
             blueprint.Name,
-            blueprint.Exercises.Select(ExerciseBlueprintDaoV1.FromModel).ToImmutableList()
+            blueprint.Exercises.Select(ExerciseBlueprintDaoV1.FromModel).ToImmutableList(),
+            blueprint.Notes
         );
 
     internal Lib.Models.SessionBlueprint ToModel() =>
-        new(Name, Exercises.Select(x => x.ToModel()).ToImmutableList());
+        new(Name, Exercises.Select(x => x.ToModel()).ToImmutableList(), Notes ?? "");
 }
 
 internal record ExerciseBlueprintDaoV1(
@@ -39,7 +41,8 @@ internal record ExerciseBlueprintDaoV1(
     [property: JsonPropertyName("InitialKilograms")] decimal InitialKilograms,
     [property: JsonPropertyName("KilogramsIncreaseOnSuccess")] decimal KilogramsIncreaseOnSuccess,
     [property: JsonPropertyName("RestBetweenSets")] RestDaoV1 RestBetweenSets,
-    [property: JsonPropertyName("SupersetWithNext")] bool SupersetWithNext
+    [property: JsonPropertyName("SupersetWithNext")] bool SupersetWithNext,
+    [property: JsonPropertyName("Notes")] string? Notes
 )
 {
     internal static ExerciseBlueprintDaoV1 FromModel(Lib.Models.ExerciseBlueprint blueprint) =>
@@ -50,7 +53,8 @@ internal record ExerciseBlueprintDaoV1(
             0,
             blueprint.WeightIncreaseOnSuccess,
             RestDaoV1.FromModel(blueprint.RestBetweenSets),
-            blueprint.SupersetWithNext
+            blueprint.SupersetWithNext,
+            blueprint.Notes
         );
 
     internal Lib.Models.ExerciseBlueprint ToModel() =>
@@ -60,7 +64,8 @@ internal record ExerciseBlueprintDaoV1(
             RepsPerSet,
             KilogramsIncreaseOnSuccess,
             RestBetweenSets.ToModel(),
-            SupersetWithNext
+            SupersetWithNext,
+            Notes ?? ""
         );
 }
 

--- a/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.cs
+++ b/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.cs
@@ -23,18 +23,24 @@ internal partial class SessionBlueprintDaoV2
 {
     public SessionBlueprintDaoV2(
         string name,
-        IEnumerable<ExerciseBlueprintDaoV2> exerciseBlueprints
+        IEnumerable<ExerciseBlueprintDaoV2> exerciseBlueprints,
+        string notes
     )
     {
         Name = name;
         ExerciseBlueprints.AddRange(exerciseBlueprints);
+        Notes = notes;
     }
 
     public static SessionBlueprintDaoV2 FromModel(Lib.Models.SessionBlueprint model) =>
-        new(model.Name, model.Exercises.Select(ExerciseBlueprintDaoV2.FromModel).ToImmutableList());
+        new(
+            model.Name,
+            model.Exercises.Select(ExerciseBlueprintDaoV2.FromModel).ToImmutableList(),
+            model.Notes
+        );
 
     public Lib.Models.SessionBlueprint ToModel() =>
-        new(Name, ExerciseBlueprints.Select(x => x.ToModel()).ToImmutableList());
+        new(Name, ExerciseBlueprints.Select(x => x.ToModel()).ToImmutableList(), Notes);
 }
 
 internal partial class ExerciseBlueprintDaoV2
@@ -45,7 +51,8 @@ internal partial class ExerciseBlueprintDaoV2
         int repsPerSet,
         DecimalValue weightIncreaseOnSuccess,
         RestDaoV2 restBetweenSets,
-        bool supersetWithNext
+        bool supersetWithNext,
+        string notes
     )
     {
         Name = name;
@@ -54,6 +61,7 @@ internal partial class ExerciseBlueprintDaoV2
         WeightIncreaseOnSuccess = weightIncreaseOnSuccess;
         RestBetweenSets = restBetweenSets;
         SupersetWithNext = supersetWithNext;
+        Notes = notes;
     }
 
     public static ExerciseBlueprintDaoV2 FromModel(Lib.Models.ExerciseBlueprint model) =>
@@ -63,7 +71,8 @@ internal partial class ExerciseBlueprintDaoV2
             model.RepsPerSet,
             model.WeightIncreaseOnSuccess,
             RestDaoV2.FromModel(model.RestBetweenSets),
-            model.SupersetWithNext
+            model.SupersetWithNext,
+            model.Notes
         );
 
     public Lib.Models.ExerciseBlueprint ToModel() =>
@@ -73,7 +82,8 @@ internal partial class ExerciseBlueprintDaoV2
             RepsPerSet,
             WeightIncreaseOnSuccess,
             RestBetweenSets.ToModel(),
-            SupersetWithNext
+            SupersetWithNext,
+            Notes
         );
 }
 

--- a/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.proto
+++ b/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.proto
@@ -11,6 +11,7 @@ message SessionBlueprintContainerDaoV2 {
 message SessionBlueprintDaoV2 {
     string name = 1;
     repeated ExerciseBlueprintDaoV2 exercise_blueprints = 2;
+    string notes = 3;
 }
 
 
@@ -22,6 +23,7 @@ message ExerciseBlueprintDaoV2 {
     LiftLog.Ui.Models.DecimalValue weight_increase_on_success = 5;
     RestDaoV2 rest_between_sets = 6;
     bool superset_with_next = 7;
+    string notes = 8;
 }
 
 message RestDaoV2 {

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.cs
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.cs
@@ -24,7 +24,8 @@ internal partial class SessionDaoV2
         SessionBlueprintDaoV2 sessionBlueprint,
         IEnumerable<RecordedExerciseDaoV2> recordedExercises,
         DateOnlyDao date,
-        decimal? bodyweight
+        decimal? bodyweight,
+        string blueprintNotes
     )
     {
         Id = id;
@@ -32,6 +33,7 @@ internal partial class SessionDaoV2
         Date = date;
         Bodyweight = bodyweight;
         SessionName = sessionBlueprint.Name;
+        BlueprintNotes = blueprintNotes;
     }
 
     public static SessionDaoV2 FromModel(Lib.Models.Session model) =>
@@ -40,7 +42,8 @@ internal partial class SessionDaoV2
             SessionBlueprintDaoV2.FromModel(model.Blueprint),
             model.RecordedExercises.Select(RecordedExerciseDaoV2.FromModel).ToImmutableList(),
             model.Date,
-            model.Bodyweight
+            model.Bodyweight,
+            model.Blueprint.Notes
         );
 
     public Lib.Models.Session ToModel() =>
@@ -48,7 +51,8 @@ internal partial class SessionDaoV2
             Id,
             new Lib.Models.SessionBlueprint(
                 SessionName,
-                RecordedExercises.Select(x => x.ToModel().Blueprint).ToImmutableList()
+                RecordedExercises.Select(x => x.ToModel().Blueprint).ToImmutableList(),
+                BlueprintNotes
             ),
             RecordedExercises.Select(x => x.ToModel()).ToImmutableList(),
             Date,

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.proto
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.proto
@@ -15,6 +15,7 @@ message SessionDaoV2 {
     repeated RecordedExerciseDaoV2 recorded_exercises = 3;
     LiftLog.Ui.Models.DateOnlyDao date = 4;
     optional LiftLog.Ui.Models.DecimalValue bodyweight = 5;
+    string blueprint_notes = 6;
 }
 
 

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -145,7 +145,7 @@ else
     private void StartFreeformSession()
     {
         var latestBodyweight = ProgramState.Value.UpcomingSessions.FirstOrDefault()?.Bodyweight;
-        selectedSession = new Session(Guid.NewGuid(), new SessionBlueprint("Freeform Session", []), [], DateOnly.FromDateTime(DateTime.Now), latestBodyweight);
+        selectedSession = Session.FreeformSession(DateOnly.FromDateTime(DateTime.Now), latestBodyweight);
         if (CurrentSessionState.Value.WorkoutSession is { IsStarted: true })
         {
             replaceCurrentSesisonDialog?.Open();

--- a/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.Home.cs
+++ b/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.Home.cs
@@ -20,7 +20,8 @@ public partial class ScreenshotCollectorPage
                     RepsPerSet: 10,
                     WeightIncreaseOnSuccess: 2.5m,
                     RestBetweenSets: Rest.Medium,
-                    SupersetWithNext: false
+                    SupersetWithNext: false,
+                    Notes: ""
                 ),
                 new ExerciseBlueprint(
                     Name: "Bench Press",
@@ -28,7 +29,8 @@ public partial class ScreenshotCollectorPage
                     RepsPerSet: 10,
                     WeightIncreaseOnSuccess: 2.5m,
                     RestBetweenSets: Rest.Medium,
-                    SupersetWithNext: false
+                    SupersetWithNext: false,
+                    Notes: ""
                 ),
                 new ExerciseBlueprint(
                     Name: "Deadlift",
@@ -36,9 +38,11 @@ public partial class ScreenshotCollectorPage
                     RepsPerSet: 10,
                     WeightIncreaseOnSuccess: 2.5m,
                     RestBetweenSets: Rest.Medium,
-                    SupersetWithNext: false
+                    SupersetWithNext: false,
+                    Notes: ""
                 )
-            ]
+            ],
+            Notes: ""
         );
 
     private async Task HandleHomeScreenshotCollection()

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -135,7 +135,8 @@
                 10,
                 2.5m,
                 new Rest(TimeSpan.FromSeconds(90), TimeSpan.FromMinutes(3), TimeSpan.FromMinutes(5)),
-                false);
+                false,
+                "");
         isAddingExercise = true;
         editDialog?.Open();
     }

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -15,22 +15,44 @@
 @if (SessionEditorState.Value.SessionBlueprint is not null)
 {
     <div class="bg-surface pt-2">
-        <div class="px-2 pb-2">
-            <TextField
-                class="w-full mb-4 text-start"
-                Label="Session Name"
-                TextFieldType="TextFieldType.Filled"
-                Value="@SessionEditorState.Value.SessionBlueprint.Name"
-                OnChange="@((val) => SetName(val!))">
-            </TextField>
-        </div>
-        <ItemList Items="SessionEditorState.Value.SessionBlueprint.Exercises.IndexedTuples()">
-            @{
-                var exercise = context.Item;
-                var index = context.Index;
-            }
-            <ExerciseBlueprintSummary Blueprint="@exercise" OnEdit="()=>BeginEditExercise(exercise,index)" OnMoveDown="()=>MoveExerciseDown(exercise)" OnMoveUp="()=>MoveExerciseUp(exercise)" OnRemove="()=>BeginRemoveExercise(exercise)" />
-        </ItemList>
+
+        <LabelledForm>
+            <LabelledFormRow Label="Session Name" Icon="assignment">
+                <TextField
+                    TextFieldType="TextFieldType.Filled"
+                    Value="@SessionEditorState.Value.SessionBlueprint.Name"
+                    OnChange="@((val) => SetName(val!))">
+                </TextField>
+            </LabelledFormRow>
+            <LabelledFormRow Label="Session Notes" Icon="notes">
+                <TextField
+                    TextFieldType="TextFieldType.Filled"
+                    Value="@SessionEditorState.Value.SessionBlueprint.Notes"
+                    type="textarea"
+                    SelectAllOnFocus="false"
+                    class="resize-y"
+                    OnChange="@((val) => SetNotes(val!))">
+                </TextField>
+            </LabelledFormRow>
+            <LabelledFormRow Label="Exercises" Icon="fitness_center">
+                @if(SessionEditorState.Value.SessionBlueprint.Exercises.Count == 0)
+                {
+                    <Card Type="Card.CardType.Filled">
+                        <div class="flex flex-col items-center">
+                            <span class="text-on-surface">No exercises added yet</span>
+                        </div>
+                    </Card>
+                }
+                <ItemList Items="SessionEditorState.Value.SessionBlueprint.Exercises.IndexedTuples()" VerticalPadding=false >
+                    @{
+                        var exercise = context.Item;
+                        var index = context.Index;
+                    }
+                    <ExerciseBlueprintSummary PadTop=@(index!=0) Blueprint="@exercise" OnEdit="()=>BeginEditExercise(exercise,index)" OnMoveDown="()=>MoveExerciseDown(exercise)" OnMoveUp="()=>MoveExerciseUp(exercise)" OnRemove="()=>BeginRemoveExercise(exercise)" />
+                </ItemList>
+            </LabelledFormRow>
+        </LabelledForm>
+
     </div>
     <FloatingBottomContainer>
         <Fab>
@@ -169,6 +191,11 @@
     void SetName(string name)
     {
         Dispatcher.Dispatch(new SetEditingSessionNameAction(name));
+        SaveSession();
+    }
+
+    void SetNotes(string notes){
+        Dispatcher.Dispatch(new SetEditingSessionNotesAction(notes));
         SaveSession();
     }
 

--- a/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
@@ -85,7 +85,8 @@
         Dispatcher.Dispatch(
             new AddProgramSessionAction(
                 PlanId,
-                new SessionBlueprint($"Session {ProgramState.Value.GetSessionBlueprints(PlanId).Count + 1}", new ImmutableListValue<ExerciseBlueprint>())));
+                SessionBlueprint.Empty with { Name = $"Session {ProgramState.Value.GetSessionBlueprints(PlanId).Count + 1}" })
+        );
         SelectSession(ProgramState.Value.GetSessionBlueprints(PlanId).Last(), ProgramState.Value.GetSessionBlueprints(PlanId).Count - 1);
     }
 

--- a/LiftLog.Ui/Services/BuiltInProgramService.cs
+++ b/LiftLog.Ui/Services/BuiltInProgramService.cs
@@ -15,18 +15,20 @@ public static class BuiltInProgramService
                     new(
                         "Workout A",
                         [
-                            new("Squat", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Deadlift", 1, 5, 5m, Rest.Medium, false)
-                        ]
+                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Workout B",
                         [
-                            new("Squat", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Overhead Press", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Deadlift", 1, 5, 5m, Rest.Medium, false)
-                        ]
+                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Overhead Press", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     )
                 ],
                 LastEdited: new(2024, 1, 1)
@@ -37,18 +39,20 @@ public static class BuiltInProgramService
                     new(
                         "Workout A",
                         [
-                            new("Squat", 5, 5, 2.5m, Rest.Medium, false),
-                            new("Bench Press", 5, 5, 2.5m, Rest.Medium, false),
-                            new("Barbell Row", 5, 5, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Squat", 5, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Bench Press", 5, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Barbell Row", 5, 5, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Workout B",
                         [
-                            new("Squat", 5, 5, 2.5m, Rest.Medium, false),
-                            new("Overhead Press", 5, 5, 2.5m, Rest.Medium, false),
-                            new("Deadlift", 1, 5, 5m, Rest.Medium, false)
-                        ]
+                            new("Squat", 5, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Overhead Press", 5, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     )
                 ],
                 LastEdited: new(2024, 1, 1)
@@ -59,29 +63,32 @@ public static class BuiltInProgramService
                     new(
                         "Push",
                         [
-                            new("Bench Press", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Overhead Press", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Tricep Extension", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Cable Fly", 4, 8, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Bench Press", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Overhead Press", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Tricep Extension", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Cable Fly", 4, 8, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Pull",
                         [
-                            new("Deadlift", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Barbell Row", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Lat Pulldown", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Barbell Curl", 4, 8, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Deadlift", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Barbell Row", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Lat Pulldown", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Barbell Curl", 4, 8, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Legs",
                         [
-                            new("Squat", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Lunges", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Leg Extension", 4, 8, 2.5m, Rest.Medium, false),
-                            new("Leg Curl", 4, 8, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Squat", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Lunges", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Leg Extension", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Leg Curl", 4, 8, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     )
                 ],
                 LastEdited: new(2024, 1, 1)
@@ -92,45 +99,49 @@ public static class BuiltInProgramService
                     new(
                         "Upper Power",
                         [
-                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Barbell Row", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Overhead Press", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Barbell Curl", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Tricep Extension", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Cable Fly", 3, 10, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Barbell Row", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Overhead Press", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Barbell Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Tricep Extension", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Cable Fly", 3, 10, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Lower Power",
                         [
-                            new("Squat", 3, 5, 2.5m, Rest.Medium, false),
-                            new("Deadlift", 3, 5, 5m, Rest.Medium, false),
-                            new("Leg Press", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Deadlift", 3, 5, 5m, Rest.Medium, false, ""),
+                            new("Leg Press", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Upper Hypertrophy",
                         [
-                            new("Incline Bench Press", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Cable Row", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Dumbbell Fly", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Dumbbell Curl", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Skullcrusher", 3, 10, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Incline Bench Press", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Cable Row", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Dumbbell Fly", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Dumbbell Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Skullcrusher", 3, 10, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Lower Hypertrophy",
                         [
-                            new("Front Squat", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Romanian Deadlift", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Leg Extension", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false),
-                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false)
-                        ]
+                            new("Front Squat", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Romanian Deadlift", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Leg Extension", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false, "")
+                        ],
+                        ""
                     )
                 ],
                 LastEdited: new(2024, 1, 1)
@@ -141,26 +152,29 @@ public static class BuiltInProgramService
                     new(
                         "Push",
                         [
-                            new("Pushups", 3, 10, 0m, Rest.Medium, false),
-                            new("Dips", 3, 10, 0m, Rest.Medium, false),
-                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false)
-                        ]
+                            new("Pushups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Dips", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Pull",
                         [
-                            new("Pullups", 3, 10, 0m, Rest.Medium, false),
-                            new("Chinups", 3, 10, 0m, Rest.Medium, false),
-                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false)
-                        ]
+                            new("Pullups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Chinups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Legs",
                         [
-                            new("Squats", 3, 10, 0m, Rest.Medium, false),
-                            new("Lunges", 3, 10, 0m, Rest.Medium, false),
-                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false)
-                        ]
+                            new("Squats", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Lunges", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false, "")
+                        ],
+                        ""
                     )
                 ],
                 LastEdited: new(2024, 1, 1)
@@ -171,29 +185,32 @@ public static class BuiltInProgramService
                     new(
                         "Push",
                         [
-                            new("Pushups", 3, 10, 0m, Rest.Medium, false),
-                            new("Dips", 3, 10, 0m, Rest.Medium, false),
-                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false),
-                            new("Planche Pushups", 3, 10, 0m, Rest.Medium, false)
-                        ]
+                            new("Pushups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Dips", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Planche Pushups", 3, 10, 0m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Pull",
                         [
-                            new("Pullups", 3, 10, 0m, Rest.Medium, false),
-                            new("Chinups", 3, 10, 0m, Rest.Medium, false),
-                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false),
-                            new("Muscle Ups", 3, 10, 0m, Rest.Medium, false)
-                        ]
+                            new("Pullups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Chinups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Muscle Ups", 3, 10, 0m, Rest.Medium, false, "")
+                        ],
+                        ""
                     ),
                     new(
                         "Legs",
                         [
-                            new("Squats", 3, 10, 0m, Rest.Medium, false),
-                            new("Lunges", 3, 10, 0m, Rest.Medium, false),
-                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false),
-                            new("Pistol Squats", 3, 10, 0m, Rest.Medium, false)
-                        ]
+                            new("Squats", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Lunges", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Pistol Squats", 3, 10, 0m, Rest.Medium, false, "")
+                        ],
+                        ""
                     )
                 ],
                 LastEdited: new(2024, 1, 1)

--- a/LiftLog.Ui/Shared/Presentation/ExerciseBlueprintSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseBlueprintSummary.razor
@@ -1,4 +1,4 @@
-<div class="py-4 pl-5 pr-2 relative" @onclick="OnEdit">
+<div class="pb-4 @TopPadding relative" @onclick="OnEdit">
     <md-ripple></md-ripple>
     <div class="flex flex-col">
         <div class="flex justify-between items-center">
@@ -37,8 +37,13 @@
     [EditorRequired]
     public EventCallback OnEdit { get; set; }
 
+    [Parameter]
+    public bool PadTop { get; set; } = true;
+
     private string Pluralize(int count, string singular)
     {
         return count == 1 ? singular : singular + "s";
     }
+
+    private string TopPadding => PadTop ? "pt-4" : "";
 }

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -12,7 +12,10 @@
     data-cy="exercise-notes"
     TextFieldType="TextFieldType.Filled"
     class="w-full mb-2 text-xl text-start"
-    Label="Notes"
+    Label="Plan Notes"
+    type="textarea"
+    SelectAllOnFocus="false"
+    class="resize-y"
     Value="@Exercise.Notes"
     OnChange="@(val => SetExerciseNotes(val!))"/>
 <div class="flex flex-wrap justify-around w-full gap-4">

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -8,6 +8,13 @@
     required
     OnChange="@(val => SetExerciseName(val!))">
 </TextField>
+<TextField
+    data-cy="exercise-notes"
+    TextFieldType="TextFieldType.Filled"
+    class="w-full mb-2 text-xl text-start"
+    Label="Notes"
+    Value="@Exercise.Notes"
+    OnChange="@(val => SetExerciseNotes(val!))"/>
 <div class="flex flex-wrap justify-around w-full gap-4">
     <div class="flex items-center w-full gap-4">
         <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex-1 flex justify-center">
@@ -76,6 +83,8 @@
     void IncrementExerciseRepsPerSet() => UpdateExerciseHandler(exercise with { RepsPerSet = exercise.RepsPerSet + 1 });
 
     void SetExerciseName(string name) => UpdateExerciseHandler(exercise with { Name = name });
+
+    void SetExerciseNotes(string notes) => UpdateExerciseHandler(exercise with { Notes = notes });
 
     void SetExerciseSupersetsNext(bool supersets)
         => UpdateExerciseHandler(exercise with { SupersetWithNext = supersets });

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -11,11 +11,10 @@
 <TextField
     data-cy="exercise-notes"
     TextFieldType="TextFieldType.Filled"
-    class="w-full mb-2 text-xl text-start"
+    class="w-full mb-2 text-xl text-start resize-y"
     Label="Plan Notes"
     type="textarea"
     SelectAllOnFocus="false"
-    class="resize-y"
     Value="@Exercise.Notes"
     OnChange="@(val => SetExerciseNotes(val!))"/>
 <div class="flex flex-wrap justify-around w-full gap-4">

--- a/LiftLog.Ui/Shared/Presentation/ItemList.razor
+++ b/LiftLog.Ui/Shared/Presentation/ItemList.razor
@@ -1,5 +1,5 @@
 @typeparam TItem
-<div @attributes="AdditionalAttributes" class=" @(AdditionalAttributes?.GetValueOrDefault("class")) flex flex-col py-2 itemlist">
+<div @attributes="AdditionalAttributes" class=" @(AdditionalAttributes?.GetValueOrDefault("class")) flex flex-col @VerticalPaddingClass itemlist">
     @for (var i = 0; i < Items.Count; i++)
     {
         <div class="text-on-surface">
@@ -17,6 +17,10 @@
 
     [Parameter] public RenderFragment<TItem>? ChildContent { get; set; } = null!;
 
+    [Parameter] public bool VerticalPadding { get; set; } = true;
+
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
+
+    private string VerticalPaddingClass => VerticalPadding ? "py-2" : "";
 }

--- a/LiftLog.Ui/Shared/Presentation/TextField.razor
+++ b/LiftLog.Ui/Shared/Presentation/TextField.razor
@@ -45,6 +45,8 @@
 
     [Parameter] public TextFieldType TextFieldType { get; set; } = TextFieldType.Outline;
 
+    [Parameter] public bool SelectAllOnFocus { get; set; } = true;
+
     protected override async Task OnParametersSetAsync()
     {
         await JSRuntime.InvokeVoidAsync("AppUtils.setValueIfNotFocused", _textField, Value);
@@ -53,7 +55,8 @@
 
     private async Task SelectOnFocus(FocusEventArgs args)
     {
-        await JSRuntime.InvokeVoidAsync("AppUtils.selectAllText", _textField);
+        if (SelectAllOnFocus)
+            await JSRuntime.InvokeVoidAsync("AppUtils.selectAllText", _textField);
     }
 
     private async Task SetValueOnElement()

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -104,8 +104,8 @@
 </div>
 
 <Dialog @ref="notesDialog">
-    <span slot="headline">@(RecordedExercise.Blueprint.Name) Notes</span>
-    <div slot="content">
+    <span slot="headline">Session Notes for @(RecordedExercise.Blueprint.Name)</span>
+    <div slot="content" class="flex flex-col">
         <TextField label="Notes" TextFieldType="TextFieldType.Outline" Value="@EditorNotes" OnChange="HandleNotesChange" type="textarea"/>
     </div>
     <div slot="actions" data-cy="notes-dialog-actions">

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -1,15 +1,20 @@
 ﻿@{
-    var (displayedExercise, repToStartNext, notesToShow) = (_holdingPrevious, PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise) switch
+    var (displayedExercise, repToStartNext) = (_holdingPrevious, PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise) switch
     {
-        (true, null) => (RecordedExercise, -1, RecordedExercise.Notes),
-        (true, var previous) => (previous, -1, previous.Notes),
-        (false, _) => (RecordedExercise, RecordedExercise.PotentialSets.IndexOf(x => x.Set is null), RecordedExercise.Notes)
+        (true, null) => (RecordedExercise, -1),
+        (true, var previous) => (previous, -1),
+        (false, _) => (RecordedExercise, RecordedExercise.PotentialSets.IndexOf(x => x.Set is null))
     };
+    var previousNotes = PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise?.Notes ?? "";
+    var thisNotes = RecordedExercise.Notes ?? "";
+    var blueprintNotes = RecordedExercise.Blueprint.Notes;
 }
 <div class="flex flex-col gap-4 py-4 pl-7 pr-2 w-full">
     <div class="flex flex-col">
         <div class="flex justify-between">
-            <ItemTitle Title="@RecordedExercise.Blueprint.Name" />
+            <div>
+                <ItemTitle Title="@RecordedExercise.Blueprint.Name" />
+            </div>
             @if(!IsReadonly)
             {
                 <div class="flex justify-end">
@@ -57,10 +62,31 @@
                 ToStartNext=@(ToStartNext && repToStartNext == i && !IsReadonly)/>
         }
     </div>
-    @if (notesToShow is not null)
+    @if((blueprintNotes ,previousNotes , thisNotes) is not ("","",""))
     {
-        <div class="flex justify-start">
-            <span data-cy="exercise-notes" class="text-tertiary font-bold">@notesToShow</span>
+        <div class="grid grid-cols-[min-content_1fr] gap-2 text-left">
+            <IconButton Type=IconButtonType.Standard OnClick=@(()=>showNotes = !showNotes) Icon="notes" />
+            <div class="flex flex-col">
+                @if (showNotes && blueprintNotes is not "")
+                {
+                    <div class="flex justify-start">
+                        <span data-cy="exercise-blueprint-notes" class="text-tertiary">@blueprintNotes</span>
+                    </div>
+                }
+                @if (showNotes && previousNotes is not "")
+                {
+                    <div class="flex justify-start">
+                        <span data-cy="exercise-previous-notes" class="text-secondary">Last time: @previousNotes</span>
+                    </div>
+                }
+                @if (showNotes && thisNotes is not "")
+                {
+                    <div class="flex justify-start">
+                        <span data-cy="exercise-notes" class="text-primary">@thisNotes</span>
+                    </div>
+                }
+
+            </div>
         </div>
     }
     @if (_holdingPrevious && PreviousRecordedExercises?.Any() == true)
@@ -87,6 +113,7 @@
     private bool _holdingPrevious = false;
     private Menu? _menu;
     private Dialog? notesDialog;
+    private bool showNotes = true;
 
     private string EditorNotes { get; set; } = "";
 

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -64,30 +64,36 @@
     </div>
     @if((blueprintNotes ,previousNotes , thisNotes) is not ("","",""))
     {
-        <div class="grid grid-cols-[min-content_1fr] gap-2 text-left">
-            <IconButton Type=IconButtonType.Standard OnClick=@(()=>showNotes = !showNotes) Icon="notes" />
-            <div class="flex flex-col">
-                @if (showNotes && blueprintNotes is not "")
+        <Card Type=Card.CardType.Filled class="grid grid-cols-[min-content_1fr] mr-5 gap-2 text-left">
+            <md-icon>notes</md-icon>
+            <div class="flex flex-col gap-1">
+                @if (blueprintNotes is not "")
                 {
                     <div class="flex justify-start">
-                        <span data-cy="exercise-blueprint-notes" class="text-tertiary">@blueprintNotes</span>
+                        <span data-cy="exercise-blueprint-notes" >@blueprintNotes</span>
                     </div>
                 }
-                @if (showNotes && previousNotes is not "")
+                @if (previousNotes is not "")
                 {
+                    if(blueprintNotes is not ""){
+                        <md-divider></md-divider>
+                    }
                     <div class="flex justify-start">
-                        <span data-cy="exercise-previous-notes" class="text-secondary">Last time: @previousNotes</span>
+                        <span data-cy="exercise-previous-notes" >Last time: @previousNotes</span>
                     </div>
                 }
-                @if (showNotes && thisNotes is not "")
+                @if (thisNotes is not "")
                 {
+                    if(previousNotes is not "" || blueprintNotes is not ""){
+                        <md-divider></md-divider>
+                    }
                     <div class="flex justify-start">
-                        <span data-cy="exercise-notes" class="text-primary">@thisNotes</span>
+                        <span data-cy="exercise-notes" >@thisNotes</span>
                     </div>
                 }
 
             </div>
-        </div>
+        </Card>
     }
     @if (_holdingPrevious && PreviousRecordedExercises?.Any() == true)
     {
@@ -113,7 +119,6 @@
     private bool _holdingPrevious = false;
     private Menu? _menu;
     private Dialog? notesDialog;
-    private bool showNotes = true;
 
     private string EditorNotes { get; set; } = "";
 

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -4,6 +4,14 @@
 @inject IState<CurrentSessionState> CurrentSessionState
 @inject IDispatcher Dispatcher
 
+@if(Session.Blueprint.Notes != "")
+{
+    <Card class="m-2 gap-4 text-start flex items-center" Type=Card.CardType.Filled>
+        <md-icon>notes</md-icon>
+        <p>@Session.Blueprint.Notes</p>
+    </Card>
+}
+
 @if (!Session.RecordedExercises.Any())
 {
     <div class="flex flex-col justify-center items-center gap-4 my-8 text-on-surface">

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -6,7 +6,7 @@
 
 @if(Session.Blueprint.Notes != "")
 {
-    <Card class="m-2 gap-4 text-start flex items-center" Type=Card.CardType.Filled>
+    <Card class="my-2 mx-7 gap-4 text-start flex items-center" Type=Card.CardType.Filled>
         <md-icon>notes</md-icon>
         <p>@Session.Blueprint.Notes</p>
     </Card>

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -149,7 +149,8 @@ else
         RepsPerSet: 10,
         WeightIncreaseOnSuccess: 0,
         RestBetweenSets: Rest.Medium,
-        SupersetWithNext: false
+        SupersetWithNext: false,
+        Notes: ""
     );
 
     private (int ExerciseIndex, int PotentialSetIndex)? setAdditionalActions;
@@ -280,7 +281,8 @@ else
             RepsPerSet: 10,
             WeightIncreaseOnSuccess: 0,
             RestBetweenSets: Rest.Medium,
-            SupersetWithNext: false
+            SupersetWithNext: false,
+            Notes: ""
         );
         _editExerciseDialog?.Open();
     }

--- a/LiftLog.Ui/Store/Feed/FeedStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Feed/FeedStateInitMiddleware.cs
@@ -48,6 +48,7 @@ public class FeedStateInitMiddleware(
                 }
             }
             dispatch.Dispatch(new SetFeedIsHydratedAction());
+            dispatch.Dispatch(new FetchInboxItemsAction());
             sw.Stop();
             logger.LogInformation(
                 "Feed state initialized in {ElapsedMilliseconds}ms",

--- a/LiftLog.Ui/Store/SessionEditor/SessionEditorActions.cs
+++ b/LiftLog.Ui/Store/SessionEditor/SessionEditorActions.cs
@@ -6,6 +6,8 @@ public record SetEditingSessionAction(SessionBlueprint SessionBlueprint);
 
 public record SetEditingSessionNameAction(string Name);
 
+public record SetEditingSessionNotesAction(string Notes);
+
 public record MoveExerciseUpAction(ExerciseBlueprint ExerciseBlueprint);
 
 public record MoveExerciseDownAction(ExerciseBlueprint ExerciseBlueprint);

--- a/LiftLog.Ui/Store/SessionEditor/SessionEditorReducers.cs
+++ b/LiftLog.Ui/Store/SessionEditor/SessionEditorReducers.cs
@@ -18,7 +18,7 @@ public static class SessionEditorReducers
         SessionEditorState state,
         SetEditingSessionNameAction action
     ) =>
-        new SessionEditorState(
+        new(
             state.SessionBlueprint == null
                 ? null
                 : state.SessionBlueprint with
@@ -28,11 +28,25 @@ public static class SessionEditorReducers
         );
 
     [ReducerMethod]
+    public static SessionEditorState SetEditingSessionNotes(
+        SessionEditorState state,
+        SetEditingSessionNotesAction action
+    ) =>
+        new(
+            state.SessionBlueprint == null
+                ? null
+                : state.SessionBlueprint with
+                {
+                    Notes = action.Notes
+                }
+        );
+
+    [ReducerMethod]
     public static SessionEditorState AddExerciseAction(
         SessionEditorState state,
         AddExerciseAction action
     ) =>
-        new SessionEditorState(
+        new(
             state.SessionBlueprint == null
                 ? null
                 : state.SessionBlueprint with
@@ -46,7 +60,7 @@ public static class SessionEditorReducers
         SessionEditorState state,
         RemoveExerciseAction action
     ) =>
-        new SessionEditorState(
+        new(
             state.SessionBlueprint == null
                 ? null
                 : state.SessionBlueprint with

--- a/LiftLog.Ui/ThemedWebApplication.razor
+++ b/LiftLog.Ui/ThemedWebApplication.razor
@@ -7,7 +7,7 @@
 @inject NavigationManagerProvider NavigationManagerProvider
 @inject NavigationManager NavigationManager
 
-<LiftLog.Ui.WebApplication/>
+<LiftLog.Ui.WebApp/>
 
 @if (_scheme is not null)
 {
@@ -97,10 +97,6 @@
 
     string GetColorStr(uint color) => $"{ColorUtils.RedFromArgb(color)} {ColorUtils.GreenFromArgb(color)} {ColorUtils.BlueFromArgb(color)}";
 
-    protected override async Task OnInitializedAsync()
-    {
-        _scheme = await ThemeProvider.GetColorSchemeAsync();
-    }
 
     protected override void OnAfterRender(bool firstRender)
     {
@@ -111,6 +107,16 @@
         }
 
         base.OnAfterRender(firstRender);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _scheme = await ThemeProvider.GetColorSchemeAsync();
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
     }
 
     public void Dispose()

--- a/LiftLog.Ui/WebApp.razor
+++ b/LiftLog.Ui/WebApp.razor
@@ -1,5 +1,5 @@
 ﻿<Fluxor.Blazor.Web.StoreInitializer/>
-<Router AppAssembly="@typeof(WebApplication).Assembly">
+<Router AppAssembly="@typeof(WebApp).Assembly">
     <Found Context="routeData">
         <LayoutView Layout="@typeof(MainLayout)">
             <TransitionableRoutePrimary RouteData="@routeData" ForgetStateOnTransition="true">

--- a/LiftLog.Web/Properties/launchSettings.json
+++ b/LiftLog.Web/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "LiftLog.Web": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "https://0.0.0.0:5001/feed/shared-item/NsOZ7u?k=F632120748D66CA8B35D10DDD6222955",
+      "launchUrl": "https://0.0.0.0:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/LiftLog.Web/deploy.sh
+++ b/LiftLog.Web/deploy.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-npx tailwindcss --config ../LiftLog.Ui/tailwind.config.js -i ../LiftLog.Ui/Styles/app.css -o ../LiftLog.Ui/wwwroot/app.min.css --minify && \
-dotnet publish -c Release && \
-aws s3 sync ./bin/Release/net8.0/publish/wwwroot s3://limajuice.liftlog/ --cache-control max-age=2592000 && \
-aws s3 cp s3://limajuice.liftlog/index.html s3://limajuice.liftlog/index.html --metadata-directive REPLACE --cache-control max-age=0 --content-type=text/html && \
-aws cloudfront create-invalidation --distribution-id E2RTJJGPJ5XUFP  --paths /\*

--- a/LiftLog.Web/wwwroot/crypto-utils.ts
+++ b/LiftLog.Web/wwwroot/crypto-utils.ts
@@ -3,207 +3,207 @@ const HashLengthBytes = 32;
 const SignatureLengthBytes = 256;
 
 const generateAesKey = async function (): Promise<AesKey> {
-    const params: AesKeyGenParams = {
-        name: "AES-CBC",
-        length: 128,
-    };
-    const key = await crypto.subtle.generateKey(params, true, ["encrypt", "decrypt"]);
+  const params: AesKeyGenParams = {
+    name: "AES-CBC",
+    length: 128,
+  };
+  const key = await crypto.subtle.generateKey(params, true, ["encrypt", "decrypt"]);
 
-    return {value: new Uint8Array(await crypto.subtle.exportKey("raw", key))};
+  return { value: new Uint8Array(await crypto.subtle.exportKey("raw", key)) };
 };
 
 const decryptAesCbcAndVerifyRsa256PssAsync = async function (
-    data: AesEncryptedAndRsaSignedData,
-    key: AesKey,
-    publicKey: RsaPublicKey
+  data: AesEncryptedAndRsaSignedData,
+  key: AesKey,
+  publicKey: RsaPublicKey
 ): Promise<Uint8Array> {
-    const params: AesCbcParams = {
-        name: "AES-CBC",
-        iv: data.iv.value,
-    };
-    const cryptoKey = await crypto.subtle.importKey("raw", key.value, params, false, ["decrypt"]);
-    const decrypted = new Uint8Array(await crypto.subtle.decrypt(params, cryptoKey, data.encryptedPayload));
+  const params: AesCbcParams = {
+    name: "AES-CBC",
+    iv: data.iv.value,
+  };
+  const cryptoKey = await crypto.subtle.importKey("raw", key.value, params, false, ["decrypt"]);
+  const decrypted = new Uint8Array(await crypto.subtle.decrypt(params, cryptoKey, data.encryptedPayload));
 
-    const signature = decrypted.slice(decrypted.length - SignatureLengthBytes);
-    const payload = decrypted.slice(0, decrypted.length - SignatureLengthBytes);
+  const signature = decrypted.slice(decrypted.length - SignatureLengthBytes);
+  const payload = decrypted.slice(0, decrypted.length - SignatureLengthBytes);
 
-    const payloadHash = await crypto.subtle.digest("SHA-256", payload);
+  const payloadHash = await crypto.subtle.digest("SHA-256", payload);
 
-    const rsaParams: RsaHashedImportParams & RsaPssParams = {
-        name: "RSA-PSS",
-        hash: "SHA-256",
-        saltLength: HashLengthBytes,
-    };
-    const rsaKey = await crypto.subtle.importKey("spki", publicKey.spkiPublicKeyBytes, rsaParams, false, ["verify"]);
-    const verified = await crypto.subtle.verify(rsaParams, rsaKey, signature, payloadHash);
+  const rsaParams: RsaHashedImportParams & RsaPssParams = {
+    name: "RSA-PSS",
+    hash: "SHA-256",
+    saltLength: HashLengthBytes,
+  };
+  const rsaKey = await crypto.subtle.importKey("spki", publicKey.spkiPublicKeyBytes, rsaParams, false, ["verify"]);
+  const verified = await crypto.subtle.verify(rsaParams, rsaKey, signature, payloadHash);
 
-    if (!verified) {
-        throw new Error("Signature verification failed");
-    }
+  if (!verified) {
+    throw new Error("Signature verification failed");
+  }
 
-    return payload;
+  return payload;
 };
 
 const signRsa256PssAndEncryptAesCbcAsync = async function (
-    data: Uint8Array,
-    key: AesKey,
-    privateKey: RsaPrivateKey,
-    aesIv: AesIV | null
+  data: Uint8Array,
+  key: AesKey,
+  privateKey: RsaPrivateKey,
+  aesIv: AesIV | null
 ): Promise<AesEncryptedAndRsaSignedData> {
-    var iv = aesIv?.value ?? crypto.getRandomValues(new Uint8Array(16));
-    const params: AesCbcParams = {
-        name: "AES-CBC",
-        iv,
-    };
-    const cryptoKey = await crypto.subtle.importKey("raw", key.value, params, false, ["encrypt"]);
+  var iv = aesIv?.value ?? crypto.getRandomValues(new Uint8Array(16));
+  const params: AesCbcParams = {
+    name: "AES-CBC",
+    iv,
+  };
+  const cryptoKey = await crypto.subtle.importKey("raw", key.value, params, false, ["encrypt"]);
 
-    const rsaParams: RsaHashedImportParams & RsaPssParams = {
-        name: "RSA-PSS",
-        hash: "SHA-256",
-        saltLength: HashLengthBytes,
-    };
-    const rsaKey = await crypto.subtle.importKey("pkcs8", privateKey.pkcs8PrivateKeyBytes, rsaParams, false, ["sign"]);
+  const rsaParams: RsaHashedImportParams & RsaPssParams = {
+    name: "RSA-PSS",
+    hash: "SHA-256",
+    saltLength: HashLengthBytes,
+  };
+  const rsaKey = await crypto.subtle.importKey("pkcs8", privateKey.pkcs8PrivateKeyBytes, rsaParams, false, ["sign"]);
 
-    const sha256Hash = await crypto.subtle.digest("SHA-256", data);
+  const sha256Hash = await crypto.subtle.digest("SHA-256", data);
 
-    const signature = await crypto.subtle.sign(rsaParams, rsaKey, sha256Hash);
+  const signature = await crypto.subtle.sign(rsaParams, rsaKey, sha256Hash);
 
-    const payload = new Uint8Array([...data, ...new Uint8Array(signature)]);
+  const payload = new Uint8Array([...data, ...new Uint8Array(signature)]);
 
-    const encrypted = await crypto.subtle.encrypt(params, cryptoKey, payload);
+  const encrypted = await crypto.subtle.encrypt(params, cryptoKey, payload);
 
-    return {
-        encryptedPayload: new Uint8Array(encrypted),
-        iv: {value: iv},
-    };
+  return {
+    encryptedPayload: new Uint8Array(encrypted),
+    iv: { value: iv },
+  };
 };
 
 const generateRsaKeys = async function (): Promise<RsaKeyPair> {
-    const keyPair = await crypto.subtle.generateKey(
-        {
-            name: "RSA-OAEP",
-            modulusLength: 2048,
-            publicExponent: new Uint8Array([1, 0, 1]),
-            hash: "SHA-256",
-        } satisfies RsaHashedKeyGenParams & RsaOaepParams & RsaKeyGenParams,
-        true,
-        ["encrypt", "decrypt"]
-    );
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSA-OAEP",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    } satisfies RsaHashedKeyGenParams & RsaOaepParams & RsaKeyGenParams,
+    true,
+    ["encrypt", "decrypt"]
+  );
 
-    const privateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const publicKey = await crypto.subtle.exportKey("spki", keyPair.publicKey);
+  const privateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  const publicKey = await crypto.subtle.exportKey("spki", keyPair.publicKey);
 
-    return {
-        privateKey: {pkcs8PrivateKeyBytes: new Uint8Array(privateKey)},
-        publicKey: {spkiPublicKeyBytes: new Uint8Array(publicKey)},
-    };
+  return {
+    privateKey: { pkcs8PrivateKeyBytes: new Uint8Array(privateKey) },
+    publicKey: { spkiPublicKeyBytes: new Uint8Array(publicKey) },
+  };
 };
 
 const encryptRsaOaepSha256Async = async function (
-    data: Uint8Array,
-    publicKey: RsaPublicKey
+  data: Uint8Array,
+  publicKey: RsaPublicKey
 ): Promise<RsaEncryptedData> {
-    const key = await crypto.subtle.importKey(
-        "spki",
-        publicKey.spkiPublicKeyBytes,
-        {
-            name: "RSA-OAEP",
-            hash: "SHA-256",
-        } satisfies RsaHashedImportParams & RsaOaepParams,
-        true,
-        ["encrypt"]
-    );
-    const chunkedData: Uint8Array[] = [];
-    // RSA can only encrypt 122 bytes at a time
-    for (let i = 0; i < data.length; i += 122) {
-        chunkedData.push(data.slice(i, i + 122));
-    }
-    return {
-        dataChunks: await Promise.all(
-            chunkedData.map(async (chunk) => {
-                return new Uint8Array(
-                    await crypto.subtle.encrypt(
-                        {
-                            name: "RSA-OAEP",
-                        },
-                        key,
-                        chunk
-                    )
-                );
-            })
-        ),
-    };
+  const key = await crypto.subtle.importKey(
+    "spki",
+    publicKey.spkiPublicKeyBytes,
+    {
+      name: "RSA-OAEP",
+      hash: "SHA-256",
+    } satisfies RsaHashedImportParams & RsaOaepParams,
+    true,
+    ["encrypt"]
+  );
+  const chunkedData: Uint8Array[] = [];
+  // RSA can only encrypt 122 bytes at a time
+  for (let i = 0; i < data.length; i += 122) {
+    chunkedData.push(data.slice(i, i + 122));
+  }
+  return {
+    dataChunks: await Promise.all(
+      chunkedData.map(async (chunk) => {
+        return new Uint8Array(
+          await crypto.subtle.encrypt(
+            {
+              name: "RSA-OAEP",
+            },
+            key,
+            chunk
+          )
+        );
+      })
+    ),
+  };
 };
 
 const decryptRsaOaepSha256Async = async function (
-    data: RsaEncryptedData,
-    privateKey: RsaPrivateKey
+  data: RsaEncryptedData,
+  privateKey: RsaPrivateKey
 ): Promise<Uint8Array> {
-    const key = await crypto.subtle.importKey(
-        "pkcs8",
-        privateKey.pkcs8PrivateKeyBytes,
-        {
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    privateKey.pkcs8PrivateKeyBytes,
+    {
+      name: "RSA-OAEP",
+      hash: "SHA-256",
+    } satisfies RsaHashedImportParams & RsaOaepParams,
+    true,
+    ["decrypt"]
+  );
+  const chunkedData: Uint8Array[] = [];
+  for (let i = 0; i < data.dataChunks.length; i++) {
+    chunkedData.push(data.dataChunks[i]);
+  }
+  const decryptedChunks = await Promise.all(
+    chunkedData.map(async (chunk) => {
+      return new Uint8Array(
+        await crypto.subtle.decrypt(
+          {
             name: "RSA-OAEP",
-            hash: "SHA-256",
-        } satisfies RsaHashedImportParams & RsaOaepParams,
-        true,
-        ["decrypt"]
-    );
-    const chunkedData: Uint8Array[] = [];
-    for (let i = 0; i < data.dataChunks.length; i++) {
-        chunkedData.push(data.dataChunks[i]);
-    }
-    const decryptedChunks = await Promise.all(
-        chunkedData.map(async (chunk) => {
-            return new Uint8Array(
-                await crypto.subtle.decrypt(
-                    {
-                        name: "RSA-OAEP",
-                    },
-                    key,
-                    chunk
-                )
-            );
-        })
-    );
-    return new Uint8Array(decryptedChunks.reduce((acc, chunk) => [...acc, ...chunk], [] as number[]));
+          },
+          key,
+          chunk
+        )
+      );
+    })
+  );
+  return new Uint8Array(decryptedChunks.reduce((acc, chunk) => [...acc, ...chunk], [] as number[]));
 };
 
 var CryptoUtils = {
-    generateAesKey,
-    signRsa256PssAndEncryptAesCbcAsync,
-    decryptAesCbcAndVerifyRsa256PssAsync,
-    generateRsaKeys,
-    encryptRsaOaepSha256Async,
-    decryptRsaOaepSha256Async,
+  generateAesKey,
+  signRsa256PssAndEncryptAesCbcAsync,
+  decryptAesCbcAndVerifyRsa256PssAsync,
+  generateRsaKeys,
+  encryptRsaOaepSha256Async,
+  decryptRsaOaepSha256Async,
 };
 
 interface RsaPublicKey {
-    spkiPublicKeyBytes: Uint8Array;
+  spkiPublicKeyBytes: Uint8Array;
 }
 
 interface AesKey {
-    value: Uint8Array;
+  value: Uint8Array;
 }
 
 interface RsaPrivateKey {
-    pkcs8PrivateKeyBytes: Uint8Array;
+  pkcs8PrivateKeyBytes: Uint8Array;
 }
 
 interface AesEncryptedAndRsaSignedData {
-    encryptedPayload: Uint8Array;
-    iv: AesIV;
+  encryptedPayload: Uint8Array;
+  iv: AesIV;
 }
 
 interface RsaEncryptedData {
-    dataChunks: Uint8Array[];
+  dataChunks: Uint8Array[];
 }
 
 interface RsaKeyPair {
-    publicKey: RsaPublicKey;
-    privateKey: RsaPrivateKey;
+  publicKey: RsaPublicKey;
+  privateKey: RsaPrivateKey;
 }
 
 interface AesIV {
-    value: Uint8Array;
+  value: Uint8Array;
 }

--- a/tests/LiftLog.Tests.App/Blueprints.cs
+++ b/tests/LiftLog.Tests.App/Blueprints.cs
@@ -16,7 +16,8 @@ public static class Blueprints
                 RepsPerSet: 10,
                 WeightIncreaseOnSuccess: 2.5m,
                 RestBetweenSets: Rest.Medium,
-                SupersetWithNext: false
+                SupersetWithNext: false,
+                Notes: "My exercise notes"
             )
         );
     }
@@ -29,8 +30,9 @@ public static class Blueprints
             [
                 CreateExerciseBlueprint(),
                 CreateExerciseBlueprint(e => e with { Name = "Test Exercise 2", RepsPerSet = 4 }),
-                CreateExerciseBlueprint(e => e with { Name = "Test Exercise 3", Sets = 4 })
-            ]
+                CreateExerciseBlueprint(e => e with { Name = "Test Exercise 3", Sets = 4 }),
+            ],
+            Notes: "My notes"
         );
     }
 }


### PR DESCRIPTION
More notes fields!
Now notes can be added to: Session Blueprints + Exercise Blueprints (plans)

They are displayed in cards on the session screen
<img width="380" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/ed2648c7-c7e8-4d21-821b-bc3103090632">
<img width="384" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/50b18c24-587e-465e-ad82-df5a3a30e68a">
<img width="398" alt="image" src="https://github.com/LiamMorrow/LiftLog/assets/13741016/0a372565-2d76-400c-8b71-3ed86d9881a6">
