### PR TITLE
Stop freeform exercises from interrupting plan

### DIFF
--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -115,6 +115,8 @@ public record Session(
         RecordedExercises.Sum(ex =>
             ex.PotentialSets.Sum(set => (set.Set?.RepsCompleted ?? 0) * set.Weight)
         );
+
+    public bool IsFreeform => Blueprint.Name == "Freeform Session";
 }
 
 public record RecordedExercise(

--- a/LiftLog.Ui/Services/SessionService.cs
+++ b/LiftLog.Ui/Services/SessionService.cs
@@ -32,7 +32,9 @@ public class SessionService(
         var latestSession = currentSession switch
         {
             { IsStarted: true } => currentSession,
-            _ => await progressRepository.GetOrderedSessions().FirstOrDefaultAsync(),
+            _ => await progressRepository
+                .GetOrderedSessions()
+                .FirstOrDefaultAsync(x => !x.IsFreeform),
         };
         if (latestSession == null)
         {


### PR DESCRIPTION
Sometimes a user does a freeform session during their plan.  This no longer resets their progress through their plan

Fixes: #293 

https://github.com/user-attachments/assets/d219b282-a153-484b-a786-a555c10ddf2d

