### PR TITLE
Ensure datetimes are always local + displayed as local in charts

### DIFF
--- a/LiftLog.Maui/App.xaml.cs
+++ b/LiftLog.Maui/App.xaml.cs
@@ -40,7 +40,10 @@ public partial class App : Application
             if (session?.LastExercise?.LastRecordedSet?.Set is not null)
             {
                 var lastSet = session.LastExercise.LastRecordedSet.Set;
-                var lastSetTime = session.Date.ToDateTime(lastSet.CompletionTime);
+                var lastSetTime = session.Date.ToDateTime(
+                    lastSet.CompletionTime,
+                    DateTimeKind.Local
+                );
                 var timeSinceLastSet = DateTime.Now - lastSetTime;
                 if (
                     (timeSinceLastSet > TimeSpan.FromMinutes(30) && session.IsComplete)

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
@@ -108,7 +108,10 @@ internal record RecordedSetDaoV1(
             ),
             { Set: { } } completed => new RecordedSetDaoV1(
                 RepsCompleted: model.Set.RepsCompleted,
-                CompletionTime: sessionDate.ToDateTime(completed.Set.CompletionTime),
+                CompletionTime: sessionDate.ToDateTime(
+                    completed.Set.CompletionTime,
+                    DateTimeKind.Local
+                ),
                 Weight: completed.Weight
             ),
             _ => null,

--- a/LiftLog.Ui/Services/ProgressRepository.cs
+++ b/LiftLog.Ui/Services/ProgressRepository.cs
@@ -162,7 +162,10 @@ namespace LiftLog.Ui.Services
                 .SelectMany(x =>
                     x.RecordedExercises.Where(x => x.LastRecordedSet?.Set is not null)
                         .Select(ex => new DatedRecordedExercise(
-                            x.Date.ToDateTime(ex.LastRecordedSet!.Set!.CompletionTime),
+                            x.Date.ToDateTime(
+                                ex.LastRecordedSet!.Set!.CompletionTime,
+                                DateTimeKind.Local
+                            ),
                             ex
                         ))
                         .ToAsyncEnumerable()

--- a/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
@@ -145,7 +145,8 @@ else
                     Style = new()
                     {
                         Colors = new Color(GetColorString(AppState.Value.ColorScheme.OnSurface)),
-                    }
+                    },
+                    DatetimeUTC = false,
                 },
                 AxisBorder = new()
                 {

--- a/LiftLog.Ui/Store/Feed/FeedEffects.FeedItems.cs
+++ b/LiftLog.Ui/Store/Feed/FeedEffects.FeedItems.cs
@@ -115,7 +115,10 @@ public partial class FeedEffects
                     .Select(x => x.OrderByDescending(x => x.Timestamp).First())
                     .OrderByDescending(x =>
                         x is SessionFeedItem sessionFeedItem
-                            ? sessionFeedItem.Session.Date.ToDateTime(TimeOnly.MinValue)
+                            ? sessionFeedItem.Session.Date.ToDateTime(
+                                TimeOnly.MinValue,
+                                DateTimeKind.Local
+                            )
                             : x.Timestamp
                     )
                     .ThenByDescending(x => x.Timestamp)

--- a/LiftLog.Ui/Store/Stats/StatsEffects.cs
+++ b/LiftLog.Ui/Store/Stats/StatsEffects.cs
@@ -52,21 +52,22 @@ public class StatsEffects(
                         && currentSessionNames.Contains(session.Blueprint.Name)
                     )
                 )
-                .Where(x => x.RecordedExercises.Any())
                 .ToListAsync();
+            var sessionsWithExercises = sessions.Where(x => x.RecordedExercises.Any()).ToList();
             if (sessions.Count == 0)
             {
                 dispatcher.Dispatch(new SetStatsIsLoadingAction(false));
+                dispatcher.Dispatch(new SetOverallStatsAction(null));
                 return;
             }
 
             var bodyweightStats = CreateBodyweightStatistic(sessions);
-            var sessionStats = sessions
+            var sessionStats = sessionsWithExercises
                 .GroupBy(session => session.Blueprint.Name)
                 .Select(CreateSessionStatistic)
                 .ToImmutableList();
 
-            var exerciseStats = sessions
+            var exerciseStats = sessionsWithExercises
                 .SelectMany(x =>
                     x.RecordedExercises.Where(y => y.LastRecordedSet?.Set is not null)
                         .Select(ex => new DatedRecordedExercise(
@@ -81,7 +82,7 @@ public class StatsEffects(
                 .Select(CreateExerciseStatistic)
                 .ToImmutableList();
 
-            var averageTimeBetweenSets = sessions
+            var averageTimeBetweenSets = sessionsWithExercises
                 .SelectMany(x => x.RecordedExercises)
                 .SelectMany(x =>
                     x.PotentialSets.Select(set => set.Set?.CompletionTime.ToTimeSpan())
@@ -95,7 +96,7 @@ public class StatsEffects(
                     acc => acc.RunningAvg != 0 ? acc.Zero / acc.RunningAvg : TimeSpan.Zero
                 );
 
-            var averageSessionLength = sessions
+            var averageSessionLength = sessionsWithExercises
                 .Select(session => session.SessionLength)
                 .WhereNotNull()
                 .Aggregate(
@@ -104,7 +105,7 @@ public class StatsEffects(
                     acc => acc.Item2 != 0 ? acc.Zero / acc.Item2 : TimeSpan.Zero
                 );
 
-            var exerciseMostTimeSpent = sessions
+            var exerciseMostTimeSpent = sessionsWithExercises
                 .SelectMany(x => x.RecordedExercises)
                 .Where(x => x.LastRecordedSet?.Set is not null)
                 .GroupBy(x => new KeyedExerciseBlueprint(x.Blueprint.Name))
@@ -114,7 +115,7 @@ public class StatsEffects(
                 ))
                 .MaxBy(x => x.TimeSpent);
 
-            var heaviestLift = sessions
+            var heaviestLift = sessionsWithExercises
                 .SelectMany(x => x.RecordedExercises)
                 .Where(x => x.FirstRecordedSet is not null)
                 .MaxBy(x => x.MaxWeightLifted);

--- a/LiftLog.Ui/Store/Stats/StatsEffects.cs
+++ b/LiftLog.Ui/Store/Stats/StatsEffects.cs
@@ -27,7 +27,8 @@ public class StatsEffects(
 
         var latestTime = DateOnly.FromDateTime(DateTime.Now);
         var earliestTime = DateOnly.FromDateTime(
-            latestTime.ToDateTime(TimeOnly.MinValue) - state.Value.OverallViewTime
+            latestTime.ToDateTime(TimeOnly.MinValue, DateTimeKind.Local)
+                - state.Value.OverallViewTime
         );
 
         var filteringToCurrentSessions = "CURRENT_SESSIONS".Equals(
@@ -69,7 +70,10 @@ public class StatsEffects(
                 .SelectMany(x =>
                     x.RecordedExercises.Where(y => y.LastRecordedSet?.Set is not null)
                         .Select(ex => new DatedRecordedExercise(
-                            x.Date.ToDateTime(ex.LastRecordedSet!.Set!.CompletionTime),
+                            x.Date.ToDateTime(
+                                ex.LastRecordedSet!.Set!.CompletionTime,
+                                DateTimeKind.Local
+                            ),
                             ex
                         ))
                 )
@@ -141,7 +145,7 @@ public class StatsEffects(
             sessions
                 .Where(x => x.Bodyweight is not null)
                 .Select(session => new TimeTrackedStatistic(
-                    session.Date.ToDateTime(TimeOnly.MinValue),
+                    session.Date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Local),
                     session.Bodyweight!.Value
                 ))
                 .ToImmutableList()
@@ -154,7 +158,7 @@ public class StatsEffects(
             sessions.Key,
             sessions
                 .Select(session => new TimeTrackedStatistic(
-                    session.Date.ToDateTime(TimeOnly.MinValue),
+                    session.Date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Local),
                     session.TotalWeightLifted
                 ))
                 .ToImmutableList()


### PR DESCRIPTION
This PR Fixes: #283 

## Date Off By 1
All dates/times in LiftLog are stored in Local time (no offset or timezone information).

This PR acheives two things:
 1. Ensure that we specify the `Kind` whenever we create a DateTime from a DateOnly/TimeOnly as Local.  This has no effect on the issue addressed in this PR but it is good to be explicit.
 2. Amends the apex charts options to specify that our dates are not UTC, so it should display them verbatim

## Empty sessions don't show bodyweight in stats

Additionally, this PR amends the stats calculations to show sessions in the bodyweight card even when there are no exercises in that session

![image](https://github.com/user-attachments/assets/b9a83d6e-838f-4f00-a0ba-65801ce5b576)

![image](https://github.com/user-attachments/assets/d2829b2d-b370-418c-a546-43939424ad76)
