### PR TITLE
Add trust anchors for user certificates

### DIFF
--- a/LiftLog.Maui/Platforms/Android/Resources/xml/network_security_config.xml
+++ b/LiftLog.Maui/Platforms/Android/Resources/xml/network_security_config.xml
@@ -3,4 +3,12 @@
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
+    <base-config>
+        <trust-anchors>
+        <!-- Trust preinstalled CAs -->
+        <certificates src="system" />
+        <!-- Additionaly trusted user added CAs -->
+        <certificates src="user"/>
+    </trust-anchors>
+    </base-config>
 </network-security-config>

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -253,18 +253,25 @@ public class SettingsEffects(
         }
         catch (HttpRequestException ex) when (ex.StatusCode is null)
         {
+            logger.LogWarning(ex, "Failed to backup data to remote server [connection failure]");
             dispatcher.Dispatch(
                 new ToastAction("Failed to backup data to remote server [connection failure]")
             );
         }
         catch (HttpRequestException ex)
         {
+            logger.LogWarning(
+                ex,
+                "Failed to backup data to remote server [{StatusCode}]",
+                ex.StatusCode
+            );
             dispatcher.Dispatch(
                 new ToastAction("Failed to backup data to remote server [" + ex.StatusCode + "]")
             );
         }
-        catch
+        catch (Exception ex)
         {
+            logger.LogWarning(ex, "Failed to backup data to remote server [unknown]");
             dispatcher.Dispatch(
                 new ToastAction("Failed to backup data to remote server [unknown]")
             );


### PR DESCRIPTION
One of the requirements for auto backup is the server uses HTTPS.  We need the app to allow self signed certs for use cases where users have used self signed certs.

See: https://github.com/LiamMorrow/LiftLog/issues/243#issuecomment-2366866412