### PR TITLE
Hide the previous button on the history and feed page

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -12,7 +12,10 @@
             @if(!IsReadonly)
             {
                 <div class="flex justify-end">
-                    <IconButton data-cy="prev-exercise-btn" Type="IconButtonType.Standard" Icon="history" OnClick="ShowPrevious"/>
+                    @if(ShowPreviousButton)
+                    {
+                        <IconButton data-cy="prev-exercise-btn" Type="IconButtonType.Standard" Icon="history" OnClick="ShowPrevious"/>
+                    }
                     <IconButton data-cy="per-rep-weight-btn" Type=IconButtonType.Standard Icon=weight OnClick="ToggleExercisePerSetWeight"></IconButton>
                     <div>
                         <IconButton data-cy="more-exercise-btn" class="self-end" Type="IconButtonType.Standard" OnClick="() => { _menu?.Open(); }" Icon="more_horiz" id="@moreButtonId"/>
@@ -142,6 +145,8 @@
     [EditorRequired] [Parameter] public Action OnRemoveExercise { get; set; } = null!;
 
     [Parameter] public bool IsReadonly { get; set; } = false;
+
+    [EditorRequired] [Parameter] public bool ShowPreviousButton { get; set; }
 
     private void HandleNotesChange(string value)
     {

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -34,7 +34,8 @@ else
             UpdateNotesForExercise=@((notes) => UpdateNotesForExercise(context.Index, notes))
             OnEditExercise=@(() => BeginEditExercise(context.Index))
             OnRemoveExercise=@(() => BeginRemoveExercise(context.Index))
-            IsReadonly=IsReadonly />
+            IsReadonly=IsReadonly
+            ShowPreviousButton=@(SessionTarget == SessionTarget.WorkoutSession) />
     </ItemList>
 }
 @if (ShowBodyweight)
@@ -78,7 +79,9 @@ else
 @if(IsInActiveScreen && !IsReadonly)
 {
     <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
-        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=SaveSession>Finish</AppButton>
+        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=SaveSession>
+            @(SessionTarget == SessionTarget.WorkoutSession ? "Finish" : "Save")
+        </AppButton>
     </Microsoft.AspNetCore.Components.Sections.SectionContent>
 }
 


### PR DESCRIPTION
Fixes: #292 

A previous commit accidentally exposed the previous button on the history page, this PR just hides it again