### PR TITLE
Specify a key when rendering the list of stats

### DIFF
--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -77,7 +77,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
         <Card class=@CardClass>
             <StatGraphCardContent Title="Sessions" Statistics="overallStats.SessionStats" RenderDelay="TimeSpan.FromMilliseconds(200)"/>
         </Card>
-        <CardList Items="@(UnpinnedExercisesToShow.IndexedTuples())">
+        <CardList KeySelector="context=>context.Item.ExerciseName" Items="@(UnpinnedExercisesToShow.IndexedTuples())" >
             <StatGraphCardContent Title="@context.Item.ExerciseName" Statistics="[context.Item.Statistics, context.Item.OneRepMaxStatistics]" RenderDelay="TimeSpan.FromMilliseconds(200 + context.Index * 200)"/>
         </CardList>
         @if(SearchTerm != "" && !UnpinnedExercisesToShow.Any())

--- a/LiftLog.Ui/Shared/Presentation/CardList.razor
+++ b/LiftLog.Ui/Shared/Presentation/CardList.razor
@@ -1,9 +1,13 @@
 @typeparam TItem
 
 <div @attributes="AdditionalAttributes" class=" @(AdditionalAttributes?.GetValueOrDefault("class")) flex flex-col gap-2 p-2 cardlist">
+    @{
+        var index = 0;
+    }
     @foreach (var item in Items)
     {
         <Card
+            @key="KeySelector?.Invoke(item) ?? index++"
             class="@CardClass"
             Type="CardType"
             OnLongPress=@(OnLongPress.HasDelegate ? ()=>OnLongPress.InvokeAsync(item) : default!)
@@ -29,6 +33,8 @@
     [Parameter] public string? CardClass { get; set; }
 
     [Parameter] public Card.CardType CardType { get; set; } = Card.CardType.Outlined;
+
+    [Parameter] public Func<TItem, object>? KeySelector { get; set; }
 
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? AdditionalAttributes { get; set; }


### PR DESCRIPTION
The default behaviour was to reuse the same component as the list changes, however we should not be reusing the stats cards as they do not rerender on changes. Fixes: #295