### PR TITLE
Remember and reopen history and feed pages when navigating

### DIFF
--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -135,6 +135,7 @@
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new FetchSessionFeedItemsAction(FromUserAction: false));
         Dispatcher.Dispatch(new FetchInboxItemsAction(FromUserAction: false));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.FeedSession, false));
         Dispatcher.Dispatch(new PublishUnpublishedSessionsAction());
         if (FeedState.Value.Identity is null)
         {

--- a/LiftLog.Ui/Pages/Feed/ViewFeedSessionPage.razor
+++ b/LiftLog.Ui/Pages/Feed/ViewFeedSessionPage.razor
@@ -32,6 +32,7 @@
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Feed Session"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/feed"));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.FeedSession, true));
 
         var hasSession = false;
 

--- a/LiftLog.Ui/Pages/History/HistoryEditPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryEditPage.razor
@@ -47,6 +47,7 @@
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Session"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/history"));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.HistorySession, true));
         if (CurrentSessionState.Value.HistorySession is null)
         {
             NavigationManager.NavigateTo("/history");

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -106,6 +106,7 @@ else
         var sw = System.Diagnostics.Stopwatch.StartNew();
         Dispatcher.Dispatch(new SetPageTitleAction("History"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.HistorySession, false));
         this._latestSessions = await SessionService
             .GetLatestSessionsAsync()
             .ToListAsync();

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -97,7 +97,7 @@ else
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Upcoming Workouts"));
         Dispatcher.Dispatch(new FetchUpcomingSessionsAction());
-        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(false));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.WorkoutSession, false));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new PublishUnpublishedSessionsAction());
         Dispatcher.Dispatch(new ExecuteRemoteBackupAction(SettingsState.Value.RemoteBackupSettings));

--- a/LiftLog.Ui/Pages/PostSessionPage.razor
+++ b/LiftLog.Ui/Pages/PostSessionPage.razor
@@ -29,7 +29,7 @@
         }
 
         Dispatcher.Dispatch(new SetPageTitleAction("Session Summary"));
-        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(false));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.WorkoutSession, false));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Session = await ProgressRepository.GetSessionAsync(id);
         if (Session is null)

--- a/LiftLog.Ui/Pages/SessionPage.razor
+++ b/LiftLog.Ui/Pages/SessionPage.razor
@@ -32,7 +32,7 @@
     protected override async Task OnInitializedAsync()
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Session"));
-        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(true));
+        Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.WorkoutSession, true));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/"));
         if (CurrentSessionState.Value.WorkoutSession is null)
         {

--- a/LiftLog.Ui/Shared/Smart/NavBar.razor
+++ b/LiftLog.Ui/Shared/Smart/NavBar.razor
@@ -45,7 +45,7 @@
     private void NavigateToWorkout()
     {
         if (CurrentSessionState.Value.WorkoutSession != null
-            && AppState.Value.ReopenCurrentSession
+            && AppState.Value.ReopenCurrentSessionTargets.Contains(SessionTarget.WorkoutSession)
             && !IsRouteMatch("/session/?$"))
         {
             Dispatcher.Dispatch(new NavigateAction("/session", ClearPageStack: false));
@@ -71,12 +71,32 @@
 
     private void NavigateToFeed()
     {
+        if (CurrentSessionState.Value.FeedSession != null
+            && AppState.Value.ReopenCurrentSessionTargets.Contains(SessionTarget.FeedSession)
+            && !IsRouteMatch("/feed/?.*$"))
+        {
+            var feedItem = FeedState.Value.Feed.OfType<SessionFeedItem>().FirstOrDefault(x => x.Session.Id == CurrentSessionState.Value.FeedSession.Id);
+            if (feedItem != null)
+            {
+                Dispatcher.Dispatch(new NavigateAction("feed/view-session/"+feedItem.EventId, ClearPageStack: false));
+                StateHasChanged();
+                return;
+            }
+        }
         Dispatcher.Dispatch(new NavigateAction("/feed", ClearPageStack: false));
         StateHasChanged();
     }
 
     private void NavigateToHistory()
     {
+        if (CurrentSessionState.Value.HistorySession != null
+            && AppState.Value.ReopenCurrentSessionTargets.Contains(SessionTarget.HistorySession)
+            && !IsRouteMatch("/history/?.*$"))
+        {
+            Dispatcher.Dispatch(new NavigateAction("/history/edit", ClearPageStack: false));
+            StateHasChanged();
+            return;
+        }
         Dispatcher.Dispatch(new NavigateAction("/history", ClearPageStack: false));
         StateHasChanged();
     }

--- a/LiftLog.Ui/Store/App/AppActions.cs
+++ b/LiftLog.Ui/Store/App/AppActions.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using LiftLog.Lib.Models;
 using LiftLog.Ui.Models;
+using LiftLog.Ui.Store.CurrentSession;
 
 namespace LiftLog.Ui.Store.App;
 
@@ -8,7 +9,7 @@ public record SetPageTitleAction(string Title);
 
 public record SetProTokenAction(string? ProToken);
 
-public record SetReopenCurrentSessionAction(bool ReopenCurrentSession);
+public record SetReopenCurrentSessionAction(SessionTarget SessionTarget, bool ReopenSession);
 
 public record ToastAction(string Message);
 

--- a/LiftLog.Ui/Store/App/AppFeature.cs
+++ b/LiftLog.Ui/Store/App/AppFeature.cs
@@ -10,18 +10,5 @@ public class AppFeature : Feature<AppState>
 {
     public override string GetName() => nameof(AppFeature);
 
-    protected override AppState GetInitialState() =>
-        new(
-            Title: "LiftLog",
-            IsHydrated: false,
-            ProState: new ProState(ProToken: null),
-            ReopenCurrentSession: true,
-            BackNavigationUrl: null,
-            LatestSettingsUrl: null,
-            HasRequestedNotificationPermission: false,
-            ColorScheme: new AppColorScheme<uint>(),
-            AppLaunchCount: 0,
-            AppRatingResult: AppRatingResult.NotRated,
-            HistoryYearMonth: null
-        );
+    protected override AppState GetInitialState() => AppState.InitialState;
 }

--- a/LiftLog.Ui/Store/App/AppReducers.cs
+++ b/LiftLog.Ui/Store/App/AppReducers.cs
@@ -50,7 +50,13 @@ public static class AppReducers
     public static AppState SetReopenCurrentSession(
         AppState state,
         SetReopenCurrentSessionAction action
-    ) => state with { ReopenCurrentSession = action.ReopenCurrentSession };
+    ) =>
+        state with
+        {
+            ReopenCurrentSessionTargets = action.ReopenSession
+                ? state.ReopenCurrentSessionTargets.Add(action.SessionTarget)
+                : state.ReopenCurrentSessionTargets.Remove(action.SessionTarget),
+        };
 
     [ReducerMethod]
     public static AppState SetBackNavigationUrl(

--- a/LiftLog.Ui/Store/App/AppState.cs
+++ b/LiftLog.Ui/Store/App/AppState.cs
@@ -1,7 +1,9 @@
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using LiftLog.Lib;
 using LiftLog.Lib.Models;
 using LiftLog.Ui.Models;
+using LiftLog.Ui.Store.CurrentSession;
 
 namespace LiftLog.Ui.Store.App;
 
@@ -9,7 +11,7 @@ public record AppState(
     string Title,
     ProState ProState,
     bool IsHydrated,
-    bool ReopenCurrentSession,
+    ImmutableHashSet<SessionTarget> ReopenCurrentSessionTargets,
     string? BackNavigationUrl,
     string? LatestSettingsUrl,
     bool HasRequestedNotificationPermission,
@@ -17,7 +19,28 @@ public record AppState(
     int AppLaunchCount,
     AppRatingResult AppRatingResult,
     (int Year, int Month)? HistoryYearMonth
-);
+)
+{
+    public static readonly AppState InitialState =
+        new(
+            Title: "LiftLog",
+            IsHydrated: false,
+            ProState: new ProState(ProToken: null),
+            ReopenCurrentSessionTargets:
+            [
+                SessionTarget.WorkoutSession,
+                SessionTarget.HistorySession,
+                SessionTarget.FeedSession,
+            ],
+            BackNavigationUrl: null,
+            LatestSettingsUrl: null,
+            HasRequestedNotificationPermission: false,
+            ColorScheme: new AppColorScheme<uint>(),
+            AppLaunchCount: 0,
+            AppRatingResult: AppRatingResult.NotRated,
+            HistoryYearMonth: null
+        );
+};
 
 public enum AppRatingResult
 {


### PR DESCRIPTION
The 'current session' has a behaviour where navigating with the nav bar remembers it and keeps it open, without having to go back to the 'base' page first.

This commit adds this behaviour for history and feed.  The advantage of this is now you can open a historical session, go back to your current session, and go back to the historical session, without having to find it in the list again.

Simply tap the nav button again to go to the 'base' page.

Before:

https://github.com/user-attachments/assets/ee0c78bb-3075-46b9-83a0-e64932f4d0b1

After:

https://github.com/user-attachments/assets/c634e85b-4ea7-431d-b0c9-afd9750139f1

