### PR TITLE
Add RSA verification that inbox message came from the user who it relates to

### DIFF
--- a/LiftLog.Api/LiftLog.Api.csproj
+++ b/LiftLog.Api/LiftLog.Api.csproj
@@ -7,6 +7,8 @@
         <InvariantGlobalization>true</InvariantGlobalization>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ContainerRepository>liftlog-api</ContainerRepository>
+        <!-- Enums not handled exhaustively with numbers -->
+        <NoWarn>CS8524</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/LiftLog.Api/Service/PurchaseVerificationService.cs
+++ b/LiftLog.Api/Service/PurchaseVerificationService.cs
@@ -17,7 +17,6 @@ public class PurchaseVerificationService(
                 proToken
             ),
             AppStore.Web => webAuthPurchaseVerificationService.IsValidPurchaseToken(proToken),
-            _ => throw new NotSupportedException(),
         };
     }
 }

--- a/LiftLog.Lib/Services/IEncryptionService.cs
+++ b/LiftLog.Lib/Services/IEncryptionService.cs
@@ -40,6 +40,14 @@ public interface IEncryptionService
     public Task<RsaEncryptedData> EncryptRsaOaepSha256Async(byte[] data, RsaPublicKey publicKey);
 
     public ValueTask<RsaKeyPair> GenerateRsaKeysAsync();
+
+    public Task<byte[]> SignRsaPssSha256Async(byte[] data, RsaPrivateKey privateKey);
+
+    public Task<bool> VerifyRsaPssSha256Async(
+        byte[] data,
+        byte[] signature,
+        RsaPublicKey publicKey
+    );
 }
 
 public record RsaPublicKey(byte[] SpkiPublicKeyBytes);

--- a/LiftLog.Lib/Services/OsEncryptionService.cs
+++ b/LiftLog.Lib/Services/OsEncryptionService.cs
@@ -163,4 +163,37 @@ public class OsEncryptionService : IEncryptionService
             )
         );
     }
+
+    public Task<byte[]> SignRsaPssSha256Async(byte[] data, RsaPrivateKey privateKey)
+    {
+        return Task.Run(() =>
+        {
+            var rsa = RSA.Create();
+
+            rsa.ImportPkcs8PrivateKey(privateKey.Pkcs8PrivateKeyBytes, out _);
+
+            var dataHash = SHA256.HashData(data);
+
+            return rsa.SignData(dataHash, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
+        });
+    }
+
+    public Task<bool> VerifyRsaPssSha256Async(byte[] data, byte[] signature, RsaPublicKey publicKey)
+    {
+        return Task.Run(() =>
+        {
+            var rsa = RSA.Create();
+
+            rsa.ImportSubjectPublicKeyInfo(publicKey.SpkiPublicKeyBytes, out _);
+
+            var dataHash = SHA256.HashData(data);
+
+            return rsa.VerifyData(
+                dataHash,
+                signature,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pss
+            );
+        });
+    }
 }

--- a/LiftLog.Maui/LiftLog.Maui.csproj
+++ b/LiftLog.Maui/LiftLog.Maui.csproj
@@ -11,6 +11,8 @@
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableDefaultCssItems>false</EnableDefaultCssItems>
+        <!-- Enums not handled exhaustively with numbers -->
+        <NoWarn>CS8524</NoWarn>
 
         <!-- Display name -->
         <ApplicationTitle>LiftLog</ApplicationTitle>

--- a/LiftLog.Maui/Services/AppHapticFeedbackService.cs
+++ b/LiftLog.Maui/Services/AppHapticFeedbackService.cs
@@ -11,7 +11,6 @@ public class AppHapticFeedbackService(IHapticFeedback hapticFeedback) : IHapticF
         {
             Ui.Services.HapticFeedbackType.Click => HapticFeedbackType.Click,
             Ui.Services.HapticFeedbackType.LongPress => HapticFeedbackType.LongPress,
-            _ => throw new ArgumentOutOfRangeException(nameof(amount), amount, null),
         };
         hapticFeedback.Perform(mapped);
         return Task.CompletedTask;

--- a/LiftLog.Maui/Services/AppThemeProvider.cs
+++ b/LiftLog.Maui/Services/AppThemeProvider.cs
@@ -21,11 +21,6 @@ public class AppThemeProvider(AppColorService colorUpdateService) : IThemeProvid
             ThemePreference.FollowSystem => AppTheme.Unspecified,
             ThemePreference.Light => AppTheme.Light,
             ThemePreference.Dark => AppTheme.Dark,
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(themePreference),
-                themePreference,
-                null
-            ),
         };
         if (seed is not null)
         {
@@ -55,11 +50,6 @@ public class AppThemeProvider(AppColorService colorUpdateService) : IThemeProvid
             AppTheme.Unspecified => ThemePreference.FollowSystem,
             AppTheme.Light => ThemePreference.Light,
             AppTheme.Dark => ThemePreference.Dark,
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(Microsoft.Maui.Controls.Application.Current.UserAppTheme),
-                Microsoft.Maui.Controls.Application.Current.UserAppTheme,
-                null
-            ),
         };
     }
 

--- a/LiftLog.Ui/LiftLog.Ui.csproj
+++ b/LiftLog.Ui/LiftLog.Ui.csproj
@@ -6,6 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <!-- Enums not handled exhaustively with numbers -->
+    <NoWarn>CS8524</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/LiftLog.Ui/Models/FeedStateDao.cs
+++ b/LiftLog.Ui/Models/FeedStateDao.cs
@@ -216,4 +216,15 @@ internal partial class InboxMessageDao
                 FromUserId = value.UserId,
                 FollowRequest = new FollowRequestDao { Name = value.Name },
             };
+
+    public byte[] GetPayloadBytes()
+    {
+        return MessagePayloadCase switch
+        {
+            MessagePayloadOneofCase.FollowRequest => FollowRequest.ToByteArray(),
+            MessagePayloadOneofCase.FollowResponse => FollowResponse.ToByteArray(),
+            MessagePayloadOneofCase.UnfollowNotification => UnfollowNotification.ToByteArray(),
+            MessagePayloadOneofCase.None => [],
+        };
+    }
 }

--- a/LiftLog.Ui/Models/UserEvent.proto
+++ b/LiftLog.Ui/Models/UserEvent.proto
@@ -29,7 +29,7 @@ message InboxMessageDao {
         FollowResponseDao follow_response = 3;
         UnFollowNotification unfollow_notification = 4;
     }
-    // The signature of the [message + the to_user_id], signed with the private key of the from_user_id
+    // The signature of the [message +from_user_id+ the to_user_id], signed with the private key of the from_user_id
     bytes signature = 5;
 }
 

--- a/LiftLog.Ui/Models/UserEvent.proto
+++ b/LiftLog.Ui/Models/UserEvent.proto
@@ -29,6 +29,8 @@ message InboxMessageDao {
         FollowResponseDao follow_response = 3;
         UnFollowNotification unfollow_notification = 4;
     }
+    // The signature of the [message + the to_user_id], signed with the private key of the from_user_id
+    bytes signature = 5;
 }
 
 message FollowRequestDao {

--- a/LiftLog.Ui/Services/FeedFollowService.cs
+++ b/LiftLog.Ui/Services/FeedFollowService.cs
@@ -22,7 +22,11 @@ public class FeedFollowService(
         };
         inboxMessage.Signature = ByteString.CopyFrom(
             await encryptionService.SignRsaPssSha256Async(
-                [.. inboxMessage.GetPayloadBytes(), .. toFollow.Id.ToByteArray()],
+                [
+                    .. inboxMessage.GetPayloadBytes(),
+                    .. identity.Id.ToByteArray(),
+                    .. toFollow.Id.ToByteArray(),
+                ],
                 identity.RsaKeyPair.PrivateKey
             )
         );
@@ -73,7 +77,11 @@ public class FeedFollowService(
         };
         inboxMessage.Signature = ByteString.CopyFrom(
             await encryptionService.SignRsaPssSha256Async(
-                [.. inboxMessage.GetPayloadBytes(), .. request.UserId.ToByteArray()],
+                [
+                    .. inboxMessage.GetPayloadBytes(),
+                    .. identity.Id.ToByteArray(),
+                    .. request.UserId.ToByteArray(),
+                ],
                 identity.RsaKeyPair.PrivateKey
             )
         );
@@ -109,7 +117,11 @@ public class FeedFollowService(
         };
         inboxMessage.Signature = ByteString.CopyFrom(
             await encryptionService.SignRsaPssSha256Async(
-                [.. inboxMessage.GetPayloadBytes(), .. request.UserId.ToByteArray()],
+                [
+                    .. inboxMessage.GetPayloadBytes(),
+                    .. identity.Id.ToByteArray(),
+                    .. request.UserId.ToByteArray(),
+                ],
                 identity.RsaKeyPair.PrivateKey
             )
         );

--- a/LiftLog.Ui/Services/FeedFollowService.cs
+++ b/LiftLog.Ui/Services/FeedFollowService.cs
@@ -20,6 +20,12 @@ public class FeedFollowService(
             FromUserId = identity.Id,
             FollowRequest = new FollowRequestDao { Name = identity.Name },
         };
+        inboxMessage.Signature = ByteString.CopyFrom(
+            await encryptionService.SignRsaPssSha256Async(
+                [.. inboxMessage.GetPayloadBytes(), .. toFollow.Id.ToByteArray()],
+                identity.RsaKeyPair.PrivateKey
+            )
+        );
         var response = await feedApiService.PutInboxMessageAsync(
             new PutInboxMessageRequest(
                 ToUserId: toFollow.Id,
@@ -65,6 +71,12 @@ public class FeedFollowService(
                 },
             },
         };
+        inboxMessage.Signature = ByteString.CopyFrom(
+            await encryptionService.SignRsaPssSha256Async(
+                [.. inboxMessage.GetPayloadBytes(), .. request.UserId.ToByteArray()],
+                identity.RsaKeyPair.PrivateKey
+            )
+        );
         var encryptedMessage = await encryptionService.EncryptRsaOaepSha256Async(
             inboxMessage.ToByteArray(),
             userPublicKey
@@ -95,6 +107,12 @@ public class FeedFollowService(
             FromUserId = identity.Id,
             FollowResponse = new FollowResponseDao { Rejected = new FollowResponseRejectedDao() },
         };
+        inboxMessage.Signature = ByteString.CopyFrom(
+            await encryptionService.SignRsaPssSha256Async(
+                [.. inboxMessage.GetPayloadBytes(), .. request.UserId.ToByteArray()],
+                identity.RsaKeyPair.PrivateKey
+            )
+        );
         RsaEncryptedData? encryptedMessage;
         try
         {

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -173,7 +173,6 @@ else
         SessionTarget.WorkoutSession => CurrentSessionState.Value.WorkoutSession,
         SessionTarget.HistorySession => CurrentSessionState.Value.HistorySession,
         SessionTarget.FeedSession => CurrentSessionState.Value.FeedSession,
-        _ => throw new InvalidOperationException("Invalid session target")
     } ?? Session.Empty;
 
     [EditorRequired] [Parameter] public ImmutableDictionary<KeyedExerciseBlueprint, ImmutableListValue<DatedRecordedExercise>> PreviouslyCompleted { get; set; } = null!;

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionEffects.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionEffects.cs
@@ -26,7 +26,6 @@ public class CurrentSessionEffects(
             SessionTarget.WorkoutSession => state.Value.WorkoutSession,
             SessionTarget.HistorySession => state.Value.HistorySession,
             SessionTarget.FeedSession => state.Value.FeedSession,
-            _ => throw new Exception(),
         };
         if (session is not null)
             await progressRepository.SaveCompletedSessionAsync(session);
@@ -54,7 +53,6 @@ public class CurrentSessionEffects(
             SessionTarget.WorkoutSession => state.Value.WorkoutSession,
             SessionTarget.HistorySession => state.Value.HistorySession,
             SessionTarget.FeedSession => state.Value.FeedSession,
-            _ => throw new Exception(),
         };
         if (session?.NextExercise is not null && session.LastExercise is not null)
         {
@@ -77,7 +75,6 @@ public class CurrentSessionEffects(
             SessionTarget.WorkoutSession => state.Value.WorkoutSession,
             SessionTarget.HistorySession => state.Value.HistorySession,
             SessionTarget.FeedSession => state.Value.FeedSession,
-            _ => throw new Exception(),
         };
         if (session?.NextExercise is not null)
         {

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
@@ -364,7 +364,6 @@ public static class CurrentSessionReducers
             SessionTarget.WorkoutSession => state with { WorkoutSession = session },
             SessionTarget.HistorySession => state with { HistorySession = session },
             SessionTarget.FeedSession => state with { FeedSession = session },
-            _ => throw new Exception(),
         };
 
     private static CurrentSessionState WithActiveSession(
@@ -383,7 +382,6 @@ public static class CurrentSessionReducers
                 HistorySession = sessionMap(state.HistorySession),
             },
             SessionTarget.FeedSession => state with { FeedSession = sessionMap(state.FeedSession) },
-            _ => throw new Exception(),
         };
 
     private static Session? ActiveSession(this CurrentSessionState state, SessionTarget target) =>
@@ -392,6 +390,5 @@ public static class CurrentSessionReducers
             SessionTarget.WorkoutSession => state.WorkoutSession,
             SessionTarget.HistorySession => state.HistorySession,
             SessionTarget.FeedSession => state.FeedSession,
-            _ => throw new Exception(),
         };
 }

--- a/LiftLog.Web/LiftLog.Web.csproj
+++ b/LiftLog.Web/LiftLog.Web.csproj
@@ -6,6 +6,8 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <ImplicitUsings>enable</ImplicitUsings>
 
+        <!-- Enums not handled exhaustively with numbers -->
+        <NoWarn>CS8524</NoWarn>
         <!-- <RunAOTCompilation>true</RunAOTCompilation>
         <RunAOTCompilationAfterBuild>true</RunAOTCompilationAfterBuild>
         <WasmNativeStrip>false</WasmNativeStrip> -->

--- a/LiftLog.Web/Services/JsEncryptionService.cs
+++ b/LiftLog.Web/Services/JsEncryptionService.cs
@@ -64,4 +64,18 @@ public class JsEncryptionService(IJSRuntime jSRuntime) : IEncryptionService
     {
         return jSRuntime.InvokeAsync<RsaKeyPair>("CryptoUtils.generateRsaKeys");
     }
+
+    public Task<byte[]> SignRsaPssSha256Async(byte[] data, RsaPrivateKey privateKey)
+    {
+        return jSRuntime
+            .InvokeAsync<byte[]>("CryptoUtils.signRsaPssSha256Async", data, privateKey)
+            .AsTask();
+    }
+
+    public Task<bool> VerifyRsaPssSha256Async(byte[] data, byte[] signature, RsaPublicKey publicKey)
+    {
+        return jSRuntime
+            .InvokeAsync<bool>("CryptoUtils.verifyRsaPssSha256Async", data, signature, publicKey)
+            .AsTask();
+    }
 }

--- a/LiftLog.Web/Services/WebThemeProvider.cs
+++ b/LiftLog.Web/Services/WebThemeProvider.cs
@@ -71,11 +71,6 @@ public class WebThemeProvider : IThemeProvider
             ThemePreference.FollowSystem => windowThemePrefersDark ? Dark() : Light(),
             ThemePreference.Light => Light(),
             ThemePreference.Dark => Dark(),
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(themePreference),
-                themePreference,
-                null
-            ),
         };
         dispatcher.Dispatch(
             new ThemeColorUpdatedAction(

--- a/LiftLog.Web/wwwroot/crypto-utils.ts
+++ b/LiftLog.Web/wwwroot/crypto-utils.ts
@@ -169,6 +169,40 @@ const decryptRsaOaepSha256Async = async function (
   return new Uint8Array(decryptedChunks.reduce((acc, chunk) => [...acc, ...chunk], [] as number[]));
 };
 
+const signRsaPssSha256Async = async function (data: Uint8Array, privateKey: RsaPrivateKey): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    privateKey.pkcs8PrivateKeyBytes,
+    {
+      name: "RSA-PSS",
+      hash: "SHA-256",
+    } satisfies RsaHashedImportParams,
+    true,
+    ["sign"]
+  );
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return new Uint8Array(await crypto.subtle.sign("RSA-PSS", key, hash));
+};
+
+const verifyRsaPssSha256Async = async function (
+  data: Uint8Array,
+  signature: Uint8Array,
+  publicKey: RsaPublicKey
+): Promise<boolean> {
+  const key = await crypto.subtle.importKey(
+    "spki",
+    publicKey.spkiPublicKeyBytes,
+    {
+      name: "RSA-PSS",
+      hash: "SHA-256",
+    } satisfies RsaHashedImportParams,
+    true,
+    ["verify"]
+  );
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return crypto.subtle.verify("RSA-PSS", key, signature, hash);
+};
+
 var CryptoUtils = {
   generateAesKey,
   signRsa256PssAndEncryptAesCbcAsync,
@@ -176,6 +210,8 @@ var CryptoUtils = {
   generateRsaKeys,
   encryptRsaOaepSha256Async,
   decryptRsaOaepSha256Async,
+  signRsaPssSha256Async,
+  verifyRsaPssSha256Async,
 };
 
 interface RsaPublicKey {


### PR DESCRIPTION
Basically it was possible to forge an inbox message (such as unfollow a user) by:

`MaliciousUser`
1. Creating an InboxMessage saying to `Unfollow[SubjectUserId=UserA]`
2. Signing/encrypting that message with `VictimUser`'s RSA key
3. Sending the encrypted message to `VictimUser`

When `VictimUser` receives the message, they see a message which is  sent by `MaliciousUser`, however the only verification is that the message is for `VictimUser` - which it is.  This used to be slightly less of an issue when PublicKeys used to encrypt inbox messages were secret, however they are entirely public now.

This PR remedies this by adding an additional `Signature` field to `InboxMessages` which is:
```
[InnerMessagePayloadBytes,ToUserId,SubjectUserId]
```

Signed with the private key of the SubjectUserId.  Therefore, a valid message for a SubjectUserId (such as above UserA) cannot be created without having their private key.