### PR TITLE
Fix: finish session when last exercise is superset

### DIFF
--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -76,7 +76,10 @@ public record Session(
                     indexToJumpBackTo++;
                 }
 
-                return RecordedExercises[indexToJumpBackTo];
+                if (indexToJumpBackTo < RecordedExercises.Count)
+                {
+                    return RecordedExercises[indexToJumpBackTo];
+                }
             }
 
             return RecordedExercises

--- a/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
+++ b/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
@@ -179,6 +179,22 @@ public class SessionSupersetTests
                   .Be(session.RecordedExercises[3].Blueprint.Name);
               });
           });
+
+        Describe("and the last completed set was exercise 6 (last exercise and superset with 5)")
+          .As(() =>
+          {
+            BeforeEach(() =>
+            {
+              session = CycleExerciseReps(6, 0);
+            });
+
+            It("Should end the session")
+              .When(() =>
+              {
+                var nextExercise = session.NextExercise;
+                nextExercise.Should().BeNull();
+              });
+          });
       }
     );
 


### PR DESCRIPTION
In a session with the second to last exercise marked as superset (so that is supersets with the last exercise), it was not possible to complete the session.

Additional fix for #246