### PR TITLE
Replace previous hold graph with list

### DIFF
--- a/LiftLog.Lib/Util/EnumerableExtensions.cs
+++ b/LiftLog.Lib/Util/EnumerableExtensions.cs
@@ -13,13 +13,6 @@ public static class LinqExtensions
         return source.Select((item, index) => (item, index));
     }
 
-    public static IReadOnlyList<(TSource Item, int Index)> IndexedTuples<TSource>(
-        this IReadOnlyList<TSource> source
-    )
-    {
-        return new IndexedTupleList<TSource>(source);
-    }
-
     public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
         where T : notnull
     {
@@ -98,22 +91,5 @@ public static class LinqExtensions
         }
 
         return immutableDictionaryBuilder.ToImmutable();
-    }
-
-    private class IndexedTupleList<T>(IReadOnlyList<T> source) : IReadOnlyList<(T Item, int Index)>
-    {
-        public (T Item, int Index) this[int index] => (source[index], index);
-
-        public int Count => source.Count;
-
-        public IEnumerator<(T Item, int Index)> GetEnumerator()
-        {
-            return ((IEnumerable<T>)source).IndexedTuples().GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
     }
 }

--- a/LiftLog.Ui/Pages/SessionPage.razor
+++ b/LiftLog.Ui/Pages/SessionPage.razor
@@ -29,7 +29,6 @@
 {
     private ImmutableDictionary<KeyedExerciseBlueprint, ImmutableListValue<DatedRecordedExercise>> previouslyCompleted = ImmutableDictionary<KeyedExerciseBlueprint, ImmutableListValue<DatedRecordedExercise>>.Empty;
 
-
     protected override async Task OnInitializedAsync()
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Session"));

--- a/LiftLog.Ui/Shared/MainLayout.razor
+++ b/LiftLog.Ui/Shared/MainLayout.razor
@@ -58,21 +58,6 @@
 <Microsoft.AspNetCore.Components.Sections.SectionOutlet SectionName="FullscreenDialog"></Microsoft.AspNetCore.Components.Sections.SectionOutlet>
 <Microsoft.AspNetCore.Components.Sections.SectionOutlet SectionName="Dialog"></Microsoft.AspNetCore.Components.Sections.SectionOutlet>
 <Microsoft.AspNetCore.Components.Sections.SectionOutlet SectionName="AndroidNotificationDialog"></Microsoft.AspNetCore.Components.Sections.SectionOutlet>
-<div class="hidden">
-    <ApexChart
-        TItem="DummyChartType"
-        Title=""
-        XAxisType="XAxisType.Datetime">
-
-        <ApexPointSeries TItem="DummyChartType"
-                         Items="new DummyChartType[0]"
-                         Name="Placeholder to load apex charts so it doesn't freeze on load"
-                         SeriesType="SeriesType.Line"
-                         XValue="@(e => DateTime.Now)"
-                         YAggregate="@(e => e.Max(e => e.X))"
-                         OrderByDescending="e => e.X"/>
-    </ApexChart>
-</div>
 <ToastComponent/>
 <HeadContent>
     <title>@AppState.Value.Title</title>
@@ -171,8 +156,4 @@
             Dispatcher.Dispatch(new NavigateAction(AppState.Value.BackNavigationUrl));
         }
     }
-
-
-    private record DummyChartType(int X);
-
 }

--- a/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor
@@ -1,0 +1,65 @@
+@{
+ var splitWeights = (Exercise.PerSetWeight
+    && !Exercise.PotentialSets.All(s => s.Weight == Exercise.Weight))
+    || Exercise.PotentialSets.DistinctBy(x=>x.Set?.RepsCompleted).Count() != 1;
+}
+<span class="flex items-center">
+    @if(ShowName)
+    {
+        <span>@Exercise.Blueprint.Name</span>
+    }
+    @if(ShowSets || ShowWeight)
+    {
+        @if(!splitWeights)
+        {
+        <span class="flex justify-around ml-auto items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
+
+            @if (ShowSets)
+            {
+                <span>
+                    @(Exercise.Blueprint.Sets)x@(Exercise.Blueprint.RepsPerSet)
+                </span>
+                @if(ShowWeight)
+                {
+                    <span class="text-2xs">@@</span>
+                }
+            }
+
+            @if (ShowWeight)
+            {
+                <WeightFormat Weight="@Exercise.Weight"/>
+            }
+        </span>
+        }
+
+        @if (ShowWeight && splitWeights)
+        {
+            <span class="flex ml-auto flex-wrap justify-end gap-1">
+                @foreach(var set in Exercise.PotentialSets)
+                {
+                    if(set.Set?.RepsCompleted == null)
+                    {
+                        continue;
+                    }
+                    <span class="flex items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
+                        @if (ShowSets){
+                            <span>@(set.Set?.RepsCompleted ?? Exercise.Blueprint.RepsPerSet)</span><span class="text-2xs">@@</span>
+                        }
+                        <WeightFormat Weight="@set.Weight"/>
+                    </span>
+                }
+            </span>
+        }
+    }
+</span>
+
+@code
+{
+    [EditorRequired] [Parameter] public RecordedExercise Exercise { get; set; } = null!;
+
+    [Parameter] public bool ShowSets { get; set; }
+
+    [Parameter] public bool ShowWeight { get; set; }
+
+    [Parameter] public bool ShowName { get; set; }
+}

--- a/LiftLog.Ui/Shared/Presentation/IconButton.razor
+++ b/LiftLog.Ui/Shared/Presentation/IconButton.razor
@@ -3,40 +3,37 @@
     case IconButtonType.Standard:
         <md-icon-button
             @attributes="AdditionalAttributes"
-            @onpointerdown="OnPointerDown"
-            @onpointerleave="OnPointerLeave"
-            @onpointercancel="OnPointerCancel"
-            @onpointerup="OnPointerUp" class="pointer-events-auto" @onclick="OnClick" disabled=@Disabled @onclick:stopPropagation="true" @onclick:preventDefault="true">
+            class="pointer-events-auto"
+            @onclick="OnClick" @onclick:stopPropagation="true" @onclick:preventDefault="true"
+            disabled=@Disabled >
             <md-icon>@Icon</md-icon>
         </md-icon-button>
         break;
     case IconButtonType.Filled:
         <md-filled-icon-button
             @attributes="AdditionalAttributes"
-            @onpointerdown="OnPointerDown"
-            @onpointerleave="OnPointerLeave"
-            @onpointercancel="OnPointerCancel"
-            @onpointerup="OnPointerUp" class="pointer-events-auto" @onclick="OnClick" disabled=@Disabled @onclick:stopPropagation="true" @onclick:preventDefault="true">
+            class="pointer-events-auto"
+            @onclick="OnClick" @onclick:stopPropagation="true" @onclick:preventDefault="true"
+            disabled=@Disabled >
             <md-icon>@Icon</md-icon>
         </md-filled-icon-button>
         break;
     case IconButtonType.FilledTonal:
         <md-filled-tonal-icon-button
             @attributes="AdditionalAttributes"
-            @onpointerdown="OnPointerDown"
-            @onpointerleave="OnPointerLeave"
-            @onpointercancel="OnPointerCancel"
-            @onpointerup="OnPointerUp" class="pointer-events-auto" @onclick="OnClick" disabled=@Disabled @onclick:stopPropagation="true" @onclick:preventDefault="true">
+            class="pointer-events-auto"
+            @onclick="OnClick" @onclick:stopPropagation="true" @onclick:preventDefault="true"
+            disabled=@Disabled >
             <md-icon>@Icon</md-icon>
         </md-filled-tonal-icon-button>
         break;
     case IconButtonType.Outlined:
         <md-outlined-icon-button
             @attributes="AdditionalAttributes"
-            @onpointerdown="OnPointerDown"
-            @onpointerleave="OnPointerLeave"
-            @onpointercancel="OnPointerCancel"
-            @onpointerup="OnPointerUp" class="pointer-events-auto" @onclick="OnClick" disabled=@Disabled @onclick:stopPropagation="true" @onclick:preventDefault="true">
+            class="pointer-events-auto"
+            @onclick="OnClick" @onclick:stopPropagation="true" @onclick:preventDefault="true"
+            disabled=@Disabled
+            >
             <md-icon>@Icon</md-icon>
         </md-outlined-icon-button>
         break;
@@ -51,34 +48,10 @@
 
     [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
 
-    [Parameter] public EventCallback<PointerEventArgs> OnStartHold { get; set; }
-
-    [Parameter] public EventCallback<PointerEventArgs> OnEndHold { get; set; }
-
     [Parameter] public IconButtonType Type { get; set; } = IconButtonType.Filled;
 
     [Parameter] public bool Disabled { get; set; }
 
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
-
-    private void OnPointerDown(PointerEventArgs args)
-    {
-        OnStartHold.InvokeAsync(args);
-    }
-
-    private void OnPointerLeave(PointerEventArgs args)
-    {
-        OnEndHold.InvokeAsync(args);
-    }
-
-    private void OnPointerUp(PointerEventArgs args)
-    {
-        OnEndHold.InvokeAsync(args);
-    }
-    private void OnPointerCancel(PointerEventArgs args)
-    {
-        OnEndHold.InvokeAsync(args);
-    }
-
 }

--- a/LiftLog.Ui/Shared/Presentation/ItemList.razor
+++ b/LiftLog.Ui/Shared/Presentation/ItemList.razor
@@ -1,19 +1,17 @@
 @typeparam TItem
 <div @attributes="AdditionalAttributes" class=" @(AdditionalAttributes?.GetValueOrDefault("class")) flex flex-col @VerticalPaddingClass itemlist">
-    @for (var i = 0; i < Items.Count; i++)
+    @foreach (var item in Items)
     {
         <div class="text-on-surface item" >
-            @ChildContent?.Invoke(Items[i])
+            @ChildContent?.Invoke(item)
         </div>
-        @if(Dividers && i < Items.Count - 1){
-            <md-divider></md-divider>
-        }
+        <md-divider class="last:hidden"></md-divider>
     }
 </div>
 
 @code
 {
-    [EditorRequired] [Parameter] public IReadOnlyList<TItem> Items { get; set; } = null!;
+    [EditorRequired] [Parameter] public IEnumerable<TItem> Items { get; set; } = null!;
 
     [Parameter] public RenderFragment<TItem>? ChildContent { get; set; } = null!;
 

--- a/LiftLog.Ui/Shared/Presentation/PreviousExerciseViewer.razor
+++ b/LiftLog.Ui/Shared/Presentation/PreviousExerciseViewer.razor
@@ -1,0 +1,18 @@
+<div class="flex flex-col gap-2">
+@foreach (var exercise in PreviousRecordedExercises)
+{
+    <div class="flex justify-between items-center">
+        <span>@exercise.DateTime.Date.ToShortDateString()</span>
+        <ExerciseSummary
+            Exercise=exercise.RecordedExercise
+            ShowSets=true
+            ShowWeight=true
+            ShowName=false />
+    </div>
+    <md-divider class="last:hidden"></md-divider>
+}
+</div>
+
+@code {
+    [EditorRequired] [Parameter] public ImmutableListValue<DatedRecordedExercise> PreviousRecordedExercises { get; set; } = null!;
+}

--- a/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
@@ -1,51 +1,13 @@
 
-<div class="flex flex-col gap-y-1.5 text-start" data-cy="session-summary">
+<div class="flex flex-col gap-y-2 text-start" data-cy="session-summary">
     @foreach (var exercise in Session.RecordedExercises)
     {
-        var splitWeights = exercise.PerSetWeight && !exercise.PotentialSets.All(s => s.Weight == exercise.Weight);
-
-        <span class="flex items-center">
-            <span>@exercise.Blueprint.Name</span>
-            @if(ShowSets || ShowWeight)
-            {
-                @if(!splitWeights)
-                {
-                <span class="flex justify-around ml-auto items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
-
-                    @if (ShowSets)
-                    {
-                        <span>
-                            @(exercise.Blueprint.Sets)x@(exercise.Blueprint.RepsPerSet)
-                        </span>
-                        @if(ShowWeight)
-                        {
-                            <span class="text-2xs">@@</span>
-                        }
-                    }
-
-                    @if (ShowWeight)
-                    {
-                        <WeightFormat Weight="@exercise.Weight"/>
-                    }
-                </span>
-                }
-
-                @if (ShowWeight && splitWeights)
-                {
-                    <span class="flex ml-auto flex-wrap justify-end gap-1">
-                        @foreach(var set in exercise.PotentialSets)
-                        {
-                            <span class="flex items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
-                                @if (ShowSets){
-                                    <span>@(set.Set?.RepsCompleted ?? exercise.Blueprint.RepsPerSet)</span><span class="text-2xs">@@</span>
-                                }
-                                <WeightFormat Weight="@set.Weight"/>
-                            </span>
-                        }
-                    </span>
-                }
-            }
-        </span>
+       <ExerciseSummary
+            Exercise=exercise
+            ShowSets=ShowSets
+            ShowWeight=ShowWeight
+            ShowName=true />
+        <md-divider class="last:hidden"></md-divider>
     }
 </div>
 

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -1,9 +1,8 @@
 ﻿@{
-    var (displayedExercise, repToStartNext) = (_holdingPrevious, PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise) switch
+    var (displayedExercise, repToStartNext) = (PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise) switch
     {
-        (true, null) => (RecordedExercise, -1),
-        (true, var previous) => (previous, -1),
-        (false, _) => (RecordedExercise, RecordedExercise.PotentialSets.IndexOf(x => x.Set is null))
+        null => (RecordedExercise, -1),
+        _ => (RecordedExercise, RecordedExercise.PotentialSets.IndexOf(x => x.Set is null))
     };
     var previousNotes = PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise?.Notes ?? "";
     var thisNotes = RecordedExercise.Notes ?? "";
@@ -18,7 +17,7 @@
                 <div class="flex justify-end">
                     @if (PreviousRecordedExercises?.Any() == true)
                     {
-                        <IconButton data-cy="prev-exercise-btn" Type="IconButtonType.Standard" Icon="history" OnStartHold="() => _holdingPrevious = true" OnEndHold="() => _holdingPrevious = false"/>
+                        <IconButton data-cy="prev-exercise-btn" Type="IconButtonType.Standard" Icon="history" OnClick="ShowPrevious"/>
                     }
                     <IconButton data-cy="per-rep-weight-btn" Type=IconButtonType.Standard Icon=weight OnClick="ToggleExercisePerSetWeight"></IconButton>
                     <div>
@@ -61,7 +60,7 @@
                 IsReadonly=@IsReadonly />
         }
     </div>
-    @if((blueprintNotes ,previousNotes , thisNotes) is not ("","",""))
+    @if((blueprintNotes, previousNotes, thisNotes) is not ("", "", ""))
     {
         <Card Type=Card.CardType.Filled class="grid grid-cols-[min-content_1fr] mr-5 gap-2 text-left">
             <md-icon>notes</md-icon>
@@ -94,12 +93,6 @@
             </div>
         </Card>
     }
-    @if (_holdingPrevious && PreviousRecordedExercises?.Any() == true)
-    {
-        <div class="-m-4 -mr-1">
-            <StatGraphCardContent Title="" Statistics="[GetStatistics()]" RenderDelay=TimeSpan.Zero ShowTitle=false></StatGraphCardContent>
-        </div>
-    }
 </div>
 
 <Dialog @ref="notesDialog">
@@ -113,11 +106,22 @@
     </div>
 </Dialog>
 
+<Dialog @ref="previousDialog">
+    <span slot="headline">Previous Sessions for @(RecordedExercise.Blueprint.Name)</span>
+    <div slot="content" class="flex flex-col">
+        <PreviousExerciseViewer PreviousRecordedExercises="@PreviousRecordedExercises" />
+    </div>
+    <div slot="actions" data-cy="previous-dialog-actions">
+        <AppButton Type="AppButtonType.Text" OnClick="@(() => previousDialog?.Close())">Close</AppButton>
+    </div>
+</Dialog>
+
 @code {
     private string moreButtonId = "a" + Guid.NewGuid();
-    private bool _holdingPrevious = false;
+
     private Menu? _menu;
     private Dialog? notesDialog;
+    private Dialog? previousDialog;
 
     private string EditorNotes { get; set; } = "";
 
@@ -162,14 +166,8 @@
         notesDialog?.Open();
     }
 
-    private StatisticOverTime GetStatistics()
+    private void ShowPrevious()
     {
-        return new StatisticOverTime(
-            RecordedExercise.Blueprint.Name,
-            PreviousRecordedExercises
-                .Select(x => new TimeTrackedStatistic(x.DateTime, x.RecordedExercise.Weight))
-                .ToImmutableList()
-        );
+        previousDialog?.Open();
     }
-
 }

--- a/LiftLog.Ui/Shared/Smart/Tips/PreviousButtonTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/PreviousButtonTip.razor
@@ -1,7 +1,7 @@
 <div class="flex gap-2">
-    <span>If you <span class="font-bold text-primary">hold</span> the <span class="font-bold text-primary">Previous</span> button on an exercise during a session, that exercise will temporarily show how you performed the last time you completed it, along with a graph of your progression. Try it now!</span>
+    <span>If you <span class="font-bold text-primary">tap</span> the <span class="font-bold text-primary">Previous</span> button on an exercise during a session, that exercise will show how you performed in the past. Try it now!</span>
     <div>
-        <IconButton Type="IconButtonType.Standard" Icon="history" OnStartHold=@(() => text = "Well done!") OnEndHold=@(() => text = "")/>
+        <IconButton Type="IconButtonType.Standard" Icon="history" OnClick=@(() => text = "Well done!")/>
     </div>
 </div>
 <div class="font-bold text-primary">


### PR DESCRIPTION
This PR replaces the "Hold to view previous" in a weighted exercise with a "Tap to view history" action.  Instead of showing a graph over time and replacing the current values, it just shows a list of historical completions of that exercise- with weight and how many reps in each set as chips.

Before:

https://github.com/user-attachments/assets/c87b06fa-5256-4bfd-9355-bf1d8ca84b30

After:

https://github.com/user-attachments/assets/57b2d2fa-9364-4ac8-a6b0-97f8e21fd42a

