### PR TITLE
Allow for supersets to behave in chains of more than 2

### DIFF
--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -52,12 +52,24 @@ public record Session(
                 return RecordedExercises[latestExerciseIndex + 1];
             }
 
-            if (
-                latestExerciseSupersetsWithPrevious
-                && RecordedExercises[latestExerciseIndex - 1].HasRemainingSets
-            )
+            // loop back to the original exercise in the case of a superset chain
+            if (latestExerciseSupersetsWithPrevious)
             {
-                return RecordedExercises[latestExerciseIndex - 1];
+                var indexToJumpBackTo = latestExerciseIndex - 1;
+                while (RecordedExercises[indexToJumpBackTo].Blueprint.SupersetWithNext)
+                {
+                    indexToJumpBackTo--;
+                }
+                // We are now at an exercise which is not supersetting with the next,
+                // so jump forward to the next exercise
+                indexToJumpBackTo++;
+                // Now jump to the first exercise which has remaining sets in the chain
+                while (!RecordedExercises[indexToJumpBackTo].HasRemainingSets)
+                {
+                    indexToJumpBackTo++;
+                }
+
+                return RecordedExercises[indexToJumpBackTo];
             }
 
             return RecordedExercises

--- a/LiftLog.Maui/LiftLog.Maui.csproj
+++ b/LiftLog.Maui/LiftLog.Maui.csproj
@@ -69,6 +69,7 @@
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
         <RunAOTCompilation>true</RunAOTCompilation>
+        <AndroidStripILAfterAOT>true</AndroidStripILAfterAOT>
         <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
         <EnableLLVM>true</EnableLLVM>
     </PropertyGroup>

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionState.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionState.cs
@@ -8,5 +8,17 @@ namespace LiftLog.Ui.Store.CurrentSession
         Session? HistorySession,
         Session? FeedSession,
         Guid? LatestSetTimerNotificationId
-    );
+    )
+    {
+        public static CurrentSessionState FromWorkoutSession(Session session)
+        {
+            return new CurrentSessionState(
+                IsHydrated: true,
+                WorkoutSession: session,
+                HistorySession: null,
+                FeedSession: null,
+                LatestSetTimerNotificationId: null
+            );
+        }
+    }
 }

--- a/tests/LiftLog.Tests.App/Encryption/OsEncryptionServiceTests.cs
+++ b/tests/LiftLog.Tests.App/Encryption/OsEncryptionServiceTests.cs
@@ -86,9 +86,9 @@ public class OsEncryptionServiceTests
                 );
 
                 // Assert
-                Assert.Equal(data1, decryptedData1);
-                Assert.Equal(data2, decryptedData2);
-                Assert.Equal(encryptedData1.IV, encryptedData2.IV);
+                data1.Should().Equal(decryptedData1);
+                data2.Should().Equal(decryptedData2);
+                encryptedData1.IV.Should().BeEquivalentTo(encryptedData2.IV);
               });
           });
 
@@ -113,7 +113,7 @@ public class OsEncryptionServiceTests
                 encryptedData.EncryptedPayload[0] ^= 0xFF;
 
                 // Assert
-                await Assert.ThrowsAsync<SignatureMismatchException>(
+                Assert.ThrowsAsync<SignatureMismatchException>(
                   async () =>
                     await sut.DecryptAesCbcAndVerifyRsa256PssAsync(
                       encryptedData,

--- a/tests/LiftLog.Tests.App/GlobalUsings.cs
+++ b/tests/LiftLog.Tests.App/GlobalUsings.cs
@@ -1,7 +1,7 @@
 global using System.Collections.Immutable;
 global using FluentAssertions;
 global using NSubstitute;
+global using NUnit.Framework;
 global using Oatmilk;
+global using Oatmilk.Nunit;
 global using static Oatmilk.TestBuilder;
-global using Oatmilk.Xunit;
-global using Xunit;

--- a/tests/LiftLog.Tests.App/LiftLog.Tests.App.csproj
+++ b/tests/LiftLog.Tests.App/LiftLog.Tests.App.csproj
@@ -10,15 +10,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Oatmilk.Xunit" Version="0.0.8" />
+        <PackageReference Include="Oatmilk.Nunit" Version="0.1.3" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
         <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="xunit" Version="2.9.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.3.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
+++ b/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
@@ -54,7 +54,7 @@ public class SessionSupersetTests
             )
         );
 
-        It("should have the first exercise and set as the next exercise")
+        It("should have exercise 0 set as the next exercise")
           .When(() =>
           {
             var nextExercise = session.NextExercise;
@@ -62,7 +62,7 @@ public class SessionSupersetTests
             nextExercise.Blueprint.Name.Should().Be(session.RecordedExercises[0].Blueprint.Name);
           });
 
-        Describe("and the last completed set was the first exercise (not a superset)")
+        Describe("and the last completed set was exercise 0 (not a superset)")
           .As(() =>
           {
             BeforeEach(() =>
@@ -83,9 +83,7 @@ public class SessionSupersetTests
             );
           });
 
-        Describe(
-            "and the last completed set was the second exercise (a superset with the third exercise)"
-          )
+        Describe("and the last completed set was the exercise 1 (a superset with exercise 2)")
           .As(() =>
           {
             BeforeEach(() =>
@@ -93,7 +91,7 @@ public class SessionSupersetTests
               session = CycleExerciseReps(1, 0);
             });
 
-            It("Should have the next set be the third exercise")
+            It("Should have the next set be 2")
               .When(() =>
               {
                 var nextExercise = session.NextExercise;
@@ -103,8 +101,9 @@ public class SessionSupersetTests
                   .Be(session.RecordedExercises[2].Blueprint.Name);
               });
           });
+
         Describe(
-            "and the last completed set was the third exercise (a superset with the previous exercise)"
+            "and the last completed set was exercise 2 (a superset with the previous exercise (1))"
           )
           .As(() =>
           {
@@ -113,7 +112,7 @@ public class SessionSupersetTests
               session = CycleExerciseReps(2, 0);
             });
 
-            It("Should have the next set be the second exercise")
+            It("Should have the next set be 1")
               .When(() =>
               {
                 var nextExercise = session.NextExercise;
@@ -123,9 +122,8 @@ public class SessionSupersetTests
                   .Be(session.RecordedExercises[1].Blueprint.Name);
               });
           });
-        Describe(
-            "and the last completed set was the fourth exercise (a superset with the fifth and sixth exercise)"
-          )
+
+        Describe("and the last completed set was exercise 3 (a superset with the 4 and 5)")
           .As(() =>
           {
             BeforeEach(() =>
@@ -133,7 +131,7 @@ public class SessionSupersetTests
               session = CycleExerciseReps(3, 0);
             });
 
-            It("Should have the next set be the fifth exercise")
+            It("Should have the next set be 4")
               .When(() =>
               {
                 var nextExercise = session.NextExercise;
@@ -144,9 +142,7 @@ public class SessionSupersetTests
               });
           });
 
-        Describe(
-            "and the last completed set was the fifth exercise (a superset with the fourth and sixth exercise)"
-          )
+        Describe("and the last completed set was exercise 4 (a superset with the 3 and 5)")
           .As(() =>
           {
             BeforeEach(() =>
@@ -154,7 +150,7 @@ public class SessionSupersetTests
               session = CycleExerciseReps(4, 0);
             });
 
-            It("Should have the next set be the sixth exercise")
+            It("Should have the next set be 5")
               .When(() =>
               {
                 var nextExercise = session.NextExercise;
@@ -165,24 +161,22 @@ public class SessionSupersetTests
               });
           });
 
-        Describe(
-            "and the last completed set was the sixth exercise (a superset with the fourth and fifth exercise)"
-          )
+        Describe("and the last completed set was exercise 5 (a superset with the 3 and 4)")
           .As(() =>
           {
             BeforeEach(() =>
             {
-              session = CycleExerciseReps(4, 0);
+              session = CycleExerciseReps(5, 0);
             });
 
-            It("Should have the next set be the fourth exercise")
+            It("Should cycle back to exercise 3")
               .When(() =>
               {
                 var nextExercise = session.NextExercise;
                 nextExercise.Should().NotBeNull();
                 nextExercise
                   .Blueprint.Name.Should()
-                  .Be(session.RecordedExercises[4].Blueprint.Name);
+                  .Be(session.RecordedExercises[3].Blueprint.Name);
               });
           });
       }

--- a/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
+++ b/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
@@ -1,0 +1,191 @@
+using LiftLog.Lib.Models;
+using LiftLog.Ui.Store.CurrentSession;
+
+namespace LiftLog.Tests.App.SessionBehaviors;
+
+public class SessionSupersetTests
+{
+  [Describe("Session supersets")]
+  public void Spec()
+  {
+    Describe(
+      "When given a session with supersets",
+      () =>
+      {
+        Session session = null!;
+        CurrentSessionState GetState() => CurrentSessionState.FromWorkoutSession(session);
+        Session CycleExerciseReps(int exerciseIndex, int setIndex) =>
+          CurrentSessionReducers
+            .CycleExerciseReps(
+              GetState(),
+              new CycleExerciseRepsAction(
+                SessionTarget.WorkoutSession,
+                ExerciseIndex: exerciseIndex,
+                SetIndex: setIndex
+              )
+            )
+            .WorkoutSession!;
+
+        ExerciseBlueprint Exercise(int index, bool supersetWithNext) =>
+          Blueprints.CreateExerciseBlueprint(x =>
+            x with
+            {
+              Name = $"Ex{index}",
+              SupersetWithNext = supersetWithNext
+            }
+          );
+
+        BeforeEach(
+          () =>
+            session = Sessions.CreateSession(
+              sessionBlueprint: Blueprints.CreateSessionBlueprint() with
+              {
+                Exercises =
+                [
+                  Exercise(0, supersetWithNext: false),
+                  Exercise(1, supersetWithNext: true),
+                  Exercise(2, supersetWithNext: false),
+                  Exercise(3, supersetWithNext: true),
+                  Exercise(4, supersetWithNext: true),
+                  Exercise(5, supersetWithNext: false)
+                ]
+              },
+              fillFirstSet: false
+            )
+        );
+
+        It("should have the first exercise and set as the next exercise")
+          .When(() =>
+          {
+            var nextExercise = session.NextExercise;
+            nextExercise.Should().NotBeNull();
+            nextExercise.Blueprint.Name.Should().Be(session.RecordedExercises[0].Blueprint.Name);
+          });
+
+        Describe("and the last completed set was the first exercise (not a superset)")
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(0, 0);
+            });
+
+            It(
+              "Should have the next set be the first exercise",
+              () =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().NotBeNull();
+                nextExercise
+                  .Blueprint.Name.Should()
+                  .Be(session.RecordedExercises[0].Blueprint.Name);
+              }
+            );
+          });
+
+        Describe(
+            "and the last completed set was the second exercise (a superset with the third exercise)"
+          )
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(1, 0);
+            });
+
+            It("Should have the next set be the third exercise")
+              .When(() =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().NotBeNull();
+                nextExercise
+                  .Blueprint.Name.Should()
+                  .Be(session.RecordedExercises[2].Blueprint.Name);
+              });
+          });
+        Describe(
+            "and the last completed set was the third exercise (a superset with the previous exercise)"
+          )
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(2, 0);
+            });
+
+            It("Should have the next set be the second exercise")
+              .When(() =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().NotBeNull();
+                nextExercise
+                  .Blueprint.Name.Should()
+                  .Be(session.RecordedExercises[1].Blueprint.Name);
+              });
+          });
+        Describe(
+            "and the last completed set was the fourth exercise (a superset with the fifth and sixth exercise)"
+          )
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(3, 0);
+            });
+
+            It("Should have the next set be the fifth exercise")
+              .When(() =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().NotBeNull();
+                nextExercise
+                  .Blueprint.Name.Should()
+                  .Be(session.RecordedExercises[4].Blueprint.Name);
+              });
+          });
+
+        Describe(
+            "and the last completed set was the fifth exercise (a superset with the fourth and sixth exercise)"
+          )
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(4, 0);
+            });
+
+            It("Should have the next set be the sixth exercise")
+              .When(() =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().NotBeNull();
+                nextExercise
+                  .Blueprint.Name.Should()
+                  .Be(session.RecordedExercises[5].Blueprint.Name);
+              });
+          });
+
+        Describe(
+            "and the last completed set was the sixth exercise (a superset with the fourth and fifth exercise)"
+          )
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(4, 0);
+            });
+
+            It("Should have the next set be the fourth exercise")
+              .When(() =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().NotBeNull();
+                nextExercise
+                  .Blueprint.Name.Should()
+                  .Be(session.RecordedExercises[4].Blueprint.Name);
+              });
+          });
+      }
+    );
+  }
+}

--- a/tests/LiftLog.Tests.App/Sessions.cs
+++ b/tests/LiftLog.Tests.App/Sessions.cs
@@ -6,7 +6,8 @@ public static class Sessions
 {
   public static Session CreateSession(
     SessionBlueprint? sessionBlueprint = null,
-    Func<Session, Session>? transform = null
+    Func<Session, Session>? transform = null,
+    bool fillFirstSet = true
   )
   {
     sessionBlueprint ??= Blueprints.CreateSessionBlueprint();
@@ -15,7 +16,7 @@ public static class Sessions
         Id: Guid.NewGuid(),
         Blueprint: sessionBlueprint,
         RecordedExercises: sessionBlueprint
-          .Exercises.Select(x => CreateRecordedExercise(x))
+          .Exercises.Select(x => CreateRecordedExercise(x, fillFirstSet: fillFirstSet))
           .ToImmutableList(),
         Date: DateOnly.Parse("2021-04-05"),
         Bodyweight: null
@@ -25,7 +26,8 @@ public static class Sessions
 
   public static RecordedExercise CreateRecordedExercise(
     ExerciseBlueprint? exerciseBlueprint = null,
-    Func<RecordedExercise, RecordedExercise>? transform = null
+    Func<RecordedExercise, RecordedExercise>? transform = null,
+    bool fillFirstSet = true
   )
   {
     exerciseBlueprint ??= Blueprints.CreateExerciseBlueprint();
@@ -37,9 +39,9 @@ public static class Sessions
           .Range(0, exerciseBlueprint.Sets)
           .Select(
             (i) =>
-              i switch
+              (fillFirstSet, i) switch
               {
-                0
+                (true, 0)
                   => new PotentialSet(
                     new(
                       RepsCompleted: exerciseBlueprint.RepsPerSet,


### PR DESCRIPTION
Fixes #246


This PR fixes a behaviour where a chain of 3 (or more) exercises in superset would not cycle properly. Instead of cycling through each of the exercises in order, it would get to the end of the chain then cycle between the last two exercises.  