### PR TITLE
Show per set weights as chip like things in summaries / stats

### DIFF
--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -31,7 +31,9 @@ describe('Completing a session', () => {
 
       cy.navigate('History')
 
-      cy.getA('.itemlist .item').first('.item').should('contain.text', 'Freeform Session').should('contain.text', '7.5kg')
+      cy.getA('[data-cy=session-summary-title]').first().should('contain.text', 'Freeform Session');
+
+      cy.getA('[data-cy=session-summary]').should('contain.text', '7.5kg')
     })
   })
 

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -110,13 +110,13 @@ public record RecordedExercise(
         PotentialSets.All(x => x.Set is not null && x.Set.RepsCompleted >= Blueprint.RepsPerSet)
         && PotentialSets.Any(x => x.Weight >= Weight);
 
-    [NotNullIfNotNull("FirstRecordedSet")]
+    [NotNullIfNotNull(nameof(FirstRecordedSet))]
     public PotentialSet? LastRecordedSet =>
         PotentialSets
             .OrderByDescending(x => x.Set?.CompletionTime)
             .FirstOrDefault(x => x.Set is not null);
 
-    [NotNullIfNotNull("LastRecordedSet")]
+    [NotNullIfNotNull(nameof(LastRecordedSet))]
     public PotentialSet? FirstRecordedSet =>
         PotentialSets.OrderBy(x => x.Set?.CompletionTime).FirstOrDefault(x => x.Set is not null);
 
@@ -124,9 +124,15 @@ public record RecordedExercise(
         LastRecordedSet?.Set?.CompletionTime - FirstRecordedSet?.Set?.CompletionTime
         ?? TimeSpan.Zero;
 
-    public decimal OneRepMax => Math.Floor(Weight / (1.0278m - (0.0278m * Blueprint.RepsPerSet)));
+    public decimal OneRepMax =>
+        Math.Floor(MaxWeightLifted / (1.0278m - (0.0278m * Blueprint.RepsPerSet)));
 
     public bool HasRemainingSets => PotentialSets.Any(x => x.Set is null);
+
+    public decimal MaxWeightLifted =>
+        PerSetWeight
+            ? PotentialSets.Where(x => x.Set is not null).Select(x => x.Weight).Append(Weight).Max()
+            : Weight;
 }
 
 public record RecordedSet(int RepsCompleted, TimeOnly CompletionTime);

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -8,6 +8,7 @@
 @inject SessionService SessionService
 @inject NavigationManager NavigationManager
 @inject IState<CurrentSessionState> CurrentSessionState
+@inject IState<AppState> AppState
 @inject IState<ProgramState> ProgramState
 @inject IDispatcher Dispatcher
 @inject ILogger<HistoryPage> Logger
@@ -25,26 +26,25 @@ else
 {
     <Card class="mx-2" Type=Card.CardType.Filled>
         <HistoryCalendar
+            CurrentMonth="@currentMonth.Month"
+            CurrentYear="@currentMonth.Year"
             Sessions="_latestSessions"
             OnSessionClick="HandleSessionClick"
             OnMonthChange="HandleMonthChange"
             OnDateSelect=CreateSessionAtDate
             OnSessionLongPress=@((session)=>{_selectedSession = session; _deleteDialog?.Open();}) />
     </Card>
-    <ItemList CardType=Card.CardType.Filled Items="filteredToMonthSessions" TItem="Session" Dividers=false >
-        <button class="p-6 relative w-full"  @onclick=@(()=>HandleSessionClick(context)) @oncontextmenu=@(()=>{_selectedSession = context; _deleteDialog?.Open();}) @oncontextmenu:preventDefault=true >
-            <md-ripple></md-ripple>
-            <SplitCardControl>
-                <TitleContent>
-                    <SessionSummaryTitle IsFilled="true" Session="context" ></SessionSummaryTitle>
-                </TitleContent>
-                <MainContent>
-                    <SessionSummary Session="context" ShowSets="true"></SessionSummary>
-                </MainContent>
+    <CardList CardType=Card.CardType.Outlined Items="filteredToMonthSessions" TItem="Session" OnClick="HandleSessionClick" OnContextMenu=@((item)=>{_selectedSession = item; _deleteDialog?.Open();}) >
+        <SplitCardControl>
+            <TitleContent>
+                <SessionSummaryTitle IsFilled="true" Session="context" ></SessionSummaryTitle>
+            </TitleContent>
+            <MainContent>
+                <SessionSummary Session="context" ShowSets="true"></SessionSummary>
+            </MainContent>
 
-            </SplitCardControl>
-        </button>
-    </ItemList>
+        </SplitCardControl>
+    </CardList>
 }
 
 <ConfirmationDialog @ref="_deleteDialog" OkText="Delete" OnOk=DeleteSession>
@@ -87,6 +87,7 @@ else
     {
         currentMonth = date;
         filteredToMonthSessions = _latestSessions.Where(s => s.Date.Month == date.Month && s.Date.Year == date.Year).ToList();
+        Dispatcher.Dispatch(new SetHistoryYearMonthAction(date.Year, date.Month));
     }
 
     private void CreateSessionAtDate(DateOnly date)
@@ -105,7 +106,15 @@ else
         this._latestSessions = await SessionService
             .GetLatestSessionsAsync()
             .ToListAsync();
-        HandleMonthChange(DateOnly.FromDateTime(DateTime.Now));
+
+        if (AppState.Value.HistoryYearMonth is (int year, int month))
+        {
+            HandleMonthChange(new DateOnly(year, month, 1));
+        }
+        else
+        {
+            HandleMonthChange(DateOnly.FromDateTime(DateTime.Now));
+        }
         await base.OnInitializedAsync();
         sw.Stop();
         Logger.LogInformation($"History page initialized in {sw.ElapsedMilliseconds} ms");

--- a/LiftLog.Ui/Shared/Presentation/Card.razor
+++ b/LiftLog.Ui/Shared/Presentation/Card.razor
@@ -2,7 +2,10 @@
 
 <div
     class="@(AdditionalAttributes?.GetValueOrDefault("class")) @(HasPadding ?"p-5":"") relative @Style rounded-card text-on-surface card"
-    @onclick="HandleOnClick">
+    @onclick="HandleOnClick"
+    @oncontextmenu=OnContextMenu @oncontextmenu:preventDefault=@(OnContextMenu.HasDelegate)
+    >
+
     @if (OnClick != null)
     {
         <md-ripple></md-ripple>
@@ -19,6 +22,8 @@
     [Parameter] public RenderFragment ChildContent { get; set; } = null!;
 
     [Parameter] public Action<MouseEventArgs>? OnClick { get; set; }
+
+    [Parameter] public EventCallback OnContextMenu { get; set; }
 
     [Parameter] public bool IsHighlighted { get; set; }
 

--- a/LiftLog.Ui/Shared/Presentation/CardList.razor
+++ b/LiftLog.Ui/Shared/Presentation/CardList.razor
@@ -2,7 +2,12 @@
 <div @attributes="AdditionalAttributes" class=" @(AdditionalAttributes?.GetValueOrDefault("class")) flex flex-col gap-2 p-2 cardlist">
     @foreach (var item in Items)
     {
-        <Card class="@CardClass" Type="CardType" IsHighlighted="ShouldHighlight?.Invoke(item) ?? false" OnClick=@(OnClick != null ? _ => OnClick(item) : null)>
+        <Card
+            class="@CardClass"
+            Type="CardType"
+            OnContextMenu=@(()=>OnContextMenu.InvokeAsync(item))
+            IsHighlighted="ShouldHighlight?.Invoke(item) ?? false"
+            OnClick=@(OnClick != null ? _ => OnClick(item) : null)>
             @ChildContent?.Invoke(item)
         </Card>
     }
@@ -15,6 +20,8 @@
     [Parameter] public RenderFragment<TItem>? ChildContent { get; set; } = null!;
 
     [Parameter] public Action<TItem>? OnClick { get; set; }
+
+    [Parameter] public EventCallback<TItem> OnContextMenu { get; set; }
 
     [Parameter] public Func<TItem, bool>? ShouldHighlight { get; set; }
 

--- a/LiftLog.Ui/Shared/Presentation/HistoryCalendar.razor
+++ b/LiftLog.Ui/Shared/Presentation/HistoryCalendar.razor
@@ -2,7 +2,7 @@
 
 
 @{
-    var firstDayOfMonth = new DateOnly(_currentYear, _currentMonth, 1);
+    var firstDayOfMonth = new DateOnly(CurrentYear, CurrentMonth, 1);
     var firstDayOfWeek = (int)firstDayOfMonth.DayOfWeek;
     var lastDayOfPreviousMonth = firstDayOfMonth.AddDays(-1);
     var index = 0;
@@ -12,7 +12,7 @@
         <IconButton data-cy="calendar-nav-previous-month" Type=IconButtonType.Standard @onclick="PreviousMonth" Icon="chevron_left" />
     </div>
     <div class="col-span-5 flex my-2 justify-center items-center">
-        <h2 data-cy="calendar-month">@DateTimeFormatInfo.CurrentInfo.GetMonthName(_currentMonth) @_currentYear</h2>
+        <h2 data-cy="calendar-month">@DateTimeFormatInfo.CurrentInfo.GetMonthName(CurrentMonth) @CurrentYear</h2>
     </div>
     <div class="col-span-1 my-2 text-right">
         <IconButton Type=IconButtonType.Standard @onclick="NextMonth" disabled=@DisableNext Icon="chevron_right" />
@@ -28,24 +28,31 @@
     @for (int i = 0; i < firstDayOfWeek; i++)
     {
         var date = lastDayOfPreviousMonth.AddDays(-i);
-        <HistoryCalendarDay @key=@(date.ToString()+index) Index="index++" Day=date Sessions=_sessionsByDate[date] OnDayClick=@(()=>HandleDayClick(date)) OnDayLongPress=@(()=>HandleDayLongPress(date)) />
+        <HistoryCalendarDay ForOtherMonth=true @key=@(date.ToString()+index) Index="index++" Day=date Sessions=_sessionsByDate[date] OnDayClick=@(()=>HandleDayClick(date)) OnDayLongPress=@(()=>HandleDayLongPress(date)) />
     }
-    @for (int i = 1; i <= DateTime.DaysInMonth(_currentYear, _currentMonth); i++)
+    @for (int i = 1; i <= DateTime.DaysInMonth(CurrentYear, CurrentMonth); i++)
     {
-        var date = new DateOnly(_currentYear, _currentMonth, i);
+        var date = new DateOnly(CurrentYear, CurrentMonth, i);
 
         <HistoryCalendarDay @key=@(date.ToString()+index) Index="index++" Day=date Sessions=_sessionsByDate[date] OnDayClick=@(()=>HandleDayClick(date)) OnDayLongPress=@(()=>HandleDayLongPress(date)) />
+    }
+
+@{var extraDay =0;}
+    @while(index % 7 != 0)
+    {
+        var date =new DateOnly(CurrentYear, CurrentMonth, DateTime.DaysInMonth(CurrentYear, CurrentMonth)).AddDays(++extraDay);
+        <HistoryCalendarDay ForOtherMonth=true @key=@(date.ToString()+index) Index="index++" Day=date Sessions=_sessionsByDate[date] OnDayClick=@(()=>HandleDayClick(date)) OnDayLongPress=@(()=>HandleDayLongPress(date)) />
     }
 
 </div>
 
 @code {
-    private int _currentMonth = DateTime.Now.Month;
-    private int _currentYear = DateTime.Now.Year;
+    [Parameter][EditorRequired] public int CurrentMonth {get;set;}
+    [Parameter][EditorRequired] public int CurrentYear {get;set;}
 
     private ILookup<DateOnly, Session> _sessionsByDate = null!;
 
-    private bool DisableNext => _currentYear == DateTime.Now.Year && _currentMonth == DateTime.Now.Month;
+    private bool DisableNext => CurrentYear == DateTime.Now.Year && CurrentMonth == DateTime.Now.Month;
 
     [Parameter]
     [EditorRequired]
@@ -76,37 +83,37 @@
         if(DisableNext){
             return;
         }
-        if (_currentMonth == 12)
+        if (CurrentMonth == 12)
         {
-            _currentMonth = 1;
-            _currentYear++;
+            CurrentMonth = 1;
+            CurrentYear++;
         }
         else
         {
-            _currentMonth++;
+            CurrentMonth++;
         }
-        OnMonthChange.InvokeAsync(new DateOnly(_currentYear, _currentMonth, 1));
+        OnMonthChange.InvokeAsync(new DateOnly(CurrentYear, CurrentMonth, 1));
     }
 
     private void PreviousMonth()
     {
-        if (_currentMonth == 1)
+        if (CurrentMonth == 1)
         {
-            _currentMonth = 12;
-            _currentYear--;
+            CurrentMonth = 12;
+            CurrentYear--;
         }
         else
         {
-            _currentMonth--;
+            CurrentMonth--;
         }
 
-        OnMonthChange.InvokeAsync(new DateOnly(_currentYear, _currentMonth, 1));
+        OnMonthChange.InvokeAsync(new DateOnly(CurrentYear, CurrentMonth, 1));
     }
 
     private void GoToToday()
     {
-        _currentMonth = DateTime.Now.Month;
-        _currentYear = DateTime.Now.Year;
+        CurrentMonth = DateTime.Now.Month;
+        CurrentYear = DateTime.Now.Year;
     }
 
     private async Task HandleDayLongPress(DateOnly date)

--- a/LiftLog.Ui/Shared/Presentation/HistoryCalendarDay.razor
+++ b/LiftLog.Ui/Shared/Presentation/HistoryCalendarDay.razor
@@ -44,6 +44,9 @@
     [EditorRequired]
     public EventCallback OnDayLongPress {get;set;}
 
+    [Parameter]
+    public bool ForOtherMonth { get;set; }
+
     string AnimationClass = "scale-0 animate-zoom-in";
 
     bool isHolding = false;

--- a/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
@@ -1,47 +1,50 @@
 
-<div class="flex flex-col gap-y-1 text-start" data-cy="session-summary">
+<div class="flex flex-col gap-y-1.5 text-start" data-cy="session-summary">
     @foreach (var exercise in Session.RecordedExercises)
     {
         var splitWeights = exercise.PerSetWeight && !exercise.PotentialSets.All(s => s.Weight == exercise.Weight);
-        <span class="flex flex-wrap items-center">
-        <span>@exercise.Blueprint.Name</span>
-        @if(ShowSets || ShowWeight)
-        {
-            <span class="flex justify-around ml-auto items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
 
-                @if (ShowSets && !splitWeights)
+        <span class="flex items-center">
+            <span>@exercise.Blueprint.Name</span>
+            @if(ShowSets || ShowWeight)
+            {
+                @if(!splitWeights)
                 {
-                    <span>
-                        @(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet)
-                    </span>
-                    @if(ShowWeight)
+                <span class="flex justify-around ml-auto items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
+
+                    @if (ShowSets)
                     {
-                        <span class="text-2xs">@@</span>
+                        <span>
+                            @(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet)
+                        </span>
+                        @if(ShowWeight)
+                        {
+                            <span class="text-2xs">@@</span>
+                        }
                     }
-                }
 
-                @if (ShowWeight && !splitWeights)
-                {
-                    <WeightFormat Weight="@exercise.Weight"/>
+                    @if (ShowWeight)
+                    {
+                        <WeightFormat Weight="@exercise.Weight"/>
+                    }
+                </span>
                 }
 
                 @if (ShowWeight && splitWeights)
                 {
-                    <span class="flex flex-wrap gap-1 items-center ml-auto">
+                    <span class="flex ml-auto flex-wrap justify-end gap-1">
                         @foreach(var set in exercise.PotentialSets)
                         {
-                            <span class="flex gap-0.5 items-center">
+                            <span class="flex items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
                                 @if (ShowSets){
                                     <span>@(set.Set?.RepsCompleted ?? exercise.Blueprint.RepsPerSet)</span><span class="text-2xs">@@</span>
                                 }
                                 <WeightFormat Weight="@set.Weight"/>
                             </span>
-                            <span class="divider [&:last-child]:hidden bg-outline-variant self-stretch my-1 w-[1px]"></span>
                         }
                     </span>
                 }
-            </span>
-        }
+            }
         </span>
     }
 </div>

--- a/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
@@ -1,17 +1,39 @@
 
-<div class="grid @GridRows gap-x-4 text-start" data-cy="session-summary">
+<div class="grid @GridRows gap-x-4 gap-y-0.5 text-start" data-cy="session-summary">
     @foreach (var exercise in Session.RecordedExercises)
     {
+        var splitWeights = exercise.PerSetWeight && !exercise.PotentialSets.All(s => s.Weight == exercise.Weight);
         <span>@exercise.Blueprint.Name</span>
-        @if (ShowSets)
+        @if (ShowSets && !splitWeights)
         {
-            <span class="flex items-center">@(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet) </span>
+            <span class="flex items-center justify-end">
+                <span class="@ChipClass">
+                    @(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet)
+                </span>
+            </span>
         }
 
-        @if (ShowWeight)
+        @if (ShowWeight && !splitWeights)
         {
             <span class="flex justify-end">
-                <WeightFormat Weight="@exercise.Weight"/>
+                <span class="@ChipClass">
+                    <WeightFormat Weight="@exercise.Weight"/>
+                </span>
+            </span>
+        }
+
+        @if (ShowWeight && splitWeights)
+        {
+            <span class="flex justify-end gap-1  items-center col-span-2">
+                @foreach(var set in exercise.PotentialSets)
+                {
+                    <span class="flex gap-0.5 @ChipClass">
+                        @if (ShowSets){
+                            <span>@(set.Set?.RepsCompleted ?? exercise.Blueprint.RepsPerSet)</span><span>x</span>
+                        }
+                        <WeightFormat Weight="@set.Weight"/>
+                    </span>
+                }
             </span>
         }
     }
@@ -24,6 +46,8 @@
     [Parameter] public bool ShowSets { get; set; }
 
     [Parameter] public bool ShowWeight { get; set; } = true;
+
+    private string ChipClass => "bg-surface-container-highest text-on-surface-variant rounded-md py-0.5 px-1";
 
     private string GridRows => (ShowSets, ShowWeight) switch
     {

--- a/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
@@ -1,41 +1,48 @@
 
-<div class="grid @GridRows gap-x-4 gap-y-0.5 text-start" data-cy="session-summary">
+<div class="flex flex-col gap-y-1 text-start" data-cy="session-summary">
     @foreach (var exercise in Session.RecordedExercises)
     {
         var splitWeights = exercise.PerSetWeight && !exercise.PotentialSets.All(s => s.Weight == exercise.Weight);
+        <span class="flex flex-wrap items-center">
         <span>@exercise.Blueprint.Name</span>
-        @if (ShowSets && !splitWeights)
+        @if(ShowSets || ShowWeight)
         {
-            <span class="flex items-center justify-end">
-                <span class="@ChipClass">
-                    @(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet)
-                </span>
-            </span>
-        }
+            <span class="flex justify-around ml-auto items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
 
-        @if (ShowWeight && !splitWeights)
-        {
-            <span class="flex justify-end">
-                <span class="@ChipClass">
-                    <WeightFormat Weight="@exercise.Weight"/>
-                </span>
-            </span>
-        }
-
-        @if (ShowWeight && splitWeights)
-        {
-            <span class="flex justify-end gap-1  items-center col-span-2">
-                @foreach(var set in exercise.PotentialSets)
+                @if (ShowSets && !splitWeights)
                 {
-                    <span class="flex gap-0.5 @ChipClass">
-                        @if (ShowSets){
-                            <span>@(set.Set?.RepsCompleted ?? exercise.Blueprint.RepsPerSet)</span><span>x</span>
+                    <span>
+                        @(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet)
+                    </span>
+                    @if(ShowWeight)
+                    {
+                        <span class="text-2xs">@@</span>
+                    }
+                }
+
+                @if (ShowWeight && !splitWeights)
+                {
+                    <WeightFormat Weight="@exercise.Weight"/>
+                }
+
+                @if (ShowWeight && splitWeights)
+                {
+                    <span class="flex flex-wrap gap-1 items-center ml-auto">
+                        @foreach(var set in exercise.PotentialSets)
+                        {
+                            <span class="flex gap-0.5 items-center">
+                                @if (ShowSets){
+                                    <span>@(set.Set?.RepsCompleted ?? exercise.Blueprint.RepsPerSet)</span><span class="text-2xs">@@</span>
+                                }
+                                <WeightFormat Weight="@set.Weight"/>
+                            </span>
+                            <span class="divider [&:last-child]:hidden bg-outline-variant self-stretch my-1 w-[1px]"></span>
                         }
-                        <WeightFormat Weight="@set.Weight"/>
                     </span>
                 }
             </span>
         }
+        </span>
     }
 </div>
 
@@ -46,14 +53,4 @@
     [Parameter] public bool ShowSets { get; set; }
 
     [Parameter] public bool ShowWeight { get; set; } = true;
-
-    private string ChipClass => "bg-surface-container-highest text-on-surface-variant rounded-md py-0.5 px-1";
-
-    private string GridRows => (ShowSets, ShowWeight) switch
-    {
-        (true, true) => "grid-cols-[1fr,max-content,max-content]",
-        (true, false) => "grid-cols-[1fr,max-content]",
-        (false, true) => "grid-cols-[1fr,max-content]",
-        (false, false) => "grid-cols-1",
-    };
 }

--- a/LiftLog.Ui/Store/App/AppActions.cs
+++ b/LiftLog.Ui/Store/App/AppActions.cs
@@ -14,6 +14,8 @@ public record ToastAction(string Message);
 
 public record SetBackNavigationUrlAction(string? BackNavigationUrl);
 
+public record SetHistoryYearMonthAction(int Year, int Month);
+
 public record NavigateAction(
     string Path,
     bool ClearPageStack = true,

--- a/LiftLog.Ui/Store/App/AppFeature.cs
+++ b/LiftLog.Ui/Store/App/AppFeature.cs
@@ -21,6 +21,7 @@ public class AppFeature : Feature<AppState>
             HasRequestedNotificationPermission: false,
             ColorScheme: new AppColorScheme<uint>(),
             AppLaunchCount: 0,
-            AppRatingResult: AppRatingResult.NotRated
+            AppRatingResult: AppRatingResult.NotRated,
+            HistoryYearMonth: null
         );
 }

--- a/LiftLog.Ui/Store/App/AppReducers.cs
+++ b/LiftLog.Ui/Store/App/AppReducers.cs
@@ -19,6 +19,13 @@ public static class AppReducers
         };
 
     [ReducerMethod]
+    public static AppState SetHistoryYearMonth(AppState state, SetHistoryYearMonthAction action) =>
+        state with
+        {
+            HistoryYearMonth = (action.Year, action.Month)
+        };
+
+    [ReducerMethod]
     public static AppState SetThemeColor(AppState state, ThemeColorUpdatedAction action) =>
         state with
         {

--- a/LiftLog.Ui/Store/App/AppState.cs
+++ b/LiftLog.Ui/Store/App/AppState.cs
@@ -15,7 +15,8 @@ public record AppState(
     bool HasRequestedNotificationPermission,
     AppColorScheme<uint> ColorScheme,
     int AppLaunchCount,
-    AppRatingResult AppRatingResult
+    AppRatingResult AppRatingResult,
+    (int Year, int Month)? HistoryYearMonth
 );
 
 public enum AppRatingResult

--- a/LiftLog.Ui/wwwroot/twconf.json
+++ b/LiftLog.Ui/wwwroot/twconf.json
@@ -23,6 +23,10 @@
       "2xl": "1320px"
     },
     "extend": {
+      "fontSize": {
+        "2xs": "0.625rem",
+        "3xs": "0.5rem"
+      },
       "transitionTimingFunction": {
         "out-back": "cubic-bezier(0.34, 1.56, 0.64, 1)"
       },


### PR DESCRIPTION
This PR achieves three things:

 1.  Show the per set weight in stats (as the max of all set weights) and history (as individual chips)
 2. Wrap the sets and weight in session summary (shown in feed, history, and the upcoming workouts) in nice little chip things
 3. Brings back cards on this history page... I still feel like we should move away from them but I can't make it look good - better be consistent

Before (no chips):
<img width="345" alt="image" src="https://github.com/user-attachments/assets/ad5f2743-b037-4685-8487-e8551852f507">

After:
<img width="367" alt="image" src="https://github.com/user-attachments/assets/8642d393-a7d0-4e8f-8293-260fef374eaf">
<img width="367" alt="image" src="https://github.com/user-attachments/assets/c075f46a-7955-468e-be48-4c196ca71f2f">


Fixes: #236 
