### PR TITLE
Ensure that item titles do not overflow

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/ItemTitle.razor
+++ b/LiftLog.Ui/Shared/Presentation/ItemTitle.razor
@@ -1,5 +1,5 @@
 
-<span class="text-xl font-bold flex-shrink text-ellipsis text-nowrap whitespace-nowrap overflow-hidden min-w-0 text-start">@Title</span>
+<span class="text-xl font-bold flex-shrink text-ellipsis max-w-full text-nowrap whitespace-nowrap overflow-hidden min-w-0 text-start">@Title</span>
 
 @code {
     [Parameter][EditorRequired] public string Title { get; set; } = null!;


### PR DESCRIPTION
Fixes an issue where the item titles in stats would overflow their parent container

Fixes: #249

Before:
![image](https://github.com/user-attachments/assets/87c1dccf-f445-4478-91af-8e95c4c5b575)


After:
![image](https://github.com/user-attachments/assets/85a90574-d40f-4e54-a345-28dcf6eb4ced)

