### PR TITLE
Fix calendar showing previous month days backwards

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/HistoryCalendar.razor
+++ b/LiftLog.Ui/Shared/Presentation/HistoryCalendar.razor
@@ -3,8 +3,9 @@
 
 @{
     var firstDayOfMonth = new DateOnly(CurrentYear, CurrentMonth, 1);
-    var firstDayOfWeek = (int)firstDayOfMonth.DayOfWeek;
-    var lastDayOfPreviousMonth = firstDayOfMonth.AddDays(-1);
+    var dayOfFirstDayOfTheMonth = (int)firstDayOfMonth.DayOfWeek;
+    // If the first day of the month is Sunday (0) we show no days from the previous month as it is a full week
+    var numberOfDaysToShowFromPreviousMonth = dayOfFirstDayOfTheMonth;
     var index = 0;
 }
 <div class="grid grid-cols-7 gap-2 justify-center items-center">
@@ -25,9 +26,9 @@
     <span>@(DateTimeFormatInfo.CurrentInfo.GetShortestDayName(DayOfWeek.Thursday))</span>
     <span>@(DateTimeFormatInfo.CurrentInfo.GetShortestDayName(DayOfWeek.Friday))</span>
     <span>@(DateTimeFormatInfo.CurrentInfo.GetShortestDayName(DayOfWeek.Saturday))</span>
-    @for (int i = 0; i < firstDayOfWeek; i++)
+    @for (int i = -numberOfDaysToShowFromPreviousMonth; i < 0; i++)
     {
-        var date = lastDayOfPreviousMonth.AddDays(-i);
+        var date = firstDayOfMonth.AddDays(i);
         <HistoryCalendarDay ForOtherMonth=true @key=@(date.ToString()+index) Index="index++" Day=date Sessions=_sessionsByDate[date] OnDayClick=@(()=>HandleDayClick(date)) OnDayLongPress=@(()=>HandleDayLongPress(date)) />
     }
     @for (int i = 1; i <= DateTime.DaysInMonth(CurrentYear, CurrentMonth); i++)


### PR DESCRIPTION
The calendar was incorrectly showing the previous month's days in reverse order as shown in this screenshot:
![image](https://github.com/user-attachments/assets/7fd9b7a3-8dce-401a-b8dd-5977d42c556f)

This PR fixes it so that they are displayed in correct ascending order
