### PR TITLE
Format and commit code when renovate updates

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -19,5 +19,17 @@ jobs:
           dotnet-version: 8.0.x
       - name: Install csharpier
         run: dotnet tool restore
+      - name: Format with csharpier
+        # If branch is renovate we want to format and commit the changes
+        if: startsWith(github.event.ref, 'refs/heads/renovate')
+        run: dotnet tool run dotnet-csharpier .
+      - name: Commit changes
+        # If branch is renovate we want to format and commit the changes
+        if: startsWith(github.event.ref, 'refs/heads/renovate')
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: format code with csharpier"
+          commit_author: "Renovate Bot <renovate[bot]@users.noreply.github.com>"
+        # If branch is not renovate we just want to check the formatting
       - name: Check formatting with csharpier
         run: dotnet tool run dotnet-csharpier . --check

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -33,6 +33,7 @@ public record Session(
                 .OrderByDescending(x => x.Item.LastRecordedSet?.Set?.CompletionTime)
                 .Select(x => x.Index)
                 .FirstOrDefault(-1);
+
             var latestExerciseSupersetsWithNext = latestExerciseIndex switch
             {
                 -1 => false, // Not found

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "group:allNonMajor"],
   "schedule": ["before 4am every monday"],
-  "automerge": true
+  "automerge": true,
+
+  "gitIgnoredAuthors": ["renovate[bot]@users.noreply.github.com"]
 }


### PR DESCRIPTION
Renovate often updates csharpier, causing new formatting requirements which manually need to be approved.  Since we will always accept these, let's have the check format command actually apply formatting and commit it whenever we're in a renovate PR