### PR TITLE
Fix: finish session when last exercise is superset

### DIFF
--- a/tests/LiftLog.Tests.App/Reducers/CurrentSessionReducerTests.cs
+++ b/tests/LiftLog.Tests.App/Reducers/CurrentSessionReducerTests.cs
@@ -17,6 +17,7 @@ public class CurrentSessionReducerTests
               .RecordedExercises.SetItem(
                 0,
                 Sessions.CreateRecordedExercise(
+                  exerciseIndex: 0,
                   null,
                   exercise =>
                     exercise with
@@ -33,6 +34,7 @@ public class CurrentSessionReducerTests
               .SetItem(
                 1,
                 Sessions.CreateRecordedExercise(
+                  exerciseIndex: 1,
                   null,
                   exercise =>
                     exercise with

--- a/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
+++ b/tests/LiftLog.Tests.App/SessionBehaviors/SessionSuperset.cs
@@ -50,7 +50,7 @@ public class SessionSupersetTests
                   Exercise(5, supersetWithNext: false),
                 ],
               },
-              fillFirstSet: false
+              fillSets: []
             )
         );
 
@@ -180,21 +180,6 @@ public class SessionSupersetTests
               });
           });
 
-        Describe("and the last completed set was exercise 6 (last exercise and superset with 5)")
-          .As(() =>
-          {
-            BeforeEach(() =>
-            {
-              session = CycleExerciseReps(6, 0);
-            });
-
-            It("Should end the session")
-              .When(() =>
-              {
-                var nextExercise = session.NextExercise;
-                nextExercise.Should().BeNull();
-              });
-          });
       }
     );
 
@@ -213,7 +198,7 @@ public class SessionSupersetTests
                 Exercise(2, supersetWithNext: false),
               ],
             },
-            fillFirstSet: false
+            fillSets: []
           );
         });
 
@@ -279,7 +264,7 @@ public class SessionSupersetTests
                 Exercise(2, supersetWithNext: true),
               ],
             },
-            fillFirstSet: false
+            fillSets: []
           );
         });
 
@@ -348,6 +333,33 @@ public class SessionSupersetTests
                   .Blueprint.Name.Should()
                   .Be(session.RecordedExercises[2].Blueprint.Name);
               });
+          });
+      });
+
+    Describe("When the last exercise is a completed superset")
+      .As(() =>
+      {
+        BeforeEach(() =>
+        {
+          session = Sessions.CreateSession(
+            sessionBlueprint: Blueprints.CreateSessionBlueprint() with
+            {
+              Exercises =
+              [
+                Exercise(0, supersetWithNext: false),
+                Exercise(1, supersetWithNext: true),
+                Exercise(2, supersetWithNext: false),
+              ],
+            },
+            fillSets: [0, 1, 2]
+          );
+        });
+
+        It("Should end the session")
+          .When(() =>
+          {
+            var nextExercise = session.NextExercise;
+            nextExercise.Should().BeNull();
           });
       });
   }

--- a/tests/LiftLog.Tests.App/Sessions.cs
+++ b/tests/LiftLog.Tests.App/Sessions.cs
@@ -7,7 +7,7 @@ public static class Sessions
   public static Session CreateSession(
     SessionBlueprint? sessionBlueprint = null,
     Func<Session, Session>? transform = null,
-    bool fillFirstSet = true
+    int[]? fillSets = null
   )
   {
     sessionBlueprint ??= Blueprints.CreateSessionBlueprint();
@@ -16,7 +16,7 @@ public static class Sessions
         Id: Guid.NewGuid(),
         Blueprint: sessionBlueprint,
         RecordedExercises: sessionBlueprint
-          .Exercises.Select(x => CreateRecordedExercise(x, fillFirstSet: fillFirstSet))
+          .Exercises.Select((x, i) => CreateRecordedExercise(i, x, fillSets: fillSets))
           .ToImmutableList(),
         Date: DateOnly.Parse("2021-04-05"),
         Bodyweight: null
@@ -25,9 +25,10 @@ public static class Sessions
   }
 
   public static RecordedExercise CreateRecordedExercise(
+    int exerciseIndex,
     ExerciseBlueprint? exerciseBlueprint = null,
     Func<RecordedExercise, RecordedExercise>? transform = null,
-    bool fillFirstSet = true
+    int[]? fillSets = null
   )
   {
     exerciseBlueprint ??= Blueprints.CreateExerciseBlueprint();
@@ -39,17 +40,15 @@ public static class Sessions
           .Range(0, exerciseBlueprint.Sets)
           .Select(
             (i) =>
-              (fillFirstSet, i) switch
-              {
-                (true, 0) => new PotentialSet(
+              fillSets != null && fillSets.Contains(i)
+              ? new PotentialSet(
                   new(
                     RepsCompleted: exerciseBlueprint.RepsPerSet,
-                    CompletionTime: TimeOnly.Parse("14:32:00")
+                    CompletionTime: TimeOnly.Parse("14:32:00").AddMinutes(exerciseIndex * 5 + i)
                   ),
                   0
-                ),
-                _ => new PotentialSet(null, 0),
-              }
+                )
+               : new PotentialSet(null, 0)
           )
           .ToImmutableList(),
         Notes: null,


### PR DESCRIPTION
Accidentally checked in WiP for the unit test in #254 