### PR TITLE
Fix decimal separator

### DIFF
--- a/LiftLog.Maui/Platforms/iOS/AppDelegate.cs
+++ b/LiftLog.Maui/Platforms/iOS/AppDelegate.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+﻿using System.Globalization;
+using Foundation;
 using LiftLog.Maui.Services;
 using UIKit;
 
@@ -7,5 +8,15 @@ namespace LiftLog.Maui;
 [Register("AppDelegate")]
 public class AppDelegate : MauiUIApplicationDelegate
 {
-    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp()
+    {
+        var app = MauiProgram.CreateMauiApp();
+        var newCulture = CultureInfo.CurrentCulture.Clone() as CultureInfo;
+        newCulture!.NumberFormat.NumberDecimalSeparator = NSLocale.CurrentLocale.DecimalSeparator;
+        newCulture.NumberFormat.CurrencyGroupSeparator = NSLocale.CurrentLocale.GroupingSeparator;
+
+        CultureInfo.CurrentCulture = newCulture;
+        CultureInfo.CurrentUICulture = newCulture;
+        return app;
+    }
 }

--- a/LiftLog.Maui/Platforms/iOS/Program.cs
+++ b/LiftLog.Maui/Platforms/iOS/Program.cs
@@ -1,5 +1,4 @@
-﻿using ObjCRuntime;
-using UIKit;
+﻿using UIKit;
 
 namespace LiftLog.Maui;
 


### PR DESCRIPTION
This commit amends the IOS app to introspect the decimal separator from the native IOS locale settings, and updates the culture to match.

The existing behaviour seems to be to use the language code only to set the decimal formatter, however ios allows users to configure number formatting independently of language/region.

Fixes #332



https://github.com/user-attachments/assets/cc9f9ab8-1b80-4570-9f33-d7642631e89d



