### PR TITLE
Add a menu button to open links

### DIFF
--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -58,6 +58,8 @@
     placeholder="https://"
     SelectAllOnFocus="false"
     Value="@Exercise.Link"
+    error-text="@LinkValueError"
+    error=@(HasLinkError)
     OnPaste="@(e => HandleLinkPaste(e))"
     PreventDefaultPaste=true
     OnChange="@(val => SetExerciseLink(val!))"/>
@@ -121,6 +123,16 @@
     }
 
     void SetExerciseNotes(string notes) => UpdateExerciseHandler(exercise with { Notes = notes });
+
+    private string LinkValueError => exercise.Link switch
+        {
+            "" or null => "",
+            var s when !s.StartsWith("https://") && !s.StartsWith("http://") => "Link must start with https:// or http://",
+            var s when !Uri.IsWellFormedUriString(s, UriKind.Absolute) => "Link is not a valid URL",
+            _ => ""
+        };
+
+    private bool HasLinkError => !string.IsNullOrWhiteSpace(LinkValueError);
 
     void SetExerciseLink(string link) => UpdateExerciseHandler(exercise with { Link = link });
 

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -23,6 +23,10 @@
                             <MenuItem Label="Edit" Icon="edit" data-cy="exercise-edit-menu-button" OnClick="OnEditExercise"/>
                             <MenuItem data-cy="exercise-notes-btn" Label="Notes" Icon="notes" OnClick="OnOpenNotesButtonClick"/>
                             <MenuItem Label="Remove" Icon="delete" OnClick="OnRemoveExercise"/>
+                            @if(Uri.IsWellFormedUriString(displayedExercise.Blueprint.Link, UriKind.Absolute))
+                            {
+                                <MenuItem Label="Open Link" Icon="open_in_new" OnClick="OnOpenLink"/>
+                            }
                         </Menu>
                     </div>
                 </div>
@@ -137,6 +141,8 @@
     [EditorRequired] [Parameter] public Action<decimal> UpdateWeightForExercise { get; set; } = null!;
 
     [EditorRequired] [Parameter] public Action<string?> UpdateNotesForExercise { get; set; } = null!;
+
+    [EditorRequired] [Parameter] public Action OnOpenLink { get; set; } = null!;
 
     [EditorRequired] [Parameter] public Action OnEditExercise { get; set; } = null!;
 

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -34,6 +34,7 @@ else
             UpdateNotesForExercise=@((notes) => UpdateNotesForExercise(context.Index, notes))
             OnEditExercise=@(() => BeginEditExercise(context.Index))
             OnRemoveExercise=@(() => BeginRemoveExercise(context.Index))
+            OnOpenLink=@(() => Dispatcher.Dispatch(new NavigateAction(context.Item.Blueprint.Link.Trim())))
             IsReadonly=IsReadonly
             ShowPreviousButton=@(SessionTarget == SessionTarget.WorkoutSession) />
     </ItemList>


### PR DESCRIPTION
This commit adds a button to the overflow menu on the weighted exercise, which allows a user to open a link that they have put against their exercise

fixes: #324 

![image](https://github.com/user-attachments/assets/e7e74c72-7490-4a05-b805-a073ecdff172)
