### PR TITLE
Include exercises with different reps in previous history

### DIFF
--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -49,10 +49,35 @@ public record ExerciseBlueprint(
     string Notes
 );
 
-public record KeyedExerciseBlueprint(string Name, int Sets, int RepsPerSet)
+public sealed record KeyedExerciseBlueprint : IEquatable<KeyedExerciseBlueprint>
 {
-    public static implicit operator KeyedExerciseBlueprint(ExerciseBlueprint e) =>
-        new(e.Name, e.Sets, e.RepsPerSet);
+    private readonly string normalizedName = string.Empty;
+    public string Name { get; }
+
+    public KeyedExerciseBlueprint(string name)
+    {
+        Name = name;
+        normalizedName = NormalizeName(name);
+    }
+
+    public static implicit operator KeyedExerciseBlueprint(ExerciseBlueprint e) => new(e.Name);
+
+    public bool Equals(KeyedExerciseBlueprint? other) => other?.normalizedName == normalizedName;
+
+    public override int GetHashCode() => normalizedName.GetHashCode();
+
+    private static string NormalizeName(string name)
+    {
+        var lowerName = name.ToLower().Trim().Replace("flies", "flys").Replace("flyes", "flys");
+        var withoutPlural = lowerName switch
+        {
+            string when lowerName.EndsWith("es") => lowerName[..^2],
+            string when lowerName.EndsWith('s') => lowerName[..^1],
+            _ => lowerName,
+        };
+
+        return withoutPlural;
+    }
 }
 
 public record Rest(TimeSpan MinRest, TimeSpan MaxRest, TimeSpan FailureRest)

--- a/LiftLog.Ui/Store/Stats/StatsEffects.cs
+++ b/LiftLog.Ui/Store/Stats/StatsEffects.cs
@@ -73,7 +73,7 @@ public class StatsEffects(
                             ex
                         ))
                 )
-                .GroupBy(x => NormalizeName(x.RecordedExercise.Blueprint.Name))
+                .GroupBy(x => new KeyedExerciseBlueprint(x.RecordedExercise.Blueprint.Name))
                 .Select(CreateExerciseStatistic)
                 .ToImmutableList();
 
@@ -103,7 +103,7 @@ public class StatsEffects(
             var exerciseMostTimeSpent = sessions
                 .SelectMany(x => x.RecordedExercises)
                 .Where(x => x.LastRecordedSet?.Set is not null)
-                .GroupBy(x => NormalizeName(x.Blueprint.Name))
+                .GroupBy(x => new KeyedExerciseBlueprint(x.Blueprint.Name))
                 .Select(x => new TimeSpentExercise(
                     x.First().Blueprint.Name,
                     x.Select(x => x.TimeSpent).Aggregate((a, b) => a + b)
@@ -132,19 +132,6 @@ public class StatsEffects(
             dispatcher.Dispatch(new SetStatsIsDirtyAction(false));
             dispatcher.Dispatch(new SetStatsIsLoadingAction(false));
         });
-    }
-
-    private static string NormalizeName(string name)
-    {
-        var lowerName = name.ToLower().Trim().Replace("flies", "flys").Replace("flyes", "flys");
-        var withoutPlural = lowerName switch
-        {
-            string when lowerName.EndsWith("es") => lowerName[..^2],
-            string when lowerName.EndsWith('s') => lowerName[..^1],
-            _ => lowerName,
-        };
-
-        return withoutPlural;
     }
 
     private static StatisticOverTime CreateBodyweightStatistic(IEnumerable<Session> sessions)


### PR DESCRIPTION

This PR relaxes the restriction of having to have the exact same name/reps/sets to show up in the exercise history list.

![Screenshot 2024-10-02 at 17 10 23](https://github.com/user-attachments/assets/97e13c31-6955-4fad-8a49-76d503b0ca3f)
