### PR TITLE
Scrolling on selecting rep count

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/PotentialSetAdditionalActions.razor
+++ b/LiftLog.Ui/Shared/Presentation/PotentialSetAdditionalActions.razor
@@ -25,24 +25,24 @@
 
     [EditorRequired] [Parameter] public EventCallback OnDeleteSet { get; set; }
 
-    private int? lasPointerDownReps = int.MinValue;
+    private int? lastPointerDownReps = int.MinValue;
 
 
     private RenderFragment GetRepButton(RenderFragment childContent, int? reps, string color)
     {
         void OnPointerDown(PointerEventArgs e)
         {
-            lasPointerDownReps = reps;
+            lastPointerDownReps = reps;
         }
         // On iOS the click event is triggered when the user lifts their finger after the dialog is opened
         // This is a workaround to prevent the click event from being triggered until the user has actually tapped the button
         async Task OnClick()
         {
-            if (lasPointerDownReps != reps)
+            if (lastPointerDownReps != reps)
             {
                 return;
             }
-            lasPointerDownReps = int.MinValue;
+            lastPointerDownReps = int.MinValue;
             await OnSelectRepCount.InvokeAsync(reps);
         }
         return @<div class="flex flex-col items-center relative">

--- a/LiftLog.Ui/Shared/Presentation/PotentialSetAdditionalActions.razor
+++ b/LiftLog.Ui/Shared/Presentation/PotentialSetAdditionalActions.razor
@@ -1,13 +1,9 @@
 <div class="flex flex-wrap gap-2 justify-center mb-2 mx-4">
-    @GetRepButton(@<span>-</span>,
-        () => OnSelectRepCount.InvokeAsync(null),
-        "bg-secondary-container text-on-secondary-container")
+    @GetRepButton(@<span>-</span>, null, "bg-secondary-container text-on-secondary-container")
     @for(int i = 0; i < MaxReps + 1; i++)
     {
         var reps = i;
-        @GetRepButton(@<span class="font-bold">@reps</span>,
-            () => OnSelectRepCount.InvokeAsync(reps),
-            "bg-primary-container text-on-primary-container");
+        @GetRepButton(@<span class="font-bold">@reps</span>,reps, "bg-primary-container text-on-primary-container");
     }
 </div>
 <div class="flex flex-grow gap-2 justify-center">
@@ -15,9 +11,7 @@
     @for(int i = MaxReps+1; i < MaxReps + 4; i++)
     {
         var reps = i;
-        @GetRepButton(@<span class="font-bold">@reps</span>,
-            () => OnSelectRepCount.InvokeAsync(reps),
-            "bg-secondary-container text-on-secondary-container");
+        @GetRepButton(@<span class="font-bold">@reps</span>, reps, "bg-secondary-container text-on-secondary-container");
     }
 </div>
 
@@ -31,12 +25,31 @@
 
     [EditorRequired] [Parameter] public EventCallback OnDeleteSet { get; set; }
 
+    private int? lasPointerDownReps = int.MinValue;
 
-    private RenderFragment GetRepButton(RenderFragment childContent, Action onClick, string color)
+
+    private RenderFragment GetRepButton(RenderFragment childContent, int? reps, string color)
     {
+        void OnPointerDown(PointerEventArgs e)
+        {
+            lasPointerDownReps = reps;
+        }
+        // On iOS the click event is triggered when the user lifts their finger after the dialog is opened
+        // This is a workaround to prevent the click event from being triggered until the user has actually tapped the button
+        async Task OnClick()
+        {
+            if (lasPointerDownReps != reps)
+            {
+                return;
+            }
+            lasPointerDownReps = int.MinValue;
+            await OnSelectRepCount.InvokeAsync(reps);
+        }
         return @<div class="flex flex-col items-center relative">
             <button
-                @onclick="onClick"
+                @key="reps ?? int.MaxValue"
+                @onclick="OnClick"
+                @onpointerdown="OnPointerDown"
                 class="
                     repcount
                     flex-shrink-0

--- a/LiftLog.Ui/Shared/Presentation/PotentialSetAdditionalActions.razor
+++ b/LiftLog.Ui/Shared/Presentation/PotentialSetAdditionalActions.razor
@@ -36,7 +36,7 @@
     {
         return @<div class="flex flex-col items-center relative">
             <button
-                @onpointerdown="onClick"
+                @onclick="onClick"
                 class="
                     repcount
                     flex-shrink-0


### PR DESCRIPTION
**Problem:** When trying to scroll down in the scrollfield on exercises with a high rep count (30+ for example) the rep count button where you try to scroll on gets selected because it used `onpointerdown`. This makes it difficult on mobile to scroll down to select higher rep counts, since you have to scroll on a small area besides the buttons and the border. See video:

https://github.com/user-attachments/assets/e4d6eeda-4f1d-455a-945f-28c4620dd391

**Solution:** Use `onclick` event instead on rep count button. This way the rep button will only be selected when actually clicked not just when the pointer is down over the element.

**NOTE:** I have only tested this in the web version (not android or ios). The reason being that i couldn't get the project to build. Every time I tried, it said that it couldn't find the android sdk even if passed the path to the sdk manually. This is probably only a issue on Arch Linux because the Build Android github action worked fine (I think its the same problem as in this [SO Post](https://stackoverflow.com/questions/77796319/maui-android-app-build-in-pipeline-failing-with-error-the-android-sdk-directory) but their solution didn't work for me). So should be tested on mobile to be sure it doesn't break anything