### PR TITLE
Add a backup reminder

### DIFF
--- a/LiftLog.Api/Db/UserDataContext.cs
+++ b/LiftLog.Api/Db/UserDataContext.cs
@@ -18,7 +18,7 @@ public class UserDataContext(DbContextOptions<UserDataContext> options) : DbCont
     /// <summary>
     /// Used to register the user event filter tuple type as a DbSet for use in FromSqlRaw.
     /// </summary>
-    public DbSet<UserEventFilter> UserEventFilterStubDbSet { get; set; }
+    public DbSet<UserEventFilter> UserEventFilterStubDbSet { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -88,6 +88,8 @@ else
     </TextContent>
 </ConfirmationDialog>
 
+<BackupAlert />
+
 @code {
 
     private ConfirmationDialog? replaceCurrentSesisonDialog;

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
@@ -2,6 +2,7 @@
 @inject IDispatcher Dispatcher
 @inject IJSRuntime JSRuntime
 @inject IDeviceService DeviceService
+@inject IState<SettingsState> SettingsState
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
@@ -26,6 +27,7 @@
         <span slot="headline">Plaintext export</span>
         <span slot="supporting-text">Export your data in a plaintext format such as CSV for use in other applications</span>
     </md-list-item>
+    <ListSwitch Headline="Backup reminders" SupportingText="Periodically suggest a backup when you have not backed up in a while" Value="@SettingsState.Value.BackupReminder" OnSwitched="SetBackupReminder" />
 </md-list>
 
 
@@ -58,12 +60,26 @@
     private ConfirmationDialog? importFeedDialog;
     private ConfirmationDialog? exportFeedDialog;
     private InputFile? fileInput;
+
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "backup")]
+    public bool Backup { get; set; }
+
     protected override void OnInitialized()
     {
         Dispatcher.Dispatch(new SetPageTitleAction("Export, Backup and Restore"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
         SubscribeToAction<BeginFeedImportAction>(OnBeginFeedImport);
         base.OnInitialized();
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        if (firstRender && Backup)
+        {
+            exportFeedDialog?.Open();
+        }
     }
 
     private async Task LoadFiles(InputFileChangeEventArgs e)
@@ -96,6 +112,8 @@
         importedFeedState = action.FeedState;
         importFeedDialog?.Open();
     }
+
+    private void SetBackupReminder(bool value) => Dispatcher.Dispatch(new SetBackupReminderAction(value));
 
     private void ImportFeedData()
     {

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -178,4 +178,31 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
     {
         return await preferenceStore.GetItemAsync("lastSuccessfulRemoteBackupHash");
     }
+
+    public async Task SetLastBackupTimeAsync(DateTimeOffset time)
+    {
+        await preferenceStore.SetItemAsync("lastBackupTime", time.ToString("O"));
+    }
+
+    public async Task<DateTimeOffset> GetLastBackupTimeAsync()
+    {
+        var lastBackupTime = await preferenceStore.GetItemAsync("lastBackupTime");
+        if (DateTimeOffset.TryParse(lastBackupTime, out var time))
+            return time;
+        else
+        {
+            await SetLastBackupTimeAsync(DateTimeOffset.Now);
+            return DateTimeOffset.Now;
+        }
+    }
+
+    public async Task SetBackupReminderAsync(bool showReminder)
+    {
+        await preferenceStore.SetItemAsync("backupReminder", showReminder.ToString());
+    }
+
+    public async Task<bool> GetBackupReminderAsync()
+    {
+        return await preferenceStore.GetItemAsync("backupReminder") is "True" or null;
+    }
 }

--- a/LiftLog.Ui/Shared/Smart/BackupAlert.razor
+++ b/LiftLog.Ui/Shared/Smart/BackupAlert.razor
@@ -1,0 +1,58 @@
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+@inject IState<SettingsState> SettingsState
+@inject IDispatcher Dispatcher
+
+<Dialog @ref="dialog" @ondialog-cancel="No" type="alert">
+    <span slot="headline">Back up data</span>
+    <span slot="content" class="block text-left">
+        It has been a while since you last created a backup. It is HIGHLY recommended you back up your data regularly to prevent data loss.
+        Would you like to back up your data now?
+    </span>
+    <div slot="actions">
+        <AppButton Type="AppButtonType.Text" OnClick="DontAsk">Don't ask again</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="No">No</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="BackUp">Yes</AppButton>
+    </div>
+</Dialog>
+
+@code {
+    private Dialog? dialog;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+        if (firstRender)
+        {
+            var lastBackupTime = SettingsState.Value.LastBackupTime;
+            var timeSinceLastBackup = DateTimeOffset.Now - lastBackupTime;
+            if (SettingsState.Value.BackupReminder && timeSinceLastBackup.TotalDays > 7)
+            {
+                dialog?.Open();
+            }
+        }
+    }
+
+    private void DontAsk()
+    {
+        Dispatcher.Dispatch(new SetBackupReminderAction(false));
+        dialog?.Close();
+    }
+
+    private void No()
+    {
+        dialog?.Close();
+    }
+
+    private async Task BackUp()
+    {
+        await dialog!.CloseWait();
+        Dispatcher.Dispatch(new NavigateAction("/settings/backup-and-restore?backup=true"));
+    }
+}

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -50,4 +50,8 @@ public record UpdateRemoteBackupSettingsAction(RemoteBackupSettings Settings);
 
 public record SetLastSuccessfulRemoteBackupHashAction(string Hash);
 
+public record SetLastBackupTimeAction(DateTimeOffset Time);
+
+public record SetBackupReminderAction(bool ShowReminder);
+
 public record ExportPlainTextAction(PlaintextExportFormat Format);

--- a/LiftLog.Ui/Store/Settings/SettingsFeature.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsFeature.cs
@@ -6,21 +6,5 @@ public class SettingsFeature : Feature<SettingsState>
 {
     public override string GetName() => nameof(SettingsFeature);
 
-    protected override SettingsState GetInitialState() =>
-        new(
-            IsHydrated: false,
-            AiWorkoutAttributes: null,
-            IsGeneratingAiPlan: false,
-            AiPlanError: null,
-            AiPlan: null,
-            UseImperialUnits: false,
-            ShowBodyweight: true,
-            ShowTips: true,
-            TipToShow: 1,
-            ShowFeed: true,
-            StatusBarFix: false,
-            RestNotifications: true,
-            RemoteBackupSettings: new RemoteBackupSettings(string.Empty, string.Empty, false),
-            LastSuccessfulRemoteBackupHash: string.Empty
-        );
+    protected override SettingsState GetInitialState() => SettingsState.Default;
 }

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -84,6 +84,18 @@ public static class SettingsReducers
     ) => state with { RemoteBackupSettings = action.Settings };
 
     [ReducerMethod]
+    public static SettingsState SetLastBackupTime(
+        SettingsState state,
+        SetLastBackupTimeAction action
+    ) => state with { LastBackupTime = action.Time };
+
+    [ReducerMethod]
+    public static SettingsState SetBackupReminder(
+        SettingsState state,
+        SetBackupReminderAction action
+    ) => state with { BackupReminder = action.ShowReminder };
+
+    [ReducerMethod]
     public static SettingsState SetLastSuccessfulRemoteBackupHash(
         SettingsState state,
         SetLastSuccessfulRemoteBackupHashAction action

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -17,8 +17,31 @@ public record SettingsState(
     bool StatusBarFix,
     bool RestNotifications,
     RemoteBackupSettings RemoteBackupSettings,
-    string LastSuccessfulRemoteBackupHash
-);
+    string LastSuccessfulRemoteBackupHash,
+    DateTimeOffset LastBackupTime,
+    bool BackupReminder
+)
+{
+    public static SettingsState Default =>
+        new(
+            IsHydrated: false,
+            AiWorkoutAttributes: null,
+            IsGeneratingAiPlan: false,
+            AiPlanError: null,
+            AiPlan: null,
+            UseImperialUnits: false,
+            ShowBodyweight: true,
+            ShowTips: true,
+            TipToShow: 1,
+            ShowFeed: true,
+            StatusBarFix: false,
+            RestNotifications: true,
+            RemoteBackupSettings: new RemoteBackupSettings(string.Empty, string.Empty, false),
+            LastSuccessfulRemoteBackupHash: string.Empty,
+            LastBackupTime: DateTimeOffset.MinValue,
+            BackupReminder: true
+        );
+}
 
 public record RemoteBackupSettings(string Endpoint, string ApiKey, bool IncludeFeedAccount)
 {

--- a/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
@@ -1,6 +1,5 @@
 using Fluxor;
 using LiftLog.Ui.Services;
-using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 
 namespace LiftLog.Ui.Store.Settings;
@@ -24,7 +23,9 @@ public class SettingsStateInitMiddleware(
                 statusBarFix,
                 restNotifications,
                 remoteBackupSettings,
-                lastSuccessfulRemoteBackupHash
+                lastSuccessfulRemoteBackupHash,
+                lastBackupTime,
+                backupReminder
             ) = await (
                 preferencesRepository.GetUseImperialUnitsAsync(),
                 preferencesRepository.GetShowBodyweightAsync(),
@@ -34,7 +35,9 @@ public class SettingsStateInitMiddleware(
                 preferencesRepository.GetStatusBarFixAsync(),
                 preferencesRepository.GetRestNotificationsAsync(),
                 preferencesRepository.GetRemoteBackupSettingsAsync(),
-                preferencesRepository.GetLastSuccessfulRemoteBackupHashAsync()
+                preferencesRepository.GetLastSuccessfulRemoteBackupHashAsync(),
+                preferencesRepository.GetLastBackupTimeAsync(),
+                preferencesRepository.GetBackupReminderAsync()
             );
 
             var state = (SettingsState)store.Features[nameof(SettingsFeature)].GetState() with
@@ -49,6 +52,8 @@ public class SettingsStateInitMiddleware(
                 RestNotifications = restNotifications,
                 RemoteBackupSettings = remoteBackupSettings,
                 LastSuccessfulRemoteBackupHash = lastSuccessfulRemoteBackupHash,
+                LastBackupTime = lastBackupTime,
+                BackupReminder = backupReminder,
             };
             store.Features[nameof(SettingsFeature)].RestoreState(state);
             sw.Stop();


### PR DESCRIPTION
As liftlog stores all data locally on device, it is important that backups are created regularly.

Users which don't use the automatic backup feature are prone to data loss if their phone breaks.

This PR adds a new alert which fires every 7 days, which will suggest a backup

<img width="378" alt="image" src="https://github.com/user-attachments/assets/4e7102af-0cef-4d7b-8500-94a76b9f87e4">

<img width="380" alt="image" src="https://github.com/user-attachments/assets/38791eb5-69ba-4dab-ad80-f07bc8d68365">
