### PR TITLE
Add a mechanism for Automatic Remote Backups

### DIFF
--- a/.github/workflows/backupserver-build.yml
+++ b/.github/workflows/backupserver-build.yml
@@ -1,0 +1,19 @@
+name: Build BackupServer
+
+on:
+  push:
+    branches-ignore: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Build
+        run: dotnet build
+        working-directory: ./LiftLog.BackupServer

--- a/.github/workflows/backupserver-publish.yml
+++ b/.github/workflows/backupserver-publish.yml
@@ -1,0 +1,39 @@
+name: Publish BackupServer docker image to GitHub Container Registry
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  upload:
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: dotnet publish --os linux --arch x64 /t:PublishContainer -c Release
+        working-directory: LiftLog.BackupServer
+      - name: Tag image
+        run: docker tag liftlog-backupserver:latest ghcr.io/liammorrow/liftlog:backupserver
+      - name: Push image
+        run: docker push ghcr.io/liammorrow/liftlog:backupserver

--- a/.gitignore
+++ b/.gitignore
@@ -259,7 +259,6 @@ Generated_Code/
 # to a newer Visual Studio version. Backup files are not needed,
 # because we have git ;-)
 _UpgradeReport_Files/
-Backup*/
 UpgradeLog*.XML
 UpgradeLog*.htm
 ServiceFabricBackup/

--- a/Docs/RemoteBackup.md
+++ b/Docs/RemoteBackup.md
@@ -1,0 +1,24 @@
+# Automatic Remote Backup
+
+LiftLog supports an automatic remote backup, whereby every time the app is opened, if there have been changes, it can send a backup to a remote server. It supports auth through an `X-API-KEY` header.
+
+Setting up this remote server is somewhat involved and recommended for advanced users who are comfortable running a server.
+
+## Notes on HTTPS
+
+Mobile devices require that HTTPS is used for connections, which means that users of this feature will require that the server supports HTTPS (could be through a reverse proxy such as nginx). As there are many ways to achieve this, and it is heavily context dependant, this document assumes the reader can do this without guidance.
+
+## Setting up the app
+
+Within the LiftLog app, navigate to `Settings -> Backup and Restore -> Automatic Remote Backup`. On this screen, two values can be set:
+
+```
+Endpoint - Required.  This is the https endpoint which will receive the backups
+Api Key - Optional (recommended).  LiftLog will pass this value as an X-API-Key header, allowing for basic auth.
+```
+
+The endpoint should simply accept a `POST` request where the body will be the raw bytes of a `liftlogbackup.gz` file. It MUST NOT decompress the gzipped data, the LiftLog app only understands gzipped files.
+
+An example implementation which stores the backups as files on disk can be found [here](../LiftLog.BackupServer/). Note that this server requires a reverse proxy for HTTPS termination.
+
+You can test if it is correctly set up by pressing the `Test` button in app. Any errors will be displayed, or a success toast on success. Ensure you hit `Save` to persist your configuration.

--- a/LiftLog.BackupServer/LiftLog.BackupServer.csproj
+++ b/LiftLog.BackupServer/LiftLog.BackupServer.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/LiftLog.BackupServer/LiftLog.BackupServer.csproj
+++ b/LiftLog.BackupServer/LiftLog.BackupServer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ContainerRepository>liftlog-backupserver</ContainerRepository>
   </PropertyGroup>
 
 </Project>

--- a/LiftLog.BackupServer/Program.cs
+++ b/LiftLog.BackupServer/Program.cs
@@ -1,0 +1,54 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Mvc;
+
+var builder = WebApplication.CreateBuilder(args);
+
+const string ApiKeyHeaderName = "X-API-Key";
+const string ApiKeyName = "ApiKey";
+
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(builder =>
+    {
+        builder.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
+    });
+});
+
+var app = builder.Build();
+
+app.UseCors();
+
+app.UseHttpsRedirection();
+
+app.MapPost(
+    "/backup",
+    async (
+        Stream body,
+        [FromHeader(Name = ApiKeyHeaderName)] string? apiKey,
+        [FromQuery] string? user,
+        IConfiguration configuration
+    ) =>
+    {
+        if (configuration.GetValue<string>(ApiKeyName) != apiKey)
+            return Results.Unauthorized();
+
+        var backupDirectory = configuration.GetValue<string>("BackupDirectory");
+
+        Directory.CreateDirectory(backupDirectory ?? "./");
+        Directory.CreateDirectory(Path.Combine(backupDirectory ?? "./", user ?? ""));
+
+        using var file = File.OpenWrite(
+            Path.Combine(
+                backupDirectory ?? "./",
+                user ?? "",
+                $"{DateTimeOffset.UtcNow:O}.liftlogbackup.gz"
+            )
+        );
+
+        await body.CopyToAsync(file);
+
+        return Results.Ok();
+    }
+);
+
+app.Run();

--- a/LiftLog.BackupServer/Program.cs
+++ b/LiftLog.BackupServer/Program.cs
@@ -18,8 +18,6 @@ var app = builder.Build();
 
 app.UseCors();
 
-app.UseHttpsRedirection();
-
 app.MapPost(
     "/backup",
     async (

--- a/LiftLog.BackupServer/Properties/launchSettings.json
+++ b/LiftLog.BackupServer/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:11715",
+      "sslPort": 44361
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5271",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7280;http://localhost:5271",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/LiftLog.BackupServer/README.md
+++ b/LiftLog.BackupServer/README.md
@@ -12,7 +12,7 @@ This header can also optionally accept an `X-API-KEY` header for controlling aut
 
 This POST endpoint accepts a `byte[]` payload which is a LiftLog backup file, gzipped. This file can be used unchanged (DO NOT decompress it) in the LiftLog app to restore all data it contains.
 
-The server has two optional configuration options:
+The server has two optional configuration options which can be specified as environment variables:
 
 ```
 BackupDirectory - A path to where backups will be stored

--- a/LiftLog.BackupServer/README.md
+++ b/LiftLog.BackupServer/README.md
@@ -1,0 +1,26 @@
+## LiftLog Backup Server
+
+This project contains a simple server which can be used as a remote server for the automatic remote backup feature.
+
+It exposes a simple endpoint:
+
+```
+POST /backup?user={OPTIONAL_USER_NAME}
+```
+
+This header can also optionally accept an `X-API-KEY` header for controlling auth to it.
+
+This POST endpoint accepts a `byte[]` payload which is a LiftLog backup file, gzipped. This file can be used unchanged (DO NOT decompress it) in the LiftLog app to restore all data it contains.
+
+The server has two optional configuration options:
+
+```
+BackupDirectory - A path to where backups will be stored
+ApiKey - The API key that the client must pass as an X-API-KEY header
+```
+
+When the endpoint receives a backup, it simply stores it as a timestamped file in the backup directory. If the `user` query param is specified, it will be within a subdirectory with that `user` value.
+
+### Notes on HTTPS
+
+Mobile devices require that HTTPS is used for all requests, and LiftLog validates the endpoint you specify to ensure it is HTTPS. As it stands, this server will require a reverse proxy such as NGINX to terminate a HTTPS connection and route to HTTP.

--- a/LiftLog.BackupServer/appsettings.json
+++ b/LiftLog.BackupServer/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/LiftLog.Ui/LiftLog.Ui.csproj
+++ b/LiftLog.Ui/LiftLog.Ui.csproj
@@ -6,8 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <!-- Enums not handled exhaustively with numbers -->
-    <NoWarn>CS8524</NoWarn>
+    <!-- Enums not handled exhaustively with numbers; No await in async -->
+    <NoWarn>CS8524;CS1998</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -8,6 +8,7 @@
 
 @inject IState<ProgramState> ProgramState
 @inject IState<AppState> AppState
+@inject IState<SettingsState> SettingsState
 @inject IState<CurrentSessionState> CurrentSessionState
 @inject IDispatcher Dispatcher
 @inject NavigationManager NavigationManager
@@ -99,6 +100,7 @@ else
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(false));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new PublishUnpublishedSessionsAction());
+        Dispatcher.Dispatch(new ExecuteRemoteBackupAction(SettingsState.Value.RemoteBackupSettings));
         await base.OnInitializedAsync();
     }
 

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
@@ -65,7 +65,7 @@
 
     private void Test(MouseEventArgs _)
     {
-        Dispatcher.Dispatch(new ExecuteRemoteBackupAction(new(EndpointValue, ApiKeyValue, IncludeFeedAccount)));
+        Dispatcher.Dispatch(new ExecuteRemoteBackupAction(new(EndpointValue, ApiKeyValue, IncludeFeedAccount), Force: true));
     }
 
     private void Save(MouseEventArgs _)

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
@@ -1,0 +1,111 @@
+@page "/settings/backup-and-restore/remote-backup"
+@inject IDispatcher Dispatcher
+@inject IState<SettingsState> SettingsState
+
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<Card Type="Card.CardType.Filled" class="mx-6 mb-4">
+    <div>
+        This is an advanced feature which enables LiftLog to send backups to a remote server.
+        <br/>
+        Please read the documentation for instructions on how to set up a remote server.
+    </div>
+    <AppButton OnClick="OpenDocumentation" Type="AppButtonType.Text">Read Documentation</AppButton>
+</Card>
+
+<LabelledForm>
+    <LabelledFormRow Label="Endpoint" Icon="public">
+        <TextField
+            TextFieldType="TextFieldType.Outline"
+            placeholder="https://example.com/backup"
+            Value="@EndpointValue"
+            error-text="@EndpointValueError"
+            error=@(HasEndpointError)
+            OnChange="UpdateEndpoint"
+            SelectAllOnFocus=false
+            required>
+        </TextField>
+    </LabelledFormRow>
+    <LabelledFormRow Label="API Key" Icon="vpn_key">
+        <TextField
+            TextFieldType="TextFieldType.Outline"
+            Value="@ApiKeyValue"
+            SelectAllOnFocus=false
+            OnChange="UpdateApiKey">
+        </TextField>
+    </LabelledFormRow>
+    <ListSwitch Headline="Backup feed account" SupportingText="Include your feed account data in backups" Value=@IncludeFeedAccount OnSwitched="UpdateIncludeFeedAccount"/>
+</LabelledForm>
+
+<div class="flex justify-end gap-4 m-6">
+    <AppButton Type="AppButtonType.Text" Disabled=@(string.IsNullOrWhiteSpace(EndpointValue)) OnClick="Test">Test</AppButton>
+    <AppButton Type="AppButtonType.Primary" Disabled=@HasEndpointError OnClick="Save">Save</AppButton>
+</div>
+
+
+@code {
+
+    private string EndpointValue = "";
+    private string EndpointValueError = "";
+
+    private bool HasEndpointError => !string.IsNullOrWhiteSpace(EndpointValueError);
+    private string ApiKeyValue = "";
+
+    private bool IncludeFeedAccount = false;
+
+    protected override void OnInitialized()
+    {
+        Dispatcher.Dispatch(new SetPageTitleAction("Automatic Remote Backup"));
+        Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/backup-and-restore"));
+        base.OnInitialized();
+        EndpointValue = SettingsState.Value.RemoteBackupSettings.Endpoint;
+        ApiKeyValue = SettingsState.Value.RemoteBackupSettings.ApiKey;
+        IncludeFeedAccount = SettingsState.Value.RemoteBackupSettings.IncludeFeedAccount;
+    }
+
+    private void Test(MouseEventArgs _)
+    {
+        Dispatcher.Dispatch(new ExecuteRemoteBackupAction(new(EndpointValue, ApiKeyValue, IncludeFeedAccount)));
+    }
+
+    private void Save(MouseEventArgs _)
+    {
+        if(HasEndpointError)
+        {
+            return;
+        }
+        Dispatcher.Dispatch(new UpdateRemoteBackupSettingsAction(new(EndpointValue, ApiKeyValue, IncludeFeedAccount)));
+        Dispatcher.Dispatch(new ToastAction("Settings saved"));
+    }
+
+    private void OpenDocumentation(MouseEventArgs _)
+    {
+        Dispatcher.Dispatch(new NavigateAction("https://github.com/LiamMorrow/LiftLog/blob/main/Docs/RemoteBackup.md"));
+    }
+
+    private void UpdateEndpoint(string endpoint)
+    {
+        EndpointValue = endpoint;
+        StateHasChanged();
+        if(!string.IsNullOrWhiteSpace(endpoint) && !endpoint.StartsWith("https://"))
+        {
+            EndpointValueError = "Endpoint must start with https://";
+        }
+        else
+        {
+            EndpointValueError = "";
+        }
+    }
+
+    private void UpdateApiKey(string apiKey)
+    {
+        ApiKeyValue = apiKey;
+        StateHasChanged();
+    }
+
+    private void UpdateIncludeFeedAccount(bool includeFeedAccount)
+    {
+        IncludeFeedAccount = includeFeedAccount;
+        StateHasChanged();
+    }
+}

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
@@ -16,6 +16,11 @@
         <span slot="headline">Import data</span>
         <span slot="supporting-text">Import data from a file to restore</span>
     </md-list-item>
+    <md-list-item type="button" class="text-left" multi-line-supporting-text @onclick="RemoteBackup">
+        <md-icon slot="start">cloud_upload</md-icon>
+        <span slot="headline">Automatic remote backup</span>
+        <span slot="supporting-text">Send backups to a remote server. Advanced users only</span>
+    </md-list-item>
 </md-list>
 
 
@@ -74,6 +79,8 @@
         Dispatcher.Dispatch(new ImportDataAction());
         Dispatcher.Dispatch(new SetStatsIsDirtyAction(true));
     }
+
+    private void RemoteBackup() => Dispatcher.Dispatch(new NavigateAction("/settings/backup-and-restore/remote-backup"));
 
     private void ExportData(bool includeFeed) => Dispatcher.Dispatch(new ExportDataAction(includeFeed));
 

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -168,4 +168,14 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
             remoteBackupSettings.IncludeFeedAccount.ToString()
         );
     }
+
+    public async Task SetLastSuccessfulRemoteBackupHashAsync(string hash)
+    {
+        await preferenceStore.SetItemAsync("lastSuccessfulRemoteBackupHash", hash);
+    }
+
+    public async Task<string?> GetLastSuccessfulRemoteBackupHashAsync()
+    {
+        return await preferenceStore.GetItemAsync("lastSuccessfulRemoteBackupHash");
+    }
 }

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -1,4 +1,5 @@
 using LiftLog.Ui.Store.App;
+using LiftLog.Ui.Store.Settings;
 
 namespace LiftLog.Ui.Services;
 
@@ -140,5 +141,31 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
             return result;
         else
             return AppRatingResult.NotRated;
+    }
+
+    public async Task<RemoteBackupSettings> GetRemoteBackupSettingsAsync()
+    {
+        var (endpoint, apiKey, includeFeedAccount) = await (
+            preferenceStore.GetItemAsync("remoteBackupSettings.Endpoint").AsTask(),
+            preferenceStore.GetItemAsync("remoteBackupSettings.ApiKey").AsTask(),
+            preferenceStore.GetItemAsync("remoteBackupSettings.IncludeFeedAccount").AsTask()
+        );
+        return new RemoteBackupSettings(endpoint ?? "", apiKey ?? "", includeFeedAccount is "True");
+    }
+
+    public async Task SetRemoteBackupSettingsAsync(RemoteBackupSettings remoteBackupSettings)
+    {
+        await preferenceStore.SetItemAsync(
+            "remoteBackupSettings.Endpoint",
+            remoteBackupSettings.Endpoint
+        );
+        await preferenceStore.SetItemAsync(
+            "remoteBackupSettings.ApiKey",
+            remoteBackupSettings.ApiKey
+        );
+        await preferenceStore.SetItemAsync(
+            "remoteBackupSettings.IncludeFeedAccount",
+            remoteBackupSettings.IncludeFeedAccount.ToString()
+        );
     }
 }

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -44,3 +44,5 @@ public record SetStatusBarFixAction(bool StatusBarFix);
 public record ExecuteRemoteBackupAction(RemoteBackupSettings Settings);
 
 public record UpdateRemoteBackupSettingsAction(RemoteBackupSettings Settings);
+
+public record SetLastSuccessfulRemoteBackupHashAction(string Hash);

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -40,3 +40,7 @@ public record SetTipToShowAction(int TipToShow);
 public record SetShowFeedAction(bool ShowFeed);
 
 public record SetStatusBarFixAction(bool StatusBarFix);
+
+public record ExecuteRemoteBackupAction(RemoteBackupSettings Settings);
+
+public record UpdateRemoteBackupSettingsAction(RemoteBackupSettings Settings);

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -41,7 +41,7 @@ public record SetShowFeedAction(bool ShowFeed);
 
 public record SetStatusBarFixAction(bool StatusBarFix);
 
-public record ExecuteRemoteBackupAction(RemoteBackupSettings Settings);
+public record ExecuteRemoteBackupAction(RemoteBackupSettings Settings, bool Force = false);
 
 public record UpdateRemoteBackupSettingsAction(RemoteBackupSettings Settings);
 

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -214,4 +214,19 @@ public class SettingsEffects(
     {
         await preferencesRepository.SetStatusBarFixAsync(action.StatusBarFix);
     }
+
+    [EffectMethod]
+    public async Task ExecuteRemoteBackup(ExecuteRemoteBackupAction action, IDispatcher __)
+    {
+        //
+    }
+
+    [EffectMethod]
+    public async Task UpdateAutomaticBackupSettings(
+        UpdateRemoteBackupSettingsAction action,
+        IDispatcher __
+    )
+    {
+        await preferencesRepository.SetRemoteBackupSettingsAsync(action.Settings);
+    }
 }

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -227,7 +227,7 @@ public class SettingsEffects(
         var exportedData = await GetDataExportAsync(includeFeedAccount);
         var bytes = exportedData.ToByteArray();
 
-        var hash = SHA256.Create().ComputeHash(bytes);
+        var hash = SHA256.HashData(bytes);
         var hashString = Convert.ToHexString(hash);
 
         if (settingsState.Value.LastSuccessfulRemoteBackupHash == hashString)

--- a/LiftLog.Ui/Store/Settings/SettingsFeature.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsFeature.cs
@@ -19,6 +19,7 @@ public class SettingsFeature : Feature<SettingsState>
             TipToShow: 1,
             ShowFeed: true,
             StatusBarFix: false,
-            RestNotifications: true
+            RestNotifications: true,
+            RemoteBackupSettings: new RemoteBackupSettings(string.Empty, string.Empty, false)
         );
 }

--- a/LiftLog.Ui/Store/Settings/SettingsFeature.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsFeature.cs
@@ -20,6 +20,7 @@ public class SettingsFeature : Feature<SettingsState>
             ShowFeed: true,
             StatusBarFix: false,
             RestNotifications: true,
-            RemoteBackupSettings: new RemoteBackupSettings(string.Empty, string.Empty, false)
+            RemoteBackupSettings: new RemoteBackupSettings(string.Empty, string.Empty, false),
+            LastSuccessfulRemoteBackupHash: string.Empty
         );
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -76,4 +76,10 @@ public static class SettingsReducers
         SettingsState state,
         SetRestNotificationsAction action
     ) => state with { RestNotifications = action.RestNotifications };
+
+    [ReducerMethod]
+    public static SettingsState UpdateRemoteBackupSettings(
+        SettingsState state,
+        UpdateRemoteBackupSettingsAction action
+    ) => state with { RemoteBackupSettings = action.Settings };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -82,4 +82,10 @@ public static class SettingsReducers
         SettingsState state,
         UpdateRemoteBackupSettingsAction action
     ) => state with { RemoteBackupSettings = action.Settings };
+
+    [ReducerMethod]
+    public static SettingsState SetLastSuccessfulRemoteBackupHash(
+        SettingsState state,
+        SetLastSuccessfulRemoteBackupHashAction action
+    ) => state with { LastSuccessfulRemoteBackupHash = action.Hash };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -16,7 +16,8 @@ public record SettingsState(
     bool ShowFeed,
     bool StatusBarFix,
     bool RestNotifications,
-    RemoteBackupSettings RemoteBackupSettings
+    RemoteBackupSettings RemoteBackupSettings,
+    string LastSuccessfulRemoteBackupHash
 );
 
 public record RemoteBackupSettings(string Endpoint, string ApiKey, bool IncludeFeedAccount)

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -15,5 +15,11 @@ public record SettingsState(
     int TipToShow,
     bool ShowFeed,
     bool StatusBarFix,
-    bool RestNotifications
+    bool RestNotifications,
+    RemoteBackupSettings RemoteBackupSettings
 );
+
+public record RemoteBackupSettings(string Endpoint, string ApiKey, bool IncludeFeedAccount)
+{
+    public bool Enabled => !string.IsNullOrWhiteSpace(Endpoint);
+}

--- a/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
@@ -23,7 +23,8 @@ public class SettingsStateInitMiddleware(
                 showFeed,
                 statusBarFix,
                 restNotifications,
-                remoteBackupSettings
+                remoteBackupSettings,
+                lastSuccessfulRemoteBackupHash
             ) = await (
                 preferencesRepository.GetUseImperialUnitsAsync(),
                 preferencesRepository.GetShowBodyweightAsync(),
@@ -32,7 +33,8 @@ public class SettingsStateInitMiddleware(
                 preferencesRepository.GetShowFeedAsync(),
                 preferencesRepository.GetStatusBarFixAsync(),
                 preferencesRepository.GetRestNotificationsAsync(),
-                preferencesRepository.GetRemoteBackupSettingsAsync()
+                preferencesRepository.GetRemoteBackupSettingsAsync(),
+                preferencesRepository.GetLastSuccessfulRemoteBackupHashAsync()
             );
 
             var state = (SettingsState)store.Features[nameof(SettingsFeature)].GetState() with
@@ -46,6 +48,7 @@ public class SettingsStateInitMiddleware(
                 StatusBarFix = statusBarFix,
                 RestNotifications = restNotifications,
                 RemoteBackupSettings = remoteBackupSettings,
+                LastSuccessfulRemoteBackupHash = lastSuccessfulRemoteBackupHash,
             };
             store.Features[nameof(SettingsFeature)].RestoreState(state);
             sw.Stop();

--- a/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
@@ -22,7 +22,8 @@ public class SettingsStateInitMiddleware(
                 tipToShow,
                 showFeed,
                 statusBarFix,
-                restNotifications
+                restNotifications,
+                remoteBackupSettings
             ) = await (
                 preferencesRepository.GetUseImperialUnitsAsync(),
                 preferencesRepository.GetShowBodyweightAsync(),
@@ -30,7 +31,8 @@ public class SettingsStateInitMiddleware(
                 preferencesRepository.GetTipToShowAsync(),
                 preferencesRepository.GetShowFeedAsync(),
                 preferencesRepository.GetStatusBarFixAsync(),
-                preferencesRepository.GetRestNotificationsAsync()
+                preferencesRepository.GetRestNotificationsAsync(),
+                preferencesRepository.GetRemoteBackupSettingsAsync()
             );
 
             var state = (SettingsState)store.Features[nameof(SettingsFeature)].GetState() with
@@ -43,6 +45,7 @@ public class SettingsStateInitMiddleware(
                 ShowFeed = showFeed,
                 StatusBarFix = statusBarFix,
                 RestNotifications = restNotifications,
+                RemoteBackupSettings = remoteBackupSettings,
             };
             store.Features[nameof(SettingsFeature)].RestoreState(state);
             sw.Stop();

--- a/LiftLog.sln
+++ b/LiftLog.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiftLog.Tests.Api", "tests\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiftLog.Tests.App", "tests\LiftLog.Tests.App\LiftLog.Tests.App.csproj", "{EAFB4E00-343C-4AA2-9CA0-CD186AC390C7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiftLog.BackupServer", "LiftLog.BackupServer\LiftLog.BackupServer.csproj", "{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -242,6 +244,22 @@ Global
 		{EAFB4E00-343C-4AA2-9CA0-CD186AC390C7}.Release|x64.Build.0 = Release|Any CPU
 		{EAFB4E00-343C-4AA2-9CA0-CD186AC390C7}.Release|x86.ActiveCfg = Release|Any CPU
 		{EAFB4E00-343C-4AA2-9CA0-CD186AC390C7}.Release|x86.Build.0 = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|arm64.Build.0 = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|arm64.ActiveCfg = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|arm64.Build.0 = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|x64.Build.0 = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E81B6EB-97E3-4DD3-8D38-28EADCD2FAB3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/release_notes/whatsnew-en-AU
+++ b/release_notes/whatsnew-en-AU
@@ -1,1 +1,1 @@
-History and stats now show the weights completed when different weights were specified on each set of an exercise.
+Advanced users can now setup remote backups.


### PR DESCRIPTION
This PR solves https://github.com/LiamMorrow/LiftLog/issues/243

It does this by adding a mechanism whereby the LiftLog app can `POST` a raw backup file to an arbitrary web URL whenever it has unbacked up changes.  

<img width="373" alt="image" src="https://github.com/user-attachments/assets/54f551e5-f80e-4515-9f44-7efe5045b195">

As part of this, a simple API project has been added which implements the backup server by persisting these backups to timestamped files on disk. 

Backup process:
```
Whenever the user opens the main page (Upcoming workouts)
If there has been changes since the last backup was sent - POST a backup to the specified endpoint
```

## Notes

It's specified in the documentation, but I'll note it again here.  This feature requires that the endpoint is HTTPS due to restrictions in mobile environments.  
