### PR TITLE
Add link field to exercises

### DIFF
--- a/LiftLog.Api/Service/GptAiWorkoutPlanner.cs
+++ b/LiftLog.Api/Service/GptAiWorkoutPlanner.cs
@@ -101,7 +101,8 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient, ILogger<GptAiWorkout
                                     TimeSpan.FromSeconds(e.RestBetweenSets.FailureRestSeconds)
                                 ),
                                 false,
-                                Notes: ""
+                                Notes: "",
+                                Link: ""
                             ))
                             .ToImmutableList(),
                         Notes: s.Description
@@ -192,7 +193,8 @@ public class GptAiWorkoutPlanner(OpenAIClient openAiClient, ILogger<GptAiWorkout
                             TimeSpan.FromSeconds(e.RestBetweenSets.FailureRestSeconds)
                         ),
                         false,
-                        Notes: ""
+                        Notes: "",
+                        Link: ""
                     ))
                     .ToImmutableList(),
                 Notes: gptPlan.Description

--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -54,7 +54,7 @@ public record ExerciseBlueprint(
         new(
             Name: string.Empty,
             Sets: 3,
-            RepsPerSet: 8,
+            RepsPerSet: 10,
             WeightIncreaseOnSuccess: 0,
             RestBetweenSets: Rest.Medium,
             SupersetWithNext: false,

--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -46,8 +46,22 @@ public record ExerciseBlueprint(
     decimal WeightIncreaseOnSuccess,
     Rest RestBetweenSets,
     bool SupersetWithNext,
-    string Notes
-);
+    string Notes,
+    string Link
+)
+{
+    public static readonly ExerciseBlueprint Default =
+        new(
+            Name: string.Empty,
+            Sets: 3,
+            RepsPerSet: 8,
+            WeightIncreaseOnSuccess: 0,
+            RestBetweenSets: Rest.Medium,
+            SupersetWithNext: false,
+            Notes: string.Empty,
+            Link: string.Empty
+        );
+}
 
 public sealed record KeyedExerciseBlueprint : IEquatable<KeyedExerciseBlueprint>
 {

--- a/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV1.cs
+++ b/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV1.cs
@@ -65,7 +65,8 @@ internal record ExerciseBlueprintDaoV1(
             KilogramsIncreaseOnSuccess,
             RestBetweenSets.ToModel(),
             SupersetWithNext,
-            Notes ?? ""
+            Notes ?? "",
+            Link: ""
         );
 }
 

--- a/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.cs
+++ b/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.cs
@@ -52,7 +52,8 @@ internal partial class ExerciseBlueprintDaoV2
         DecimalValue weightIncreaseOnSuccess,
         RestDaoV2 restBetweenSets,
         bool supersetWithNext,
-        string notes
+        string notes,
+        string link
     )
     {
         Name = name;
@@ -62,6 +63,7 @@ internal partial class ExerciseBlueprintDaoV2
         RestBetweenSets = restBetweenSets;
         SupersetWithNext = supersetWithNext;
         Notes = notes;
+        Link = link;
     }
 
     public static ExerciseBlueprintDaoV2 FromModel(Lib.Models.ExerciseBlueprint model) =>
@@ -72,7 +74,8 @@ internal partial class ExerciseBlueprintDaoV2
             model.WeightIncreaseOnSuccess,
             RestDaoV2.FromModel(model.RestBetweenSets),
             model.SupersetWithNext,
-            model.Notes
+            model.Notes,
+            model.Link
         );
 
     public Lib.Models.ExerciseBlueprint ToModel() =>
@@ -83,7 +86,8 @@ internal partial class ExerciseBlueprintDaoV2
             WeightIncreaseOnSuccess,
             RestBetweenSets.ToModel(),
             SupersetWithNext,
-            Notes
+            Notes,
+            Link
         );
 }
 

--- a/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.proto
+++ b/LiftLog.Ui/Models/SessionBlueprintDao/SessionBlueprintDaoV2.proto
@@ -24,6 +24,7 @@ message ExerciseBlueprintDaoV2 {
     RestDaoV2 rest_between_sets = 6;
     bool superset_with_next = 7;
     string notes = 8;
+    string link = 9;
 }
 
 message RestDaoV2 {

--- a/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.Home.cs
+++ b/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.Home.cs
@@ -21,7 +21,8 @@ public partial class ScreenshotCollectorPage
                     WeightIncreaseOnSuccess: 2.5m,
                     RestBetweenSets: Rest.Medium,
                     SupersetWithNext: false,
-                    Notes: ""
+                    Notes: "",
+                    Link: ""
                 ),
                 new ExerciseBlueprint(
                     Name: "Bench Press",
@@ -30,7 +31,8 @@ public partial class ScreenshotCollectorPage
                     WeightIncreaseOnSuccess: 2.5m,
                     RestBetweenSets: Rest.Medium,
                     SupersetWithNext: false,
-                    Notes: ""
+                    Notes: "",
+                    Link: ""
                 ),
                 new ExerciseBlueprint(
                     Name: "Deadlift",
@@ -39,7 +41,8 @@ public partial class ScreenshotCollectorPage
                     WeightIncreaseOnSuccess: 2.5m,
                     RestBetweenSets: Rest.Medium,
                     SupersetWithNext: false,
-                    Notes: ""
+                    Notes: "",
+                    Link: ""
                 ),
             ],
             Notes: ""

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -158,6 +158,7 @@
                 2.5m,
                 new Rest(TimeSpan.FromSeconds(90), TimeSpan.FromMinutes(3), TimeSpan.FromMinutes(5)),
                 false,
+                "",
                 "");
         isAddingExercise = true;
         editDialog?.Open();

--- a/LiftLog.Ui/Services/BuiltInProgramService.cs
+++ b/LiftLog.Ui/Services/BuiltInProgramService.cs
@@ -15,18 +15,18 @@ public static class BuiltInProgramService
                     new(
                         "Workout A",
                         [
-                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, ""),
+                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Workout B",
                         [
-                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Overhead Press", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, ""),
+                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Overhead Press", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
@@ -39,18 +39,18 @@ public static class BuiltInProgramService
                     new(
                         "Workout A",
                         [
-                            new("Squat", 5, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Bench Press", 5, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Barbell Row", 5, 5, 2.5m, Rest.Medium, false, ""),
+                            new("Squat", 5, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Bench Press", 5, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Barbell Row", 5, 5, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Workout B",
                         [
-                            new("Squat", 5, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Overhead Press", 5, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, ""),
+                            new("Squat", 5, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Overhead Press", 5, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Deadlift", 1, 5, 5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
@@ -63,30 +63,30 @@ public static class BuiltInProgramService
                     new(
                         "Push",
                         [
-                            new("Bench Press", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Overhead Press", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Tricep Extension", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Cable Fly", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Bench Press", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Overhead Press", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Tricep Extension", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Cable Fly", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Pull",
                         [
-                            new("Deadlift", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Barbell Row", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Lat Pulldown", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Barbell Curl", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Deadlift", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Barbell Row", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Lat Pulldown", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Barbell Curl", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Legs",
                         [
-                            new("Squat", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Lunges", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Leg Extension", 4, 8, 2.5m, Rest.Medium, false, ""),
-                            new("Leg Curl", 4, 8, 2.5m, Rest.Medium, false, ""),
+                            new("Squat", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Lunges", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Leg Extension", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Leg Curl", 4, 8, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
@@ -99,47 +99,56 @@ public static class BuiltInProgramService
                     new(
                         "Upper Power",
                         [
-                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Barbell Row", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Overhead Press", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Barbell Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Tricep Extension", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Cable Fly", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Bench Press", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Barbell Row", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Overhead Press", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Barbell Curl", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Tricep Extension", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Cable Fly", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Lower Power",
                         [
-                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, ""),
-                            new("Deadlift", 3, 5, 5m, Rest.Medium, false, ""),
-                            new("Leg Press", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Squat", 3, 5, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Deadlift", 3, 5, 5m, Rest.Medium, false, "", Link: ""),
+                            new("Leg Press", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Upper Hypertrophy",
                         [
-                            new("Incline Bench Press", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Cable Row", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Dumbbell Fly", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Dumbbell Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Skullcrusher", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new(
+                                "Incline Bench Press",
+                                3,
+                                10,
+                                2.5m,
+                                Rest.Medium,
+                                false,
+                                "",
+                                Link: ""
+                            ),
+                            new("Cable Row", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Dumbbell Fly", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Lat Pulldown", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Dumbbell Curl", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Skullcrusher", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Lower Hypertrophy",
                         [
-                            new("Front Squat", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Romanian Deadlift", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Leg Extension", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false, ""),
-                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false, ""),
+                            new("Front Squat", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Romanian Deadlift", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Leg Extension", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Leg Curl", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
+                            new("Calf Raise", 3, 10, 2.5m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
@@ -152,27 +161,27 @@ public static class BuiltInProgramService
                     new(
                         "Push",
                         [
-                            new("Pushups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Dips", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Pushups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Dips", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Pull",
                         [
-                            new("Pullups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Chinups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Pullups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Chinups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Legs",
                         [
-                            new("Squats", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Lunges", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Squats", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Lunges", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
@@ -185,30 +194,30 @@ public static class BuiltInProgramService
                     new(
                         "Push",
                         [
-                            new("Pushups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Dips", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Planche Pushups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Pushups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Dips", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Handstand Pushups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Planche Pushups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Pull",
                         [
-                            new("Pullups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Chinups", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Muscle Ups", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Pullups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Chinups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Inverted Rows", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Muscle Ups", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),
                     new(
                         "Legs",
                         [
-                            new("Squats", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Lunges", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false, ""),
-                            new("Pistol Squats", 3, 10, 0m, Rest.Medium, false, ""),
+                            new("Squats", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Lunges", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Calf Raises", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
+                            new("Pistol Squats", 3, 10, 0m, Rest.Medium, false, "", Link: ""),
                         ],
                         ""
                     ),

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -136,7 +136,7 @@
     {
         var text = await JSRuntime.InvokeAsync<string?>("AppUtils.extractLinkFromClipboard", e);
         SetExerciseLink(text ?? exercise.Link);
-        await linkField?.UpdateValueEvenIfFocused();
+        await linkField.UpdateValueEvenIfFocused();
     }
 
     private void UpdateExerciseHandler(ExerciseBlueprint updatedExercise)

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -1,4 +1,5 @@
-<div class="flex flex-col gap-4">
+@inject IJSRuntime JSRuntime
+<div class="flex flex-col gap-2">
 <TextField
     data-cy="exercise-name"
     TextFieldType="TextFieldType.Filled"
@@ -13,9 +14,29 @@
     required
     OnChange="@(val => {SetExerciseName(val!); exerciseListMenu!.Open();})"
     OnFocus=@(()=>{exerciseListMenu!.Open();})
-    OnBlur="()=>exerciseListMenu!.Close()">
+    OnBlur="()=>exerciseListMenu!.Close()"
+    OnPaste="HandleLinkPaste">
 </TextField>
 <ExerciseSearcher @ref="exerciseListMenu" Value="@Exercise.Name" Anchor="exerciseTextField"  ValueChanged=@(v=>SetExerciseName(v)) />
+
+<div class="flex items-center w-full gap-4">
+    <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex-1 flex justify-center">
+        <FixedIncrementer
+            data-cy="exercise-sets"
+            Value="Exercise.Sets"
+            Increment="() => IncrementExerciseSets()"
+            Decrement="() => DecrementExerciseSets()"
+            Label="Sets"/>
+    </Card>
+    <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex flex-1 justify-center">
+        <FixedIncrementer
+            data-cy="exercise-reps"
+            Value="Exercise.RepsPerSet"
+            Increment="() => IncrementExerciseRepsPerSet()"
+            Decrement="() => DecrementExerciseRepsPerSet()"
+            Label="Reps"/>
+    </Card>
+</div>
 <TextField
     data-cy="exercise-notes"
     TextFieldType="TextFieldType.Filled"
@@ -24,36 +45,32 @@
     type="textarea"
     SelectAllOnFocus="false"
     Value="@Exercise.Notes"
-    OnChange="@(val => SetExerciseNotes(val!))"/>
+    OnChange="@(val => SetExerciseNotes(val!))"
+    OnPaste="HandleLinkPaste"/>
+
+<TextField
+    @ref="linkField"
+    data-cy="exercise-link"
+    TextFieldType="TextFieldType.Filled"
+    class="w-full mb-2 text-xl text-start resize-y"
+    Label="External Link"
+    type="text"
+    placeholder="https://"
+    SelectAllOnFocus="false"
+    Value="@Exercise.Link"
+    OnPaste="@(e => HandleLinkPaste(e))"
+    PreventDefaultPaste=true
+    OnChange="@(val => SetExerciseLink(val!))"/>
+
 <div class="flex flex-wrap justify-around w-full gap-4">
-    <div class="flex items-center w-full gap-4">
-        <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex-1 flex justify-center">
-            <FixedIncrementer
-                data-cy="exercise-sets"
-                Value="Exercise.Sets"
-                Increment="() => IncrementExerciseSets()"
-                Decrement="() => DecrementExerciseSets()"
-                Label="Sets"/>
-        </Card>
-        <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex flex-1 justify-center">
-            <FixedIncrementer
-                data-cy="exercise-reps"
-                Value="Exercise.RepsPerSet"
-                Increment="() => IncrementExerciseRepsPerSet()"
-                Decrement="() => DecrementExerciseRepsPerSet()"
-                Label="Reps"/>
-        </Card>
-    </div>
     <Card Type=Card.CardType.Elevated class="w-full flex flex-col gap-6 items-start">
-        <div class="-mr-2">
-            <EditableIncrementer
-                Increment="0.1m"
-                Label="Progressive Overload"
-                data-cy="exercise-auto-increase"
-                Suffix=@WeightSuffix
-                Value="Exercise.WeightIncreaseOnSuccess"
-                OnChange="e => SetExerciseSuccessWeight(e)"/>
-        </div>
+        <EditableIncrementer
+            Increment="0.1m"
+            Label="Progressive Overload"
+            data-cy="exercise-auto-increase"
+            Suffix=@WeightSuffix
+            Value="Exercise.WeightIncreaseOnSuccess"
+            OnChange="e => SetExerciseSuccessWeight(e)"/>
         <md-divider></md-divider>
 
         <div class="w-full">
@@ -64,6 +81,7 @@
 
         <RestEditorGroup Rest="Exercise.RestBetweenSets" OnRestUpdated="rest => OnRestUpdated(rest)"/>
     </Card>
+
 </div>
 </div>
 
@@ -71,6 +89,9 @@
 {
     private ExerciseBlueprint exercise = null!;
     private ExerciseSearcher? exerciseListMenu;
+
+    private TextField linkField = null!;
+
     [Parameter] [EditorRequired] public Action<ExerciseBlueprint> UpdateExercise { get; set; } = null!;
 
     [Parameter] [EditorRequired] public ExerciseBlueprint Exercise { get; set; } = null!;
@@ -101,6 +122,8 @@
 
     void SetExerciseNotes(string notes) => UpdateExerciseHandler(exercise with { Notes = notes });
 
+    void SetExerciseLink(string link) => UpdateExerciseHandler(exercise with { Link = link });
+
     void SetExerciseSupersetsNext(bool supersets)
         => UpdateExerciseHandler(exercise with { SupersetWithNext = supersets });
 
@@ -108,6 +131,13 @@
         => UpdateExerciseHandler(exercise with { WeightIncreaseOnSuccess = weight });
 
     void OnRestUpdated(Rest rest) => UpdateExerciseHandler(exercise with { RestBetweenSets = rest });
+
+    async Task HandleLinkPaste(ClipboardEventArgs e)
+    {
+        var text = await JSRuntime.InvokeAsync<string?>("AppUtils.extractLinkFromClipboard", e);
+        SetExerciseLink(text ?? exercise.Link);
+        await linkField?.UpdateValueEvenIfFocused();
+    }
 
     private void UpdateExerciseHandler(ExerciseBlueprint updatedExercise)
     {

--- a/LiftLog.Ui/Shared/Presentation/TextField.razor
+++ b/LiftLog.Ui/Shared/Presentation/TextField.razor
@@ -10,6 +10,8 @@
             @onfocusin=SelectOnFocus
             @onclick=OnClick
             @onfocusout=@(async _=>{await SetValueOnElement(); await OnBlur.InvokeAsync();})
+            @onpaste=OnPaste
+            @onpaste:preventDefault=PastePreventDefault
         >
             @ChildContent
         </md-outlined-text-field>
@@ -22,6 +24,8 @@
             @onfocusin=SelectOnFocus
             @onclick=OnClick
             @onfocusout=@(async _=>{await SetValueOnElement(); await OnBlur.InvokeAsync();})
+            @onpaste=OnPaste
+            @onpaste:preventDefault=PastePreventDefault
         >
             @ChildContent
         </md-filled-text-field>
@@ -50,6 +54,15 @@
     [Parameter] public TextFieldType TextFieldType { get; set; } = TextFieldType.Outlined;
 
     [Parameter] public bool SelectAllOnFocus { get; set; } = true;
+
+    [Parameter] public EventCallback<ClipboardEventArgs> OnPaste { get; set; }
+
+    [Parameter] public bool PastePreventDefault { get; set; } = false;
+
+    public async Task UpdateValueEvenIfFocused()
+    {
+        await SetValueOnElement();
+    }
 
     protected override async Task OnParametersSetAsync()
     {

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -148,15 +148,7 @@ else
 
 @code {
 
-    private ExerciseBlueprint editingExerciseBlueprint = new ExerciseBlueprint(
-        Name: "",
-        Sets: 3,
-        RepsPerSet: 10,
-        WeightIncreaseOnSuccess: 0,
-        RestBetweenSets: Rest.Medium,
-        SupersetWithNext: false,
-        Notes: ""
-    );
+    private ExerciseBlueprint editingExerciseBlueprint = ExerciseBlueprint.Default;
 
     private (int ExerciseIndex, int PotentialSetIndex)? setAdditionalActions;
     private int? _exerciseToEditIndex;
@@ -279,15 +271,7 @@ else
 
     private void BeginAddExercise()
     {
-        editingExerciseBlueprint = new ExerciseBlueprint(
-            Name: "",
-            Sets: 3,
-            RepsPerSet: 10,
-            WeightIncreaseOnSuccess: 0,
-            RestBetweenSets: Rest.Medium,
-            SupersetWithNext: false,
-            Notes: ""
-        );
+        editingExerciseBlueprint = ExerciseBlueprint.Default;
         _editExerciseDialog?.Open();
     }
 

--- a/LiftLog.Ui/wwwroot/app-utils.ts
+++ b/LiftLog.Ui/wwwroot/app-utils.ts
@@ -20,6 +20,32 @@ AppUtils.vibrate = function (ms: number) {
   }
 };
 
+AppUtils.extractLinkFromClipboard = async function (): Promise<string | null> {
+  // first inspect the text in the clipboard - if it is a link, return it
+  const clipboard = await navigator.clipboard.read();
+  const text: Blob | null = clipboard[0].types.includes("text/plain") ? await clipboard[0].getType("text/plain") : null;
+  if (text) {
+    const textString = await new Response(text).text();
+    console.log(textString);
+    if (textString.startsWith("http")) {
+      return textString;
+    }
+  }
+  // then try to extract a link from a html clipboard
+  const html: Blob | null = clipboard[0].types.includes("text/html") ? await clipboard[0].getType("text/html") : null;
+  if (html) {
+    const htmlString = await new Response(html).text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlString, "text/html");
+    const link = doc.querySelector("a");
+    console.log(htmlString);
+    if (link) {
+      return link.href;
+    }
+  }
+  return null;
+};
+
 /**
  * Creates a new event for the dialog close event.
  * This new event has bubbles, which allows blazor components to intercept it

--- a/tests/LiftLog.Tests.App/Blueprints.cs
+++ b/tests/LiftLog.Tests.App/Blueprints.cs
@@ -17,7 +17,8 @@ public static class Blueprints
         WeightIncreaseOnSuccess: 2.5m,
         RestBetweenSets: Rest.Medium,
         SupersetWithNext: false,
-        Notes: "My exercise notes"
+        Notes: "My exercise notes",
+        Link: "https://example.com"
       )
     );
   }


### PR DESCRIPTION
This link will automatically fill if the clipboard contains a link when you paste into any of the name, notes, or link fields.

Right now it is not displayed anywhere and is ornamental, but as specified in #281 I'd like to add an "info" icon which can extend exercise names, perhaps put the notes in there, and hold this link.  This link can be used for anything, but its purpose is to link to "How to do" exercises, say if you are copying a plan from somewhere into liftlog.

<img width="394" alt="image" src="https://github.com/user-attachments/assets/f82d72f8-3a04-4fb2-ac69-9cc15bb87349">
