### PR TITLE
Move all base.OnInitialized calls to start

### DIFF
--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -131,6 +131,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Feed"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new FetchSessionFeedItemsAction(FromUserAction: false));
@@ -151,7 +152,6 @@
                 )
             );
         }
-        base.OnInitialized();
 
         SubscribeToAction<FeedApiErrorAction>(OnFeedApiError);
     }

--- a/LiftLog.Ui/Pages/Feed/FeedUserPlanPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedUserPlanPage.razor
@@ -46,6 +46,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("User Plan"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/feed"));
         if (!Guid.TryParse(UserIdStr, out var userId) || !FeedState.Value.FollowedUsers.TryGetValue(userId, out user))
@@ -57,8 +58,6 @@
             Dispatcher.Dispatch(new SetPageTitleAction($"{user.DisplayName}'s Plan"));
             plan = user.CurrentPlan;
         }
-
-        base.OnInitialized();
     }
 
     private async void ImportPlan()

--- a/LiftLog.Ui/Pages/Feed/ViewFeedSessionPage.razor
+++ b/LiftLog.Ui/Pages/Feed/ViewFeedSessionPage.razor
@@ -30,6 +30,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Feed Session"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/feed"));
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.FeedSession, true));
@@ -55,7 +56,5 @@
         {
             NavigationManager.NavigateTo("/feed");
         }
-
-        base.OnInitialized();
     }
 }

--- a/LiftLog.Ui/Pages/History/HistoryEditPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryEditPage.razor
@@ -45,6 +45,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Session"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/history"));
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.HistorySession, true));
@@ -56,7 +57,5 @@
         {
             Dispatcher.Dispatch(new SetPageTitleAction(CurrentSessionState.Value.HistorySession.Blueprint.Name));
         }
-
-        base.OnInitialized();
     }
 }

--- a/LiftLog.Ui/Pages/Settings/AiPlannerPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AiPlannerPage.razor
@@ -73,9 +73,9 @@ else
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("AI Planner"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
-        base.OnInitialized();
     }
 
     private void AcceptAiPlan(AiWorkoutPlan plan)

--- a/LiftLog.Ui/Pages/Settings/AiSessionCreatorPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AiSessionCreatorPage.razor
@@ -90,8 +90,8 @@ else
 
     protected override void OnInitialized()
     {
-        Dispatcher.Dispatch(new SetPageTitleAction("AI Session Creator"));
         base.OnInitialized();
+        Dispatcher.Dispatch(new SetPageTitleAction("AI Session Creator"));
     }
 
     private void HandleGenerateSession()

--- a/LiftLog.Ui/Pages/Settings/AppConfigPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AppConfigPage.razor
@@ -31,9 +31,9 @@
 @code {
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("App Configuration"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
-        base.OnInitialized();
     }
 
     private void SetUseImperialUnits(bool value)

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/PlainTextExportPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/PlainTextExportPage.razor
@@ -31,9 +31,9 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Plaintext Export"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/backup-and-restore"));
-        base.OnInitialized();
     }
 
     private void SelectFormat(string format)

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
@@ -55,10 +55,10 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Automatic Remote Backup"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/backup-and-restore"));
         SubscribeToAction<RemoteBackupSucceededEvent>(OnRemoteBackupSucceeded);
-        base.OnInitialized();
         EndpointValue = SettingsState.Value.RemoteBackupSettings.Endpoint;
         ApiKeyValue = SettingsState.Value.RemoteBackupSettings.ApiKey;
         IncludeFeedAccount = SettingsState.Value.RemoteBackupSettings.IncludeFeedAccount;

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
@@ -67,10 +67,10 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Export, Backup and Restore"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
         SubscribeToAction<BeginFeedImportAction>(OnBeginFeedImport);
-        base.OnInitialized();
     }
 
     protected override void OnAfterRender(bool firstRender)

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -202,6 +202,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Manage Session"));
         var backPath = "/settings/manage-workouts?planId=" + PlanId;
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(backPath));
@@ -213,7 +214,6 @@
         {
             Dispatcher.Dispatch(new SetEditingSessionAction(ProgramState.Value.GetSessionBlueprints(PlanId)[SessionIndex]));
         }
-        base.OnInitialized();
     }
 
     protected override ValueTask DisposeAsyncCore(bool disposing)

--- a/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
@@ -105,10 +105,10 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         var title = "Manage " + ProgramState.Value.SavedPrograms[PlanId].Name;
         Dispatcher.Dispatch(new SetPageTitleAction(title));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/program-list"));
-        base.OnInitialized();
     }
 
     protected override ValueTask DisposeAsyncCore(bool disposing)

--- a/LiftLog.Ui/Pages/Settings/NotificationsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/NotificationsPage.razor
@@ -13,9 +13,9 @@
 @code {
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Notifications"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
-        base.OnInitialized();
     }
 
     private void SetRestNotifications(bool value)

--- a/LiftLog.Ui/Pages/Settings/SettingsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/SettingsPage.razor
@@ -73,9 +73,9 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new SetPageTitleAction("Settings"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
-        base.OnInitialized();
     }
 
     private void NavigateToBackupAndRestore()

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -110,10 +110,10 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         Dispatcher.Dispatch(new FetchOverallStatsAction());
         Dispatcher.Dispatch(new SetPageTitleAction("Statistics"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
-        base.OnInitialized();
     }
 
     protected override async Task OnInitializedAsync()

--- a/LiftLog.Ui/Shared/MainLayout.razor
+++ b/LiftLog.Ui/Shared/MainLayout.razor
@@ -71,6 +71,7 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         InsetsManager.InsetsChanged += (_, _) => { InvokeAsync(StateHasChanged); };
         NavigationManager.RegisterLocationChangingHandler(async context =>
         {
@@ -82,7 +83,6 @@
             }
         });
 
-        base.OnInitialized();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/LiftLog.Ui/Shared/Smart/AppReviewRequest.razor
+++ b/LiftLog.Ui/Shared/Smart/AppReviewRequest.razor
@@ -59,9 +59,9 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         AppState.StateChanged += HandleAppStateChange;
         Dispatcher.Dispatch(new IncrementAppLaunchCountAction());
-        base.OnInitialized();
     }
 
     private void HandleAppStateChange(object? sender, EventArgs e)

--- a/LiftLog.Ui/Shared/Smart/BackupAlert.razor
+++ b/LiftLog.Ui/Shared/Smart/BackupAlert.razor
@@ -19,12 +19,6 @@
 @code {
     private Dialog? dialog;
 
-    protected override void OnInitialized()
-    {
-        base.OnInitialized();
-
-    }
-
     protected override void OnAfterRender(bool firstRender)
     {
         base.OnAfterRender(firstRender);

--- a/LiftLog.Ui/Shared/Smart/NavBar.razor
+++ b/LiftLog.Ui/Shared/Smart/NavBar.razor
@@ -30,9 +30,9 @@
 
     protected override void OnInitialized()
     {
+        base.OnInitialized();
         NavigationManager.LocationChanged += LocationChanged;
         InsetsManager.InsetsChanged += (_, _) => { InvokeAsync(StateHasChanged); };
-        base.OnInitialized();
     }
 
     private bool IsRouteMatch(string routeMatchRegex)


### PR DESCRIPTION
It is recommended that we call the base at the start, in case we accidentally don't call it in a branch, or we cause a navigate, disposing the component

See: https://liftlog.sentry.io/issues/6040370251/?project=4505937523769344&query=&statsPeriod=14d&stream_index=24
