### PR TITLE
Fix: Rep counter not showing focus ring

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -1,9 +1,6 @@
 ﻿@{
-    var (displayedExercise, repToStartNext) = (PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise) switch
-    {
-        null => (RecordedExercise, -1),
-        _ => (RecordedExercise, RecordedExercise.PotentialSets.IndexOf(x => x.Set is null))
-    };
+    var displayedExercise = RecordedExercise;
+    var setToStartNext = RecordedExercise.PotentialSets.IndexOf(x => x.Set is null);
     var previousNotes = PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise?.Notes ?? "";
     var thisNotes = RecordedExercise.Notes ?? "";
     var blueprintNotes = RecordedExercise.Blueprint.Notes;
@@ -53,7 +50,7 @@
                 OnTap=@(() => {if(!IsReadonly) CycleRepCountForSet(i);})
                 OnHold=@(() => {if(!IsReadonly) ShowAdditionalActionsForSet(i);})
                 OnUpdateWeight=@((weight) => {if(!IsReadonly) UpdateWeightForSet(i, weight);})
-                ToStartNext=@(ToStartNext && repToStartNext == i && !IsReadonly)
+                ToStartNext=@(ToStartNext && setToStartNext == i && !IsReadonly)
                 IsReadonly=@IsReadonly />
         }
     </div>


### PR DESCRIPTION
This commit fixes the issue where the next set was not showing a focus ring.  In the migraiton away from 'hold previous to show it', a bad path was followed which always set the next set to be -1.

Before:
![image](https://github.com/user-attachments/assets/20dfcbc5-a1e8-4224-8bc3-509d74ce7ea0)
After
![image](https://github.com/user-attachments/assets/230967dc-d8dd-45a4-9c21-da5793791be4)
