### PR TITLE
Ensure weight of next exercise comes from same number of reps

### DIFF
--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -136,6 +136,39 @@ describe('Completing a session', () => {
         cy.getA('[data-cy=weight-display]').first().should('contain.text', '15kg')
       })
 
+      it('can complete a workout and change the number of reps with it not adding progressive overload', () => {
+        cy.containsA('Workout A').click()
+        cy.containsA('Rest between').should('not.exist')
+        updateWeight(0, 20)
+        cy.getA('.repcount').first().click().should('contain.text', '5/5')
+        cy.getA('.snackbar').contains('Rest between').should('be.visible')
+
+        cy.getA('.itemlist div').eq(0).should('contain.text', 'Squat')
+        cy.getA('[data-cy=weight-display]').first().should('contain.text', '20kg')
+
+        // Update number of reps on the exercise
+        cy.getA('[data-cy=more-exercise-btn]').first().click()
+        cy.getA('[data-cy=exercise-edit-menu-button]').first().click()
+
+        // Update the number of reps to 6
+        cy.dialog().find('[data-cy=exercise-reps]').should('contain.text', '5').find('[data-cy=fixed-increment]').click()
+        cy.dialog().contains("Update").click()
+
+        // Complete all sets
+        for (let i = 1; i <= 6; i++) {
+          cy.getA('.repcount').eq(i).click()
+        }
+
+        cy.contains('Finish').click()
+
+        cy.getA('[data-cy=session-summary-title]').eq(0).should('contain.text', 'Workout B')
+        cy.getA('[data-cy=session-summary-title]').eq(1).should('contain.text', 'Workout A').click()
+
+        cy.getA('[data-cy=weighted-exercise]').eq(0).should('contain.text', 'Squat')
+        // Since the number of reps was increased, the weight should not have increased because it is a "different" exercise
+        cy.getA('[data-cy=weight-display]').first().should('contain.text', '0kg')
+      })
+
       it('can add notes to an exercise and see them the next time they do that exercise', () => {
         cy.containsA('Workout A').click()
 

--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -63,34 +63,36 @@ public record ExerciseBlueprint(
         );
 }
 
-public sealed record KeyedExerciseBlueprint : IEquatable<KeyedExerciseBlueprint>
+public record KeyedExerciseBlueprint(string Name, int Sets, int RepsPerSet)
 {
-    private readonly string normalizedName = string.Empty;
-    public string Name { get; }
+    public static implicit operator KeyedExerciseBlueprint(ExerciseBlueprint e) =>
+        new(e.Name, e.Sets, e.RepsPerSet);
 
-    public KeyedExerciseBlueprint(string name)
+    public class NormalizedNameOnlyEqualityComparer : IEqualityComparer<KeyedExerciseBlueprint>
     {
-        Name = name;
-        normalizedName = NormalizeName(name);
-    }
+        public static readonly NormalizedNameOnlyEqualityComparer Instance = new();
 
-    public static implicit operator KeyedExerciseBlueprint(ExerciseBlueprint e) => new(e.Name);
+        public bool Equals(KeyedExerciseBlueprint? x, KeyedExerciseBlueprint? y) =>
+            NormalizeName(x?.Name) == NormalizeName(y?.Name);
 
-    public bool Equals(KeyedExerciseBlueprint? other) => other?.normalizedName == normalizedName;
+        public int GetHashCode(KeyedExerciseBlueprint obj) => NormalizeName(obj.Name).GetHashCode();
 
-    public override int GetHashCode() => normalizedName.GetHashCode();
-
-    private static string NormalizeName(string name)
-    {
-        var lowerName = name.ToLower().Trim().Replace("flies", "flys").Replace("flyes", "flys");
-        var withoutPlural = lowerName switch
+        private static string NormalizeName(string? name)
         {
-            string when lowerName.EndsWith("es") => lowerName[..^2],
-            string when lowerName.EndsWith('s') => lowerName[..^1],
-            _ => lowerName,
-        };
+            if (name is null)
+            {
+                return string.Empty;
+            }
+            var lowerName = name.ToLower().Trim().Replace("flies", "flys").Replace("flyes", "flys");
+            var withoutPlural = lowerName switch
+            {
+                string when lowerName.EndsWith("es") => lowerName[..^2],
+                string when lowerName.EndsWith('s') => lowerName[..^1],
+                _ => lowerName,
+            };
 
-        return withoutPlural;
+            return withoutPlural;
+        }
     }
 }
 

--- a/LiftLog.Ui/Services/ProgressRepository.cs
+++ b/LiftLog.Ui/Services/ProgressRepository.cs
@@ -170,7 +170,10 @@ namespace LiftLog.Ui.Services
                         ))
                         .ToAsyncEnumerable()
                 )
-                .GroupBy(x => (KeyedExerciseBlueprint)x.RecordedExercise.Blueprint)
+                .GroupBy(
+                    x => (KeyedExerciseBlueprint)x.RecordedExercise.Blueprint,
+                    KeyedExerciseBlueprint.NormalizedNameOnlyEqualityComparer.Instance
+                )
                 .ToImmutableDictionaryAwaitAsync(
                     x => ValueTask.FromResult(x.Key),
                     async x => await x.Take(maxRecordsPerExercise).ToImmutableListValueAsync()

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -20,7 +20,7 @@
                     <div>
                         <IconButton data-cy="more-exercise-btn" class="self-end" Type="IconButtonType.Standard" OnClick="() => { _menu?.Open(); }" Icon="more_horiz" id="@moreButtonId"/>
                         <Menu @ref="_menu" anchor="@moreButtonId">
-                            <MenuItem Label="Edit" Icon="edit" OnClick="OnEditExercise"/>
+                            <MenuItem Label="Edit" Icon="edit" data-cy="exercise-edit-menu-button" OnClick="OnEditExercise"/>
                             <MenuItem data-cy="exercise-notes-btn" Label="Notes" Icon="notes" OnClick="OnOpenNotesButtonClick"/>
                             <MenuItem Label="Remove" Icon="delete" OnClick="OnRemoveExercise"/>
                         </Menu>

--- a/LiftLog.Ui/Store/Stats/StatsEffects.cs
+++ b/LiftLog.Ui/Store/Stats/StatsEffects.cs
@@ -78,7 +78,10 @@ public class StatsEffects(
                             ex
                         ))
                 )
-                .GroupBy(x => new KeyedExerciseBlueprint(x.RecordedExercise.Blueprint.Name))
+                .GroupBy(
+                    x => (KeyedExerciseBlueprint)x.RecordedExercise.Blueprint,
+                    KeyedExerciseBlueprint.NormalizedNameOnlyEqualityComparer.Instance
+                )
                 .Select(CreateExerciseStatistic)
                 .ToImmutableList();
 
@@ -108,7 +111,10 @@ public class StatsEffects(
             var exerciseMostTimeSpent = sessionsWithExercises
                 .SelectMany(x => x.RecordedExercises)
                 .Where(x => x.LastRecordedSet?.Set is not null)
-                .GroupBy(x => new KeyedExerciseBlueprint(x.Blueprint.Name))
+                .GroupBy(
+                    x => (KeyedExerciseBlueprint)x.Blueprint,
+                    KeyedExerciseBlueprint.NormalizedNameOnlyEqualityComparer.Instance
+                )
                 .Select(x => new TimeSpentExercise(
                     x.First().Blueprint.Name,
                     x.Select(x => x.TimeSpent).Aggregate((a, b) => a + b)


### PR DESCRIPTION
https://github.com/LiamMorrow/LiftLog/pull/280 introduced an issue where the next time you do an exercise with the same name, it set the weight to the previous weight (with progressive overload), regardless of if it was the same amount of reps/sets.

This PR fixes that behaviour so weight only carries over if the reps and sets are the same as well as the exercise name (original behaviour). 