### PR TITLE
Add a tip on plaintext

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       KEYCHAIN: job-${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: 8.0.x
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.1
+          xcode-version: latest-stable
       - name: Put distribution cert
         env: # Or as an environment variable
           APPLE_DISTRIBUTION_CERT_P12_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERT_P12_BASE64 }}

--- a/.github/workflows/ios-publish.yml
+++ b/.github/workflows/ios-publish.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       KEYCHAIN: job-${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
 
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: 8.0.x
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.1
+          xcode-version: latest-stable
       - uses: mlilback/build-number@v1
         name: Set build number
         id: buildNumber

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/PlainTextExportPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/PlainTextExportPage.razor
@@ -6,9 +6,9 @@
 
 <Card Type="Card.CardType.Filled" class="mx-6 mb-4">
     <div>
-        This feature allows you to export your data in a plain text format such as CSV for use in other applications.
+        This feature allows you to export your data in a plaintext format such as CSV for use in other applications.
         It is not intended for backup purposes. For backups, please use the backup feature.
-        LiftLog cannot restore data from plain text exports.
+        LiftLog cannot restore data from plaintext exports.
     </div>
     <AppButton OnClick="OpenDocumentation" Type="AppButtonType.Text">Read Documentation</AppButton>
 </Card>
@@ -31,7 +31,7 @@
 
     protected override void OnInitialized()
     {
-        Dispatcher.Dispatch(new SetPageTitleAction("Plain Text Export"));
+        Dispatcher.Dispatch(new SetPageTitleAction("Plaintext Export"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/backup-and-restore"));
         base.OnInitialized();
     }

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
@@ -23,8 +23,8 @@
     </md-list-item>
     <md-list-item type="button" class="text-left" multi-line-supporting-text @onclick="PlainTextExport">
         <md-icon slot="start">description</md-icon>
-        <span slot="headline">Plain text export</span>
-        <span slot="supporting-text">Export your data in a plain text format such as CSV for use in other applications</span>
+        <span slot="headline">Plaintext export</span>
+        <span slot="supporting-text">Export your data in a plaintext format such as CSV for use in other applications</span>
     </md-list-item>
 </md-list>
 

--- a/LiftLog.Ui/Shared/Smart/Tips/PlainTextExportTip.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/PlainTextExportTip.razor
@@ -1,0 +1,3 @@
+<div class="flex flex-col gap-2">
+    <span>LiftLog supports exporting your data as a CSV! Simply navigate to <span class="text-primary">Settings -> Export -> Plaintext Export</span></span>
+</div>

--- a/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
+++ b/LiftLog.Ui/Shared/Smart/Tips/Tips.razor
@@ -38,13 +38,16 @@
             case 9:
                 <HoldingRepCounterTip/>
                 break;
+            case 10:
+                <PlainTextExportTip/>
+                break;
         }
     </Card>
 }
 
 @code
 {
-    private static readonly int totalTips = 9;
+    private static readonly int totalTips = 10;
 
     private void HandleNextClick()
     {

--- a/release_notes/whatsnew-en-AU
+++ b/release_notes/whatsnew-en-AU
@@ -1,1 +1,1 @@
-LiftLog can now export your data in plain text as a CSV!
+LiftLog can now export your data in plaintext as a CSV!


### PR DESCRIPTION
Just adds a tip to let people know that plaintext export is available
<img width="373" alt="image" src="https://github.com/user-attachments/assets/217f9cc5-95f2-41eb-9640-8f19f5363717">
