### PR TITLE
Use localised strings on all user facing text

### DIFF
--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -14,7 +14,7 @@ describe('Completing a session', () => {
       cy.containsA('Add Exercise', { includeShadowDom: true }).click()
       cy.dialog().find('md-filled-text-field').find('input', { includeShadowDom: true }).first().click().type('Squat')
 
-      cy.dialog().contains("Update").click()
+      cy.dialog().find("[data-cy=dialog-action]").click()
 
 
       cy.getA('.repcount').first().click()
@@ -41,7 +41,7 @@ describe('Completing a session', () => {
     beforeEach(() => {
       cy.navigate('Settings')
       // Disable tips
-      cy.containsA('App Configuration').click()
+      cy.containsA('App configuration').click()
       cy.containsA('Show tips').click()
       cy.navigate('Settings')
       cy.containsA('Manage plans').click()

--- a/LiftLog.Cypress/cypress/e2e/creating-a-plan.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/creating-a-plan.cy.js
@@ -9,7 +9,7 @@ describe('Creating a plan', () => {
     beforeEach(() => {
       cy.navigate('Settings')
       // Disable tips
-      cy.containsA('App Configuration').click()
+      cy.containsA('App configuration').click()
       cy.containsA('Show tips').click()
       cy.navigate('Settings')
       cy.containsA('Manage plans').click()
@@ -24,7 +24,7 @@ describe('Creating a plan', () => {
     beforeEach(() => {
       cy.navigate('Settings')
       // Disable tips
-      cy.containsA('App Configuration').click()
+      cy.containsA('App configuration').click()
       cy.containsA('Show tips').click()
       cy.navigate('Settings')
       cy.containsA('Manage plans').click()
@@ -50,7 +50,7 @@ describe('Creating a plan', () => {
 
 function populatePlanFromEditPage(exerciseName) {
 
-  cy.containsA('Add Session', { includeShadowDom: true }).click()
+  cy.containsA('Add workout', { includeShadowDom: true }).click()
   cy.containsA('Add Exercise', { includeShadowDom: true }).click()
   cy.dialog().find('[data-cy=exercise-name]').find('input', { includeShadowDom: true }).clear().type(exerciseName)
   cy.dialog().find('[data-cy=exercise-sets]').should('contain.text', '3').find('[data-cy=fixed-increment]').click()
@@ -66,7 +66,7 @@ function populatePlanFromEditPage(exerciseName) {
 
 function assertPlanFromEditPage(exerciseName) {
 
-  cy.containsA('Session 1').click()
+  cy.containsA('Workout 1').click()
   cy.getA('.itemlist').children().first().click()
   cy.dialog().find('[data-cy=exercise-name]').find('input', { includeShadowDom: true }).should('have.value', exerciseName)
   cy.dialog().find('[data-cy=exercise-sets]').should('contain.text', '4')

--- a/LiftLog.Cypress/cypress/e2e/settings.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/settings.cy.js
@@ -9,7 +9,7 @@ describe('Settings', () => {
     beforeEach(() => {
       cy.navigate('Settings')
       // Disable tips
-      cy.containsA('App Configuration').click()
+      cy.containsA('App configuration').click()
       cy.containsA('Show tips').click()
 
       cy.navigate('Settings')
@@ -25,7 +25,7 @@ describe('Settings', () => {
         cy.navigate('Settings')
         // Navigate twice, because settings remembers its last page when you click it
         cy.navigate('Settings')
-        cy.containsA('App Configuration').click()
+        cy.containsA('App configuration').click()
         cy.containsA('Use imperial units').click()
         assertCorrectWeightUnitsOnAllPages('lbs')
       })
@@ -37,7 +37,7 @@ describe('Settings', () => {
         cy.navigate('Settings')
         // Navigate twice, because settings remembers its last page when you click it
         cy.navigate('Settings')
-        cy.containsA('App Configuration').click()
+        cy.containsA('App configuration').click()
         cy.containsA('Show bodyweight').click()
         assertShowsBodyweightOnAllPages(false)
       })

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -33,7 +33,7 @@ public record Session(
         get
         {
             var latestExerciseIndex = RecordedExercises
-                .IndexedTuples()
+                .Index()
                 .Where(x => x.Item.LastRecordedSet is not null)
                 .OrderByDescending(x => x.Item.LastRecordedSet?.Set?.CompletionTime)
                 .Select(x => x.Index)

--- a/LiftLog.Lib/Util.cs
+++ b/LiftLog.Lib/Util.cs
@@ -24,11 +24,4 @@ internal static class Util
 
         return new ImmutableListValue<T>(ImmutableList.CreateRange(items));
     }
-
-    public static IEnumerable<(TSource Item, int Index)> IndexedTuples<TSource>(
-        this IEnumerable<TSource> source
-    )
-    {
-        return source.Select((item, index) => (item, index));
-    }
 }

--- a/LiftLog.Lib/Util/EnumerableExtensions.cs
+++ b/LiftLog.Lib/Util/EnumerableExtensions.cs
@@ -6,13 +6,6 @@ namespace System.Linq;
 
 public static class LinqExtensions
 {
-    public static IEnumerable<(TSource Item, int Index)> IndexedTuples<TSource>(
-        this IEnumerable<TSource> source
-    )
-    {
-        return source.Select((item, index) => (item, index));
-    }
-
     public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source)
         where T : notnull
     {
@@ -50,7 +43,7 @@ public static class LinqExtensions
         Func<TSource, bool> predicate
     )
     {
-        var tuples = source.IndexedTuples();
+        var tuples = source.Index();
         var matchingTuple = tuples
             .Where(x => predicate(x.Item))
             .Cast<(TSource?, int)>()

--- a/LiftLog.Lib/Util/EnumerableExtensions.cs
+++ b/LiftLog.Lib/Util/EnumerableExtensions.cs
@@ -46,9 +46,9 @@ public static class LinqExtensions
         var tuples = source.Index();
         var matchingTuple = tuples
             .Where(x => predicate(x.Item))
-            .Cast<(TSource?, int)>()
-            .DefaultIfEmpty((default, -1));
-        return matchingTuple.First().Item2;
+            .Cast<(int, TSource?)>()
+            .DefaultIfEmpty(( -1, default));
+        return matchingTuple.First().Item1;
     }
 
     public static async Task<ImmutableListValue<T>> ToImmutableListValueAsync<T>(

--- a/LiftLog.Lib/Util/EnumerableExtensions.cs
+++ b/LiftLog.Lib/Util/EnumerableExtensions.cs
@@ -47,7 +47,7 @@ public static class LinqExtensions
         var matchingTuple = tuples
             .Where(x => predicate(x.Item))
             .Cast<(int, TSource?)>()
-            .DefaultIfEmpty(( -1, default));
+            .DefaultIfEmpty((-1, default));
         return matchingTuple.First().Item1;
     }
 

--- a/LiftLog.Ui/LiftLog.Ui.csproj
+++ b/LiftLog.Ui/LiftLog.Ui.csproj
@@ -8,7 +8,23 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <!-- Enums not handled exhaustively with numbers; No await in async -->
     <NoWarn>CS8524;CS1998</NoWarn>
-    </PropertyGroup>
+    <!-- Required for intellisense -->
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+    <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
+
+  </PropertyGroup>
+<ItemGroup>
+ <EmbeddedResource Update="i18n\UiStrings.resx">
+      <Generator>MSBuild:Compile</Generator>
+      <LastGenOutput>UiStrings.Designer.cs</LastGenOutput>
+      <!-- Make sure this won't clash with other generated files! -->
+      <StronglyTypedFileName>$(IntermediateOutputPath)\UiStrings.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+      <StronglyTypedNamespace>LiftLog.Ui.i18n</StronglyTypedNamespace>
+      <StronglyTypedClassName>UiStrings</StronglyTypedClassName>
+    </EmbeddedResource>
+
+</ItemGroup>
 
     <PropertyGroup>
         <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
@@ -32,6 +48,7 @@
         <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
         <PackageReference Include="Fluxor" Version="6.1.0" />
         <PackageReference Include="Fluxor.Blazor.Web" Version="6.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.0" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
 
         <PackageReference Include="Google.Protobuf" Version="3.29.0" />
@@ -44,8 +61,11 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="TypealizR" Version="0.9.9">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
-
 
     <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
         <PackageReference Include="Fluxor.Blazor.Web.ReduxDevTools" Version="6.1.0" />

--- a/LiftLog.Ui/LiftLog.Ui.csproj
+++ b/LiftLog.Ui/LiftLog.Ui.csproj
@@ -5,26 +5,28 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-    <!-- Enums not handled exhaustively with numbers; No await in async -->
-    <NoWarn>CS8524;CS1998</NoWarn>
-    <!-- Required for intellisense -->
-    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
-    <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
+        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <!-- Enums not handled exhaustively with numbers; No await in async -->
+        <NoWarn>CS8524;CS1998</NoWarn>
+        <!-- Required for intellisense -->
+        <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+        <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
 
-  </PropertyGroup>
-<ItemGroup>
- <EmbeddedResource Update="i18n\UiStrings.resx">
-      <Generator>MSBuild:Compile</Generator>
-      <LastGenOutput>UiStrings.Designer.cs</LastGenOutput>
-      <!-- Make sure this won't clash with other generated files! -->
-      <StronglyTypedFileName>$(IntermediateOutputPath)\UiStrings.Designer.cs</StronglyTypedFileName>
-      <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
-      <StronglyTypedNamespace>LiftLog.Ui.i18n</StronglyTypedNamespace>
-      <StronglyTypedClassName>UiStrings</StronglyTypedClassName>
-    </EmbeddedResource>
+    </PropertyGroup>
 
-</ItemGroup>
+    <ItemGroup>
+    <!-- https://www.paraesthesia.com/archive/2022/09/30/strongly-typed-resources-with-net-core/ -->
+        <EmbeddedResource Update="i18n\UiStrings.resx">
+            <Generator>MSBuild:Compile</Generator>
+            <LastGenOutput>UiStrings.Designer.cs</LastGenOutput>
+            <!-- Make sure this won't clash with other generated files! -->
+            <StronglyTypedFileName>$(IntermediateOutputPath)\UiStrings.Designer.cs</StronglyTypedFileName>
+            <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
+            <StronglyTypedNamespace>LiftLog.Ui.i18n</StronglyTypedNamespace>
+            <StronglyTypedClassName>UiStrings</StronglyTypedClassName>
+        </EmbeddedResource>
+
+    </ItemGroup>
 
     <PropertyGroup>
         <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>

--- a/LiftLog.Ui/LiftLog.Ui.csproj
+++ b/LiftLog.Ui/LiftLog.Ui.csproj
@@ -12,7 +12,14 @@
         <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
         <CoreCompileDependsOn>PrepareResources;$(CompileDependsOn)</CoreCompileDependsOn>
 
+        <TypealizR_UseParamNamesInMethodNames>false</TypealizR_UseParamNamesInMethodNames>
+
     </PropertyGroup>
+
+    <ItemGroup>
+        <CompilerVisibleProperty Include="TypealizR_UseParamNamesInMethodNames" />
+    </ItemGroup>
+
 
     <ItemGroup>
     <!-- https://www.paraesthesia.com/archive/2022/09/30/strongly-typed-resources-with-net-core/ -->

--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -5,6 +5,9 @@
 @inject IJSRuntime JSRuntime
 @inject IState<FeedState> FeedState
 @inject NavigationManager NavigationManager
+
+@inject IStringLocalizer<UiStrings> UiStrings
+
 @inject IDispatcher Dispatcher
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
@@ -132,7 +135,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Feed"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Feed()));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new FetchSessionFeedItemsAction(FromUserAction: false));
         Dispatcher.Dispatch(new FetchInboxItemsAction(FromUserAction: false));

--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -12,11 +12,11 @@
 
 <div class="sticky top-0 z-10 @TopNavColorClass transition-colors">
     <md-tabs @ref="tabs" @onchange="HandleTabChange">
-        <md-primary-tab id="mainfeed-tab" active=@(GetTabActiveClass("mainfeed-panel")) aria-controls="mainfeed-panel">@(UiStrings.Feed())</md-primary-tab>
-        <md-primary-tab id="following-tab" active=@(GetTabActiveClass("following-panel")) aria-controls="following-panel">@(UiStrings.Feed_Following())</md-primary-tab>
+        <md-primary-tab id="mainfeed-tab" active=@(GetTabActiveClass("mainfeed-panel")) aria-controls="mainfeed-panel">@UiStrings.Feed</md-primary-tab>
+        <md-primary-tab id="following-tab" active=@(GetTabActiveClass("following-panel")) aria-controls="following-panel">@UiStrings.Feed_Following</md-primary-tab>
         <md-primary-tab id="followers-tab" active=@(GetTabActiveClass("followers-panel")) aria-controls="followers-panel">
             <span class="flex items-center gap-1">
-                <span>@(UiStrings.Feed_Followers())</span>
+                <span>@UiStrings.Feed_Followers</span>
                 @if (FeedState.Value.FollowRequests is { Count: > 0 })
                 {
                     <div class="w-2 h-2 bg-error rounded-full"></div>
@@ -133,7 +133,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Feed()));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Feed));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new FetchSessionFeedItemsAction(FromUserAction: false));
         Dispatcher.Dispatch(new FetchInboxItemsAction(FromUserAction: false));

--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -6,19 +6,17 @@
 @inject IState<FeedState> FeedState
 @inject NavigationManager NavigationManager
 
-@inject IStringLocalizer<UiStrings> UiStrings
-
 @inject IDispatcher Dispatcher
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <div class="sticky top-0 z-10 @TopNavColorClass transition-colors">
     <md-tabs @ref="tabs" @onchange="HandleTabChange">
-        <md-primary-tab id="mainfeed-tab" active=@(GetTabActiveClass("mainfeed-panel")) aria-controls="mainfeed-panel">Feed</md-primary-tab>
-        <md-primary-tab id="following-tab" active=@(GetTabActiveClass("following-panel")) aria-controls="following-panel">Following</md-primary-tab>
+        <md-primary-tab id="mainfeed-tab" active=@(GetTabActiveClass("mainfeed-panel")) aria-controls="mainfeed-panel">@(UiStrings.Feed())</md-primary-tab>
+        <md-primary-tab id="following-tab" active=@(GetTabActiveClass("following-panel")) aria-controls="following-panel">@(UiStrings.Feed_Following())</md-primary-tab>
         <md-primary-tab id="followers-tab" active=@(GetTabActiveClass("followers-panel")) aria-controls="followers-panel">
             <span class="flex items-center gap-1">
-                <span>Followers</span>
+                <span>@(UiStrings.Feed_Followers())</span>
                 @if (FeedState.Value.FollowRequests is { Count: > 0 })
                 {
                     <div class="w-2 h-2 bg-error rounded-full"></div>

--- a/LiftLog.Ui/Pages/Feed/FeedPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedPage.razor
@@ -35,15 +35,15 @@
         }else {
             <Card class="flex flex-col items-center justify-between m-2" Type=Card.CardType.Filled>
                 <md-icon class="mb-4">error</md-icon>
-                <span class="text-on-surface">You are not publishing your workouts</span>
-                <AppButton Type=AppButtonType.Text OnClick="@(async ()=>{settingsDialog?.Open(); await Task.Delay(500); SetPublishWorkouts(true); })">Start publishing</AppButton>
+                <span class="text-on-surface">@UiStrings.NotPublishingWorkouts</span>
+                <AppButton Type=AppButtonType.Text OnClick="@(async ()=>{settingsDialog?.Open(); await Task.Delay(500); SetPublishWorkouts(true); })">@UiStrings.StartPublishing</AppButton>
             </Card>
         }
 
         @if (FeedState.Value.Feed is { Count: 0 })
         {
             <EmptyInfo class="mx-4 mt-10">
-                <p>Nothing here yet!<br> Nobody you're following has published anything yet! Come back later.</p>
+                <p>@UiStrings.NothingHereYet<br>@UiStrings.NoFollowingData</p>
             </EmptyInfo>
         }
         <VirtualizedCardList Items="@(FeedState.Value.Feed.Select(x => (Item: x, User: FeedState.Value.FollowedUsers.GetValueOrDefault(x.UserId))).Where(x => x.User is not null).ToList())" OnClick="@(x => ViewFeedSession(x.Item))" CardClass="animate-fade-zoom-in">
@@ -55,7 +55,7 @@
         @if (FeedState.Value.FollowedUsers is { Count: 0 })
         {
             <EmptyInfo class="mx-4 mt-10">
-                <p>Start following someone!<br>You're not currently following anyone, ask a friend for their share link to start!</p>
+                <p>@UiStrings.StartFollowingSomeone<br>@UiStrings.NotFollowingAnyone</p>
             </EmptyInfo>
         }
         <VirtualizedCardList Items="@(FeedState.Value.FollowedUsers.Values.ToList())" CardClass="animate-fade-zoom-in">
@@ -71,14 +71,14 @@
         }else {
             <Card class="flex flex-col items-center justify-between m-2" Type=Card.CardType.Filled>
                 <md-icon class="mb-4">error</md-icon>
-                <span class="text-on-surface">You are not publishing your workouts</span>
-                <AppButton Type=AppButtonType.Text OnClick="@(async ()=>{settingsDialog?.Open(); await Task.Delay(500); SetPublishWorkouts(true); })">Start publishing</AppButton>
+                <span class="text-on-surface">@UiStrings.NotPublishingWorkouts</span>
+                <AppButton Type=AppButtonType.Text OnClick="@(async ()=>{settingsDialog?.Open(); await Task.Delay(500); SetPublishWorkouts(true); })">@UiStrings.StartPublishing</AppButton>
             </Card>
         }
         @if (FeedState.Value.Followers is { Count: 0 } && FeedState.Value.FollowRequests is { Count: 0 })
         {
             <EmptyInfo class="mx-4 mt-10">
-                <p>Nobody is following you yet!<br>Share your link with friends to get followers</p>
+                <p>@UiStrings.NobodyFollowingYou<br>@UiStrings.ShareLinkToGetFollowers</p>
             </EmptyInfo>
         }
         <VirtualizedCardList Items="@(FeedState.Value.FollowRequests.ToList())" CardClass="animate-fade-zoom-in">
@@ -103,14 +103,17 @@
 }
 
 
-<ConfirmationDialog @ref="deleteUserDialog" OkText="Unfollow" OnOk="DeleteUser">
-    <Headline>Unfollow user</Headline>
-    <TextContent>This will unfollow <span class="text-primary font-bold">@(userToDelete?.Nickname ?? userToDelete?.Name ?? "Anonymous User")</span> and remove all their content on your device.</TextContent>
+<ConfirmationDialog @ref="deleteUserDialog" OkText="@UiStrings.Unfollow" OnOk="DeleteUser">
+    <Headline>@UiStrings.UnfollowUser</Headline>
+    <TextContent>
+        <LimitedHtml
+            Value=@(UiStrings.Unfollow_Msg(userToDelete?.Nickname ?? userToDelete?.Name ?? "Anonymous User"))/>
+    </TextContent>
 </ConfirmationDialog>
 
-<ConfirmationDialog @ref="removeFollowerDialog" OkText="Remove" OnOk="RemoveFollower">
-    <Headline>Remove follower</Headline>
-    <TextContent>This will stop <span class="text-primary font-bold">@(userToDelete?.Nickname ?? userToDelete?.Name ?? "Anonymous User")</span> from following you and remove all your content from their device.</TextContent>
+<ConfirmationDialog @ref="removeFollowerDialog" OkText="@UiStrings.Remove" OnOk="RemoveFollower">
+    <Headline>@UiStrings.RemoveFollower</Headline>
+    <TextContent>@UiStrings.RemoveFollowerMsgPart1 <span class="text-primary font-bold">@(userToDelete?.Nickname ?? userToDelete?.Name ?? "Anonymous User")</span> @UiStrings.RemoveFollowerMsgPart2</TextContent>
 </ConfirmationDialog>
 
 @code

--- a/LiftLog.Ui/Pages/Feed/FeedUserPlanPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedUserPlanPage.razor
@@ -17,7 +17,7 @@
         <SessionSummary Session="context.GetEmptySession()" ShowSets="true" ShowWeight="false"/>
     </CardList>
     <div>
-        <AppButton OnClick="() => importPlanDialog?.Open()"><md-icon slot="icon">assignment</md-icon>Import their plan</AppButton>
+        <AppButton OnClick="() => importPlanDialog?.Open()"><md-icon slot="icon">assignment</md-icon>@UiStrings.ImportTheirPlan</AppButton>
     </div>
 </div>
 
@@ -25,11 +25,13 @@
 {
     <Dialog @ref="importPlanDialog">
 
-        <span slot="headline">Import their plan</span>
-        <span slot="content" class="block text-left">This will import <span class="font-bold text-primary">@(user.DisplayName)'s</span> plan.  It will not overwrite your existing plan.</span>
+        <span slot="headline">@UiStrings.ImportTheirPlan</span>
+        <span slot="content" class="block text-left">
+            <LimitedHtml Value="@UiStrings.ImportTheirPlanMessage(user.DisplayName)"/>
+        </span>
         <div slot="actions">
-            <AppButton Type="AppButtonType.Text" OnClick=@(() => importPlanDialog?.Close())>Cancel</AppButton>
-            <AppButton Type="AppButtonType.Text" OnClick=ImportPlan>Import</AppButton>
+            <AppButton Type="AppButtonType.Text" OnClick=@(() => importPlanDialog?.Close())>@UiStrings.Cancel</AppButton>
+            <AppButton Type="AppButtonType.Text" OnClick=ImportPlan>@UiStrings.Import</AppButton>
         </div>
     </Dialog>
 }
@@ -47,7 +49,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("User Plan"));
+        Dispatcher.Dispatch(new SetPageTitleAction("User plan"));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/feed"));
         if (!Guid.TryParse(UserIdStr, out var userId) || !FeedState.Value.FollowedUsers.TryGetValue(userId, out user))
         {

--- a/LiftLog.Ui/Pages/History/HistoryEditPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryEditPage.razor
@@ -17,7 +17,7 @@
 {
     <div class="flex w-full my-2 px-2">
         <TextField
-            Label="Date"
+            Label="@UiStrings.Date"
             class="w-full"
             TextFieldType="TextFieldType.Filled"
             Value=@(CurrentSessionState.Value.HistorySession.Date.ToString("o"))

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -13,7 +13,6 @@
 @inject IDispatcher Dispatcher
 @inject ILogger<HistoryPage> Logger
 
-@inject IStringLocalizer<UiStrings> UiStrings
 
 @if (!_latestSessions.Any())
 {

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -105,7 +105,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.History()));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.History));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.HistorySession, false));
         Dispatcher.Dispatch(new SetCurrentSessionAction(SessionTarget.HistorySession, null));

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -17,7 +17,7 @@
 @if (!_latestSessions.Any())
 {
     <EmptyInfo>
-        <p>Nothing recorded yet!<br> Complete a session and check again.</p>
+        <p>@UiStrings.NothingHereYet<br>@UiStrings.CompleteAndComeBack</p>
     </EmptyInfo>
 }
 else
@@ -46,16 +46,15 @@ else
     @if (!filteredToMonthSessions.Any())
     {
         <EmptyInfo>
-            <p>Nothing recorded in @(currentMonth.ToString("MMMM"))<br> Complete a session or switch to another month to view your sessions.</p>
+            <p><LimitedHtml Value="@UiStrings.NoSessionsInMonth(currentMonth.ToString("MMMM"))"/></p>
         </EmptyInfo>
     }
 }
 
-<ConfirmationDialog @ref="_deleteDialog" OkText="Delete" OnOk=DeleteSession PreventCancel=true >
-    <Headline>Delete Session?</Headline>
+<ConfirmationDialog @ref="_deleteDialog" OkText="@UiStrings.Delete" OnOk=DeleteSession PreventCancel=true >
+    <Headline>@UiStrings.DeleteSessionQuestion</Headline>
     <TextContent>
-        The session named <span class="font-bold text-primary">@_selectedSession.Blueprint.Name</span>,
-        on @(_selectedSession.Date) will be deleted from history. This cannot be undone.
+        <LimitedHtml Value="@UiStrings.DeleteSessionMessage(@_selectedSession.Blueprint.Name,_selectedSession.Date)" />
     </TextContent>
 </ConfirmationDialog>
 

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -13,6 +13,8 @@
 @inject IDispatcher Dispatcher
 @inject ILogger<HistoryPage> Logger
 
+@inject IStringLocalizer<UiStrings> UiStrings
+
 @if (!_latestSessions.Any())
 {
     <EmptyInfo>
@@ -104,7 +106,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        Dispatcher.Dispatch(new SetPageTitleAction("History"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.History()));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.HistorySession, false));
         Dispatcher.Dispatch(new SetCurrentSessionAction(SessionTarget.HistorySession, null));

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -6,8 +6,6 @@
 @page "/"
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-@inject IStringLocalizer<UiStrings> UiStrings
-
 @inject IState<ProgramState> ProgramState
 @inject IState<AppState> AppState
 @inject IState<SettingsState> SettingsState

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -25,7 +25,7 @@
     <div class="flex flex-col gap-2 px-2">
         <Card class="flex flex-col gap-4">
             <div class="flex justify-between">
-                <span class="text-lg">No plan created yet!</span>
+                <span class="text-lg">@UiStrings.NoPlanCreated</span>
                 <md-icon>info</md-icon>
             </div>
             <div class="grid grid-cols-2 gap-2">
@@ -33,13 +33,13 @@
                     <md-icon
                         slot="icon">
                         add
-                    </md-icon>Add Workouts
+                    </md-icon>@UiStrings.AddWorkouts
                 </AppButton>
                 <AppButton OnClick=@(() => NavigationManager.NavigateTo("/settings/program-list"))>
                     <md-icon
                         slot="icon">
                         assignment
-                    </md-icon>Select a plan
+                    </md-icon>@UiStrings.SelectAPlan
                 </AppButton>
             </div>
         </Card>
@@ -72,7 +72,7 @@ else
                     <md-icon slot="icon">auto_awesome</md-icon>
                 </FloatingButton>
             }
-            <FloatingButton variant="primary" has-icon OnClick="StartFreeformSession" Label=@(UiStrings.Freeform_Session())>
+            <FloatingButton variant="primary" has-icon OnClick="StartFreeformSession" Label=@(UiStrings.Freeform_Session)>
                 <md-icon slot="icon">fitness_center</md-icon>
             </FloatingButton>
         </div>
@@ -81,10 +81,9 @@ else
 </Remote>
 
 <ConfirmationDialog @ref="replaceCurrentSesisonDialog" OkText="Replace" OnOk="ReplaceSession">
-    <Headline>Replace current session</Headline>
+    <Headline>@UiStrings.ReplaceCurrentSession</Headline>
     <TextContent>
-        There is already a current session in progress, start a new one without
-        saving?
+        @UiStrings.SessionInProgress
     </TextContent>
 </ConfirmationDialog>
 
@@ -97,7 +96,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        Dispatcher.Dispatch(new SetPageTitleAction("Upcoming Workouts"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.UpcomingWorkouts));
         Dispatcher.Dispatch(new FetchUpcomingSessionsAction());
         Dispatcher.Dispatch(new SetReopenCurrentSessionAction(SessionTarget.WorkoutSession, false));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -6,6 +6,8 @@
 @page "/"
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
+@inject IStringLocalizer<UiStrings> UiStrings
+
 @inject IState<ProgramState> ProgramState
 @inject IState<AppState> AppState
 @inject IState<SettingsState> SettingsState
@@ -72,7 +74,7 @@ else
                     <md-icon slot="icon">auto_awesome</md-icon>
                 </FloatingButton>
             }
-            <FloatingButton variant="primary" has-icon OnClick="StartFreeformSession" Label="Freeform Session">
+            <FloatingButton variant="primary" has-icon OnClick="StartFreeformSession" Label=@(UiStrings.Freeform_Session())>
                 <md-icon slot="icon">fitness_center</md-icon>
             </FloatingButton>
         </div>

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -50,7 +50,7 @@ else
     <div class="m-2">
         <Tips/>
     </div>
-    <CardList CardType=Card.CardType.Outlined Items="upcoming.IndexedTuples()" OnClick="x => SelectSession(x.Item)">
+    <CardList CardType=Card.CardType.Outlined Items="upcoming.Index()" OnClick="x => SelectSession(x.Item)">
         <SplitCardControl>
             <TitleContent>
                 <SessionSummaryTitle IsFilled="context.Item.IsStarted" Session="context.Item" />

--- a/LiftLog.Ui/Pages/PostSessionPage.razor
+++ b/LiftLog.Ui/Pages/PostSessionPage.razor
@@ -10,7 +10,8 @@
     <div class="text-left">
         <h1 class="text-2xl">Congratulations!</h1>
         <span class="text-lg">You completed <span class="font-bold text-primary">@Session.Blueprint.Name!</span></span>
-
+        <div>You hit the rep target on these exercises without failure!</div>
+        <div > Next time you'll go heavier!</div>
     </div>
 }
 

--- a/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.ExerciseEditPage.cs
+++ b/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.ExerciseEditPage.cs
@@ -11,8 +11,6 @@ namespace LiftLog.Ui.Pages.Screenshot;
 
 public partial class ScreenshotCollectorPage
 {
-    [Inject]
-    private IStringLocalizer<UiStrings> UiStrings { get; set; } = null!;
 
     private async Task HandleExerciseEditorScreenshotCollection()
     {

--- a/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.ExerciseEditPage.cs
+++ b/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.ExerciseEditPage.cs
@@ -3,11 +3,17 @@ using LiftLog.Lib.Models;
 using LiftLog.Ui.Store.App;
 using LiftLog.Ui.Store.CurrentSession;
 using LiftLog.Ui.Store.Program;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using LiftLog.Ui.i18n;
 
 namespace LiftLog.Ui.Pages.Screenshot;
 
 public partial class ScreenshotCollectorPage
 {
+    [Inject]
+    private IStringLocalizer<UiStrings> UiStrings { get; set; } = null!;
+
     private async Task HandleExerciseEditorScreenshotCollection()
     {
         Dispatcher.Dispatch(

--- a/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.ExerciseEditPage.cs
+++ b/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.ExerciseEditPage.cs
@@ -11,7 +11,6 @@ namespace LiftLog.Ui.Pages.Screenshot;
 
 public partial class ScreenshotCollectorPage
 {
-
     private async Task HandleExerciseEditorScreenshotCollection()
     {
         Dispatcher.Dispatch(

--- a/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.Home.cs
+++ b/LiftLog.Ui/Pages/Screenshot/ScreenshotCollectorPage.Home.cs
@@ -10,7 +10,7 @@ namespace LiftLog.Ui.Pages.Screenshot;
 public partial class ScreenshotCollectorPage
 {
     private SessionBlueprint demoSessionBlueprint = new(
-        Name: "Session 1",
+        Name: "Workout 1",
         Exercises:
         [
             new ExerciseBlueprint(

--- a/LiftLog.Ui/Pages/Settings/AiPlannerPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AiPlannerPage.razor
@@ -14,15 +14,9 @@
 
 @if (SettingsState.Value.IsGeneratingAiPlan)
 {
-    <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
-        <div>
-            <md-circular-progress aria-label="Ai planning progress" indeterminate four-color></md-circular-progress>
-        </div>
-        <span>
-            <p>Generating AI plan...</p>
-            <p class="text-xs">This may take up to 3 minutes</p>
-        </span>
-    </div>
+    <Loader>
+        <LimitedHtml Value="@UiStrings.GeneratingAiPlan" EmClass="text-xs" />
+    </Loader>
 }
 else if (SettingsState.Value.AiPlan != null)
 {
@@ -30,18 +24,18 @@ else if (SettingsState.Value.AiPlan != null)
         <CardList Items="SettingsState.Value.AiPlan.Sessions">
             <SessionBlueprintSummary SessionBlueprint="context"/>
         </CardList>
-        <p class="text-on-surface">Note: you can tweak this plan after you accept it. Just head to the Manage Plan page in settings.</p>
+        <p class="text-on-surface">@UiStrings.NoteAboutTweakingAiPlan</p>
         <div class="flex flex-col gap-2 mt-2">
             <AppButton OnClick="() => AcceptAiPlan(SettingsState.Value.AiPlan)">
-                <md-icon slot="icon">done</md-icon>Accept
+                <md-icon slot="icon">done</md-icon>@UiStrings.Accept
             </AppButton>
             <div class="grid grid-cols-2 grid-rows-1 gap-2">
                 <AppButton Type="AppButtonType.Secondary" OnClick="() => Dispatcher.Dispatch(new SetAiPlanAction(null))">
-                    <md-icon slot="icon">close</md-icon>Cancel
+                    <md-icon slot="icon">close</md-icon>@UiStrings.Cancel
                 </AppButton>
                 <AppButton Type="AppButtonType.Secondary"
                            OnClick="() => Dispatcher.Dispatch(new GenerateAiPlanAction(SettingsState.Value.AiWorkoutAttributes!))">
-                    <md-icon slot="icon">refresh</md-icon>Regenerate
+                    <md-icon slot="icon">refresh</md-icon>@UiStrings.Regenerate
                 </AppButton>
             </div>
         </div>
@@ -53,11 +47,11 @@ else if (SettingsState.Value.AiPlanError != null)
         <p class="text-on-surface">@SettingsState.Value.AiPlanError</p>
         <div class="grid grid-cols-2 grid-rows-1 gap-2">
             <AppButton Type="AppButtonType.Secondary" OnClick="() => Dispatcher.Dispatch(new SetAiPlanErrorAction(null))">
-                <md-icon slot="icon">close</md-icon>Cancel
+                <md-icon slot="icon">close</md-icon>@UiStrings.Cancel
             </AppButton>
             <AppButton
                 OnClick="() => Dispatcher.Dispatch(new GenerateAiPlanAction(SettingsState.Value.AiWorkoutAttributes!))">
-                <md-icon slot="icon">refresh</md-icon>Retry
+                <md-icon slot="icon">refresh</md-icon>@UiStrings.Retry
             </AppButton>
         </div>
     </div>
@@ -74,7 +68,7 @@ else
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("AI Planner"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.AiPlanner));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
     }
 

--- a/LiftLog.Ui/Pages/Settings/AiSessionCreatorPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AiSessionCreatorPage.razor
@@ -11,14 +11,9 @@
 
 @if (AiSessionCreatorState.Value.IsLoading)
 {
-    <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
-        <div>
-            <md-circular-progress aria-label="Ai planning progress" indeterminate four-color></md-circular-progress>
-        </div>
-        <span>
-            <p>Generating Session...</p>
-        </span>
-    </div>
+    <Loader>
+        <LimitedHtml Value="@UiStrings.GeneratingAiPlan" EmClass="text-xs" />
+    </Loader>
 }
 else if (AiSessionCreatorState.Value.ErrorMessage is not null)
 {
@@ -30,8 +25,8 @@ else if (AiSessionCreatorState.Value.ErrorMessage is not null)
             <p>@AiSessionCreatorState.Value.ErrorMessage</p>
         </span>
         <div class="grid grid-cols-2 gap-2">
-            <AppButton Type=AppButtonType.Text OnClick=@HandleCancel>Back</AppButton>
-            <AppButton Type=AppButtonType.Text OnClick=@(()=>Dispatcher.Dispatch(new ClearAiGeneratedSessionStateAction()))>Retry</AppButton>
+            <AppButton Type=AppButtonType.Text OnClick=@HandleCancel>@UiStrings.Back</AppButton>
+            <AppButton Type=AppButtonType.Text OnClick=@(()=>Dispatcher.Dispatch(new ClearAiGeneratedSessionStateAction()))>@UiStrings.Retry</AppButton>
         </div>
     </div>
 }
@@ -41,16 +36,15 @@ else if (AiSessionCreatorState.Value.GeneratedSession is not null)
         <Card class="flex flex-col gap-2">
             <SessionBlueprintSummary SessionBlueprint="AiSessionCreatorState.Value.GeneratedSession"/>
             <div class="grid  gap-2">
-                <AppButton Type=AppButtonType.Text OnClick=@(()=>Dispatcher.Dispatch(new ClearAiGeneratedSessionStateAction()))>Regenerate</AppButton>
+                <AppButton Type=AppButtonType.Text OnClick=@(()=>Dispatcher.Dispatch(new ClearAiGeneratedSessionStateAction()))>@UiStrings.Regenerate</AppButton>
             </div>
         </Card>
         <div class="flex flex-col gap-2 justify-end h-full">
             <div class="grid grid-cols-2 gap-2">
                 <AppButton Type=AppButtonType.Secondary OnClick=@AddToPlan>
-                    <md-icon slot="icon">assignment_add</md-icon>Add
-                    To Plan
+                    <md-icon slot="icon">assignment_add</md-icon>@UiStrings.AddToPlan
                 </AppButton>
-                <AppButton OnClick=@StartSession><md-icon slot="icon">fitness_center</md-icon>Start</AppButton>
+                <AppButton OnClick=@StartSession><md-icon slot="icon">fitness_center</md-icon>@UiStrings.Start</AppButton>
             </div>
         </div>
     </div>
@@ -70,7 +64,7 @@ else
     @if(IsInActiveScreen)
     {
         <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
-            <AppButton class="text-lg" Type=AppButtonType.Text OnClick=HandleGenerateSession Disabled=@(ValidationError is not null) >Generate</AppButton>
+            <AppButton class="text-lg" Type=AppButtonType.Text OnClick=HandleGenerateSession Disabled=@(ValidationError is not null) >@UiStrings.Generate</AppButton>
         </Microsoft.AspNetCore.Components.Sections.SectionContent>
     }
 }
@@ -82,16 +76,16 @@ else
     [CascadingParameter(Name = "IsInActiveScreen")]
     public bool IsInActiveScreen { get; set; }
 
-    private string? ValidationError => Model switch
+    private LocalizedString? ValidationError => Model switch
     {
-        var m when m.AreasToWorkout.Count == 0 => "Please select at least one area to workout",
+        var m when m.AreasToWorkout.Count == 0 => UiStrings.SelectAtLeastOneArea,
         _ => null
     };
 
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("AI Session Creator"));
+        Dispatcher.Dispatch(new SetPageTitleAction(@UiStrings.AiSessionCreator));
     }
 
     private void HandleGenerateSession()

--- a/LiftLog.Ui/Pages/Settings/AppConfigPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AppConfigPage.razor
@@ -7,17 +7,17 @@
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <md-list>
-    <ListSwitch Headline="Use imperial units" SupportingText="Use pounds in favour of kilograms" Value="@SettingsState.Value.UseImperialUnits" OnSwitched="SetUseImperialUnits" />
-    <ListSwitch Headline="Show bodyweight" SupportingText="Enable bodyweight tracking and statistics" Value="@SettingsState.Value.ShowBodyweight" OnSwitched="SetShowBodyweight" />
-    <ListSwitch Headline="Show feed" SupportingText="Display the feed in the navigation bar" Value="@SettingsState.Value.ShowFeed" OnSwitched="SetShowFeed" />
+    <ListSwitch Headline="@UiStrings.UseImperialUnits" SupportingText="@UiStrings.UseImperialUnitsSubtitle" Value="@SettingsState.Value.UseImperialUnits" OnSwitched="SetUseImperialUnits" />
+    <ListSwitch Headline="@UiStrings.ShowBodyweight" SupportingText="@UiStrings.ShowBodyweightSubtitle" Value="@SettingsState.Value.ShowBodyweight" OnSwitched="SetShowBodyweight" />
+    <ListSwitch Headline="@UiStrings.ShowFeed" SupportingText="@UiStrings.ShowFeedSubtitle" Value="@SettingsState.Value.ShowFeed" OnSwitched="SetShowFeed" />
     @* If android, we need a status bar fix sometimes *@
     @if(DeviceService.GetDeviceType() == DeviceType.Android)
     {
-        <ListSwitch Headline="Status bar fix" SupportingText="Fixes the status bar overlapping the page title controls on some devices" Value="@SettingsState.Value.StatusBarFix" OnSwitched="SetStatusBarFix" />
+        <ListSwitch Headline="@UiStrings.StatusBarFix" SupportingText="@UiStrings.StatusBarFixSubtitle" Value="@SettingsState.Value.StatusBarFix" OnSwitched="SetStatusBarFix" />
     }
 
-    <ListSwitch Headline="Show tips" SupportingText="Show tips on how to use the app" Value="@SettingsState.Value.ShowTips" OnSwitched="SetShowTips" />
-    <AppButton Type="AppButtonType.Text" OnClick="ResetTips">Reset tips</AppButton>
+    <ListSwitch Headline="@UiStrings.ShowTips" SupportingText="@UiStrings.ShowTipsSubtitle" Value="@SettingsState.Value.ShowTips" OnSwitched="SetShowTips" />
+    <AppButton Type="AppButtonType.Text" OnClick="ResetTips">@UiStrings.ResetTips</AppButton>
 
 
     <ThemeChooser
@@ -32,7 +32,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("App Configuration"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.AppConfiguration));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
     }
 

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/PlainTextExportPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/PlainTextExportPage.razor
@@ -6,21 +6,19 @@
 
 <Card Type="Card.CardType.Filled" class="mx-6 mb-4">
     <div>
-        This feature allows you to export your data in a plaintext format such as CSV for use in other applications.
-        It is not intended for backup purposes. For backups, please use the backup feature.
-        LiftLog cannot restore data from plaintext exports.
+        @UiStrings.PlaintextExportDescription
     </div>
-    <AppButton OnClick="OpenDocumentation" Type="AppButtonType.Text">Read Documentation</AppButton>
+    <AppButton OnClick="OpenDocumentation" Type="AppButtonType.Text">@UiStrings.ReadDocumentation</AppButton>
 </Card>
 
 <LabelledForm>
-    <LabelledFormRow Label="Format" Icon="description">
+    <LabelledFormRow Label="@UiStrings.PlaintextExportFormat" Icon="description">
         <SelectField data-cy="export-format-selector" Options="Formats" Value="@Format.ToString()" ValueChanged="SelectFormat"/>
     </LabelledFormRow>
 </LabelledForm>
 
 <div class="flex justify-end gap-4 m-6">
-    <AppButton Type="AppButtonType.Primary" OnClick="Export">Export</AppButton>
+    <AppButton Type="AppButtonType.Primary" OnClick="Export">@UiStrings.Export</AppButton>
 </div>
 
 
@@ -32,7 +30,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Plaintext Export"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.PlaintextExport));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/backup-and-restore"));
     }
 

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
@@ -5,16 +5,12 @@
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <Card Type="Card.CardType.Filled" class="mx-6 mb-4">
-    <div>
-        This is an advanced feature which enables LiftLog to send backups to a remote server.
-        <br/>
-        Please read the documentation for instructions on how to set up a remote server.
-    </div>
-    <AppButton OnClick="OpenDocumentation" Type="AppButtonType.Text">Read Documentation</AppButton>
+    <LimitedHtml Value="@UiStrings.RemoteBackupDescription"/>
+    <AppButton OnClick="OpenDocumentation" Type="AppButtonType.Text">@UiStrings.ReadDocumentation</AppButton>
 </Card>
 
 <LabelledForm>
-    <LabelledFormRow Label="Endpoint" Icon="public">
+    <LabelledFormRow Label="@UiStrings.Endpoint" Icon="public">
         <TextField
             TextFieldType="TextFieldType.Outlined"
             placeholder="https://example.com/backup"
@@ -26,7 +22,7 @@
             required>
         </TextField>
     </LabelledFormRow>
-    <LabelledFormRow Label="API Key" Icon="vpn_key">
+    <LabelledFormRow Label="@UiStrings.ApiKey" Icon="vpn_key">
         <TextField
             TextFieldType="TextFieldType.Outlined"
             Value="@ApiKeyValue"
@@ -34,12 +30,12 @@
             OnChange="UpdateApiKey">
         </TextField>
     </LabelledFormRow>
-    <ListSwitch Headline="Backup feed account" SupportingText="Include your feed account data in backups" Value=@IncludeFeedAccount OnSwitched="UpdateIncludeFeedAccount"/>
+    <ListSwitch Headline="@UiStrings.BackupFeedAccount" SupportingText="@UiStrings.BackupFeedAccountSubtitle" Value=@IncludeFeedAccount OnSwitched="UpdateIncludeFeedAccount"/>
 </LabelledForm>
 
 <div class="flex justify-end gap-4 m-6">
-    <AppButton Type="AppButtonType.Text" Disabled=@(string.IsNullOrWhiteSpace(EndpointValue)) OnClick="Test">Test</AppButton>
-    <AppButton Type="AppButtonType.Primary" Disabled=@HasEndpointError OnClick="Save">Save</AppButton>
+    <AppButton Type="AppButtonType.Text" Disabled=@(string.IsNullOrWhiteSpace(EndpointValue)) OnClick="Test">@UiStrings.Test</AppButton>
+    <AppButton Type="AppButtonType.Primary" Disabled=@HasEndpointError OnClick="Save">@UiStrings.Save</AppButton>
 </div>
 
 
@@ -56,7 +52,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Automatic Remote Backup"));
+        Dispatcher.Dispatch(new SetPageTitleAction(@UiStrings.AutomaticRemoteBackup));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/backup-and-restore"));
         SubscribeToAction<RemoteBackupSucceededEvent>(OnRemoteBackupSucceeded);
         EndpointValue = SettingsState.Value.RemoteBackupSettings.Endpoint;

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestore/RemoteBackupPage.razor
@@ -72,7 +72,7 @@
             return;
         }
         Dispatcher.Dispatch(new UpdateRemoteBackupSettingsAction(new(EndpointValue, ApiKeyValue, IncludeFeedAccount)));
-        Dispatcher.Dispatch(new ToastAction("Settings saved"));
+        Dispatcher.Dispatch(new ToastAction(UiStrings.SettingsSaved));
     }
 
     private void OpenDocumentation(MouseEventArgs _)
@@ -108,6 +108,6 @@
 
     private void OnRemoteBackupSucceeded(RemoteBackupSucceededEvent _)
     {
-        Dispatcher.Dispatch(new ToastAction("Backup sent successfully"));
+        Dispatcher.Dispatch(new ToastAction(UiStrings.BackupSentSuccessfully));
     }
 }

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
@@ -31,10 +31,10 @@
 </md-list>
 
 
-<ConfirmationDialog @ref="importFeedDialog" OkText="@UiStrings.ImportVerb" CancelText="@UiStrings.No" OnOk="ImportFeedData">
+<ConfirmationDialog @ref="importFeedDialog" OkText="@UiStrings.Import" CancelText="@UiStrings.No" OnOk="ImportFeedData">
     <Headline>@UiStrings.ImportFeedDataQuestion</Headline>
     <TextContent>
-        <LimitedHtml Value="@UiStrings.ImportFeedDataQuestionMessage" HighlightClass="text-error font-bold" />
+        <LimitedHtml Value="@UiStrings.ImportFeedDataQuestionMessage" EmClass="text-error font-bold" />
     </TextContent>
 </ConfirmationDialog>
 
@@ -46,7 +46,7 @@
     OnCancel="()=>ExportData(false)">
     <Headline>@UiStrings.BackupFeedAccount</Headline>
     <TextContent>
-        <LimitedHtml Value="@UiStrings.BackupFeedAccountMessage" HighlightClass="text-error font-bold" />
+        <LimitedHtml Value="@UiStrings.BackupFeedAccountMessage" EmClass="text-error font-bold" />
     </TextContent>
 </ConfirmationDialog>
 

--- a/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
+++ b/LiftLog.Ui/Pages/Settings/BackupAndRestorePage.razor
@@ -9,42 +9,44 @@
 <md-list>
     <md-list-item type="button" class="text-left" multi-line-supporting-text @onclick="()=>exportFeedDialog?.Open()">
         <md-icon slot="start">backup</md-icon>
-        <span slot="headline">Backup data</span>
-        <span slot="supporting-text">Export your data to a file for backup or transfer</span>
+        <span slot="headline">@UiStrings.BackUpData</span>
+        <span slot="supporting-text">@UiStrings.BackUpDataSubtitle</span>
     </md-list-item>
     <md-list-item type="button" class="text-left" multi-line-supporting-text @onclick="ImportData">
         <md-icon slot="start">restore</md-icon>
-        <span slot="headline">Restore data</span>
-        <span slot="supporting-text">Import data from a file to restore</span>
+        <span slot="headline">@UiStrings.RestoreData</span>
+        <span slot="supporting-text">@UiStrings.RestoreDataSubtitle</span>
     </md-list-item>
     <md-list-item type="button" class="text-left" multi-line-supporting-text @onclick="RemoteBackup">
         <md-icon slot="start">cloud_upload</md-icon>
-        <span slot="headline">Automatic remote backup</span>
-        <span slot="supporting-text">Send backups to a remote server. Advanced users only</span>
+        <span slot="headline">@UiStrings.AutomaticRemoteBackup</span>
+        <span slot="supporting-text">@UiStrings.AutomaticRemoteBackupSubtitle</span>
     </md-list-item>
     <md-list-item type="button" class="text-left" multi-line-supporting-text @onclick="PlainTextExport">
         <md-icon slot="start">description</md-icon>
-        <span slot="headline">Plaintext export</span>
-        <span slot="supporting-text">Export your data in a plaintext format such as CSV for use in other applications</span>
+        <span slot="headline">@UiStrings.PlaintextExport</span>
+        <span slot="supporting-text">@UiStrings.PlaintextExportSubtitle</span>
     </md-list-item>
     <ListSwitch Headline="Backup reminders" SupportingText="Periodically suggest a backup when you have not backed up in a while" Value="@SettingsState.Value.BackupReminder" OnSwitched="SetBackupReminder" />
 </md-list>
 
 
-<ConfirmationDialog @ref="importFeedDialog" OkText="Import" CancelText="No" OnOk="ImportFeedData">
-    <Headline>Import Feed Data?</Headline>
+<ConfirmationDialog @ref="importFeedDialog" OkText="@UiStrings.ImportVerb" CancelText="@UiStrings.No" OnOk="ImportFeedData">
+    <Headline>@UiStrings.ImportFeedDataQuestion</Headline>
     <TextContent>
-        <p>This backup includes a feed account. Would you like to import it?</p>
-        <p>You will lose access to your current account without a backup.</p>
-        <p class="text-error font-bold">This will replace your current account and cannot be undone!</p>
+        <LimitedHtml Value="@UiStrings.ImportFeedDataQuestionMessage" HighlightClass="text-error font-bold" />
     </TextContent>
 </ConfirmationDialog>
 
-<ConfirmationDialog @ref="exportFeedDialog" OkText="Include Feed" CancelText="Just my data" OnOk="()=>ExportData(true)" OnCancel="()=>ExportData(false)">
-    <Headline>Backup Feed Account</Headline>
+<ConfirmationDialog
+    @ref="exportFeedDialog"
+    OkText="@UiStrings.IncludeFeed"
+    CancelText="@UiStrings.JustMyData"
+    OnOk="()=>ExportData(true)"
+    OnCancel="()=>ExportData(false)">
+    <Headline>@UiStrings.BackupFeedAccount</Headline>
     <TextContent>
-        <p>Include your feed account and followed users in this backup?</p>
-        <p class="text-error font-bold">Caution: This would allow anyone with this backup to post feed content with your account</p>
+        <LimitedHtml Value="@UiStrings.BackupFeedAccountMessage" HighlightClass="text-error font-bold" />
     </TextContent>
 </ConfirmationDialog>
 
@@ -68,7 +70,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Export, Backup and Restore"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.ExportBackupRestore));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
         SubscribeToAction<BeginFeedImportAction>(OnBeginFeedImport);
     }

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -17,14 +17,14 @@
     <div class="bg-surface pt-2">
 
         <LabelledForm>
-            <LabelledFormRow Label="Session Name" Icon="assignment">
+            <LabelledFormRow Label="@UiStrings.WorkoutName" Icon="assignment">
                 <TextField
                     TextFieldType="TextFieldType.Filled"
                     Value="@SessionEditorState.Value.SessionBlueprint.Name"
                     OnChange="@((val) => SetName(val!))">
                 </TextField>
             </LabelledFormRow>
-            <LabelledFormRow Label="Session Notes" Icon="notes">
+            <LabelledFormRow Label="@UiStrings.WorkoutNotes" Icon="notes">
                 <TextField
                     TextFieldType="TextFieldType.Filled"
                     Value="@SessionEditorState.Value.SessionBlueprint.Notes"
@@ -34,21 +34,26 @@
                     OnChange="@((val) => SetNotes(val!))">
                 </TextField>
             </LabelledFormRow>
-            <LabelledFormRow Label="Exercises" Icon="fitness_center">
+            <LabelledFormRow Label="@UiStrings.Exercises" Icon="fitness_center">
                 @if(SessionEditorState.Value.SessionBlueprint.Exercises.Count == 0)
                 {
                     <Card Type="Card.CardType.Filled">
                         <div class="flex flex-col items-center">
-                            <span class="text-on-surface">No exercises added yet</span>
+                            <span class="text-on-surface">@UiStrings.NoExercisesAdded</span>
                         </div>
                     </Card>
                 }
-                <ItemList Items="SessionEditorState.Value.SessionBlueprint.Exercises.IndexedTuples()" VerticalPadding=false class="-mx-6" Dividers=false >
+                <ItemList Items="SessionEditorState.Value.SessionBlueprint.Exercises.Index()" VerticalPadding=false class="-mx-6" Dividers=false >
                     @{
                         var exercise = context.Item;
                         var index = context.Index;
                     }
-                    <ExerciseBlueprintSummary  Blueprint="@exercise" OnEdit="()=>BeginEditExercise(exercise,index)" OnMoveDown="()=>MoveExerciseDown(exercise)" OnMoveUp="()=>MoveExerciseUp(exercise)" OnRemove="()=>BeginRemoveExercise(exercise)" />
+                    <ExerciseBlueprintSummary
+                        Blueprint="@exercise"
+                        OnEdit="()=>BeginEditExercise(exercise,index)"
+                        OnMoveDown="()=>MoveExerciseDown(exercise)"
+                        OnMoveUp="()=>MoveExerciseUp(exercise)"
+                        OnRemove="()=>BeginRemoveExercise(exercise)" />
                 </ItemList>
             </LabelledFormRow>
         </LabelledForm>
@@ -56,12 +61,12 @@
     </div>
     <FloatingBottomContainer>
         <Fab>
-            <FloatingButton size="small" variant="surface" aria-label="Add Exercise" label="Add Exercise" OnClick="BeginAddExercise"><md-icon slot="icon">add</md-icon></FloatingButton>
+            <FloatingButton size="small" variant="surface" aria-label="Add Exercise" label="@UiStrings.AddExercise" OnClick="BeginAddExercise"><md-icon slot="icon">add</md-icon></FloatingButton>
         </Fab>
     </FloatingBottomContainer>
 }
 
-<FullScreenDialog @ref=editDialog Title=@(isAddingExercise ? "Add Exercise" : "Edit Exercise") Action="Save" OnAction="UpdateExercise" >
+<FullScreenDialog @ref=editDialog Title=@(isAddingExercise ? UiStrings.AddExercise : UiStrings.EditExercise) Action="@UiStrings.Save" OnAction="UpdateExercise" >
     @if(selectedExercise is not null)
     {
         <ExerciseEditor Exercise="selectedExercise" UpdateExercise="(ex) => {selectedExercise = ex; StateHasChanged();}" />
@@ -69,8 +74,10 @@
 </FullScreenDialog>
 
 <Dialog @ref="deleteDialog">
-    <span slot="headline">Remove Exercise?</span>
-    <span slot="content" class="block text-left">This will remove the exercise <span class="font-bold text-primary">"@(selectedExercise?.Name)"</span> from <span class="font-bold text-primary">@SessionEditorState.Value.SessionBlueprint?.Name</span>.</span>
+    <span slot="headline">@UiStrings.RemoveExerciseQuestion</span>
+    <span slot="content" class="block text-left">
+        <LimitedHtml Value="@UiStrings.RemoveExerciseFromWorkoutMessage(selectedExercise?.Name, SessionEditorState.Value.SessionBlueprint?.Name)"/>
+    </span>
     <div slot="actions">
         <AppButton Type="AppButtonType.Text" OnClick="() => { deleteDialog?.Close(); }">@UiStrings.Cancel</AppButton>
         <AppButton Type="AppButtonType.Text" OnClick="RemoveExercise">@UiStrings.Remove</AppButton>

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -6,7 +6,6 @@
 @page "/settings/manage-workouts/manage-session/{sessionIndex:int}"
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-@inject IStringLocalizer<UiStrings> UiStrings
 @inject NavigationManager NavigationManager
 @inject IState<SessionEditorState> SessionEditorState
 @inject IState<ProgramState> ProgramState

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -6,6 +6,7 @@
 @page "/settings/manage-workouts/manage-session/{sessionIndex:int}"
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
+@inject IStringLocalizer<UiStrings> UiStrings
 @inject NavigationManager NavigationManager
 @inject IState<SessionEditorState> SessionEditorState
 @inject IState<ProgramState> ProgramState
@@ -73,7 +74,7 @@
     <span slot="content" class="block text-left">This will remove the exercise <span class="font-bold text-primary">"@(selectedExercise?.Name)"</span> from <span class="font-bold text-primary">@SessionEditorState.Value.SessionBlueprint?.Name</span>.</span>
     <div slot="actions">
         <AppButton Type="AppButtonType.Text" OnClick="() => { deleteDialog?.Close(); }">Cancel</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="RemoveExercise">Remove</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="RemoveExercise">@(UiStrings.Remove())</AppButton>
     </div>
 </Dialog>
 

--- a/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageSessionPage.razor
@@ -72,8 +72,8 @@
     <span slot="headline">Remove Exercise?</span>
     <span slot="content" class="block text-left">This will remove the exercise <span class="font-bold text-primary">"@(selectedExercise?.Name)"</span> from <span class="font-bold text-primary">@SessionEditorState.Value.SessionBlueprint?.Name</span>.</span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" OnClick="() => { deleteDialog?.Close(); }">Cancel</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="RemoveExercise">@(UiStrings.Remove())</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="() => { deleteDialog?.Close(); }">@UiStrings.Cancel</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="RemoveExercise">@UiStrings.Remove</AppButton>
     </div>
 </Dialog>
 

--- a/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
@@ -14,20 +14,20 @@
 
 @if(ProgramState.Value.SavedPrograms.ContainsKey(PlanId)){
     <TextField
-        Label="Plan Name"
+        Label="@UiStrings.PlanName"
         TextFieldType="TextFieldType.Filled"
         Value="@ProgramState.Value.SavedPrograms[PlanId].Name"
         class="m-2"
-        OnChange="@((val) => Dispatcher.Dispatch(new SetSavedPlanNameAction(PlanId, val??"")))" />
+        OnChange="@((val) => Dispatcher.Dispatch(new SetSavedPlanNameAction(PlanId, val ?? "")))" />
 
 
     @if (!ProgramState.Value.GetSessionBlueprints(PlanId).Any())
     {
         <EmptyInfo>
-            <p>No sessions in plan<br> Add a session to get started.</p>
+            @UiStrings.NoWorkoutsInPlan
         </EmptyInfo>
     }
-    <CardList Items="ProgramState.Value.GetSessionBlueprints(PlanId).IndexedTuples()" OnClick="(item) => SelectSession(item.Item, item.Index)">
+    <CardList Items="ProgramState.Value.GetSessionBlueprints(PlanId).Index()" OnClick="(item) => SelectSession(item.Item, item.Index)">
         @{
             var session = context.Item;
             var index = context.Index;
@@ -42,14 +42,14 @@
 
     <FloatingBottomContainer>
         <Fab>
-            <FloatingButton size="small" variant="surface" aria-label="Add Session" label="Add Session" OnClick="AddSession"><md-icon slot="icon">add</md-icon></FloatingButton>
+            <FloatingButton size="small" variant="surface" aria-label="Add Session" label="@UiStrings.AddWorkout" OnClick="AddSession"><md-icon slot="icon">add</md-icon></FloatingButton>
         </Fab>
     </FloatingBottomContainer>
 
     @if(IsInActiveScreen && ProgramState.Value.ActivePlanId != PlanId)
     {
         <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
-            <AppButton class="text-lg" Type=AppButtonType.Text OnClick=UseSession>Use</AppButton>
+            <AppButton class="text-lg" Type=AppButtonType.Text OnClick=UseSession>@UiStrings.UseWorkout</AppButton>
         </Microsoft.AspNetCore.Components.Sections.SectionContent>
     }
 }
@@ -82,7 +82,7 @@
         Dispatcher.Dispatch(
             new AddProgramSessionAction(
                 PlanId,
-                SessionBlueprint.Empty with { Name = $"Session {ProgramState.Value.GetSessionBlueprints(PlanId).Count + 1}" })
+                SessionBlueprint.Empty with { Name = $"{UiStrings.Workout} {ProgramState.Value.GetSessionBlueprints(PlanId).Count + 1}" })
         );
         SelectSession(ProgramState.Value.GetSessionBlueprints(PlanId).Last(), ProgramState.Value.GetSessionBlueprints(PlanId).Count - 1);
     }
@@ -92,7 +92,7 @@
             PlanId,
             sessionBlueprint with
             {
-                Name = $"Session {ProgramState.Value.GetSessionBlueprints(PlanId).Count + 1}"
+                Name = $"{UiStrings.Workout} {ProgramState.Value.GetSessionBlueprints(PlanId).Count + 1}"
             }
         )
     );
@@ -106,7 +106,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        var title = "Manage " + ProgramState.Value.SavedPrograms[PlanId].Name;
+        var title = UiStrings.ManageWorkout(ProgramState.Value.SavedPrograms[PlanId].Name);
         Dispatcher.Dispatch(new SetPageTitleAction(title));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings/program-list"));
     }

--- a/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ManageWorkoutsPage.razor
@@ -24,7 +24,7 @@
     @if (!ProgramState.Value.GetSessionBlueprints(PlanId).Any())
     {
         <EmptyInfo>
-            @UiStrings.NoWorkoutsInPlan
+            <LimitedHtml Value="@UiStrings.NoWorkoutsInPlan"/>
         </EmptyInfo>
     }
     <CardList Items="ProgramState.Value.GetSessionBlueprints(PlanId).Index()" OnClick="(item) => SelectSession(item.Item, item.Index)">

--- a/LiftLog.Ui/Pages/Settings/NotificationsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/NotificationsPage.razor
@@ -5,7 +5,7 @@
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <md-list class="text-left">
-    <ListSwitch Headline="Rest notifications" SupportingText="Show a notification when the rest timer is up" Value="@SettingsState.Value.RestNotifications" OnSwitched="SetRestNotifications" />
+    <ListSwitch Headline="@UiStrings.RestNotifications" SupportingText="@UiStrings.RestNotificationsSubtitle" Value="@SettingsState.Value.RestNotifications" OnSwitched="SetRestNotifications" />
 </md-list>
 
 <AndroidNotificationAlert />
@@ -14,7 +14,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Notifications"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Notifications));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/settings"));
     }
 

--- a/LiftLog.Ui/Pages/Settings/ProgramListPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ProgramListPage.razor
@@ -47,7 +47,7 @@
         {
             <SnackBar>
                 <div class="flex justify-between items-center">
-                    <LimitedHtml Value="@UiStrings.SelectedPlan(ProgramState.Value.GetActivePlan().Name)" HighlightClass="font-bold"/>
+                    <LimitedHtml Value="@UiStrings.SelectedPlan(ProgramState.Value.GetActivePlan().Name)" EmClass="font-bold"/>
                     <SnackBarButton OnClick=@(()=>Dispatcher.Dispatch(new NavigateAction("/")))>Go to workouts</SnackBarButton>
                 </div>
             </SnackBar>

--- a/LiftLog.Ui/Pages/Settings/ProgramListPage.razor
+++ b/LiftLog.Ui/Pages/Settings/ProgramListPage.razor
@@ -14,7 +14,7 @@
     var orderedPrograms = ProgramState.Value.SavedPrograms.OrderBy(x=>x.Value.Name).ToList();
     <section class="text-left text-on-surface flex flex-col">
         <md-list>
-            <ListTitle Title="Saved Plans" />
+            <ListTitle Title="@UiStrings.SavedPlans" />
             @foreach (var (id, program) in orderedPrograms)
             {
                 <ProgramListItem
@@ -37,7 +37,7 @@
 <FloatingBottomContainer>
     <Fab>
         <div class="flex flex-col gap-2 items-end">
-            <FloatingButton variant="primary" has-icon OnClick="AddNewPlan" Label="Add plan">
+            <FloatingButton variant="primary" has-icon OnClick="AddNewPlan" Label="@UiStrings.AddPlan">
                 <md-icon slot="icon">add</md-icon>
             </FloatingButton>
         </div>
@@ -47,7 +47,7 @@
         {
             <SnackBar>
                 <div class="flex justify-between items-center">
-                    <span>Selected <span class="font-bold">@ProgramState.Value.GetActivePlan().Name</span></span>
+                    <LimitedHtml Value="@UiStrings.SelectedPlan(ProgramState.Value.GetActivePlan().Name)" HighlightClass="font-bold"/>
                     <SnackBarButton OnClick=@(()=>Dispatcher.Dispatch(new NavigateAction("/")))>Go to workouts</SnackBarButton>
                 </div>
             </SnackBar>

--- a/LiftLog.Ui/Pages/Settings/SettingsPage.razor
+++ b/LiftLog.Ui/Pages/Settings/SettingsPage.razor
@@ -12,26 +12,26 @@
     <ListTitle Title="Configuration" />
     <md-list-item type="button" multi-line-supporting-text @onclick="NavigateToProgramList">
         <md-icon slot="start">assignment</md-icon>
-        <span slot="headline" >Manage plans</span>
-        <span slot="supporting-text">Setup your workout plans</span>
+        <span slot="headline" >@UiStrings.ManagePlans</span>
+        <span slot="supporting-text">@UiStrings.ManagePlansSubtitle</span>
     </md-list-item>
 
     <md-list-item type="button" multi-line-supporting-text @onclick="NavigateToAppConfiguration">
         <md-icon slot="start">settings</md-icon>
-        <span slot="headline" >App Configuration</span>
-        <span slot="supporting-text">Adjust weight units, theme, and other misc. settings</span>
+        <span slot="headline" >@UiStrings.AppConfiguration</span>
+        <span slot="supporting-text">@UiStrings.AppConfigurationSubtitle</span>
     </md-list-item>
 
     <md-list-item type="button" multi-line-supporting-text @onclick="NavigateToNotifications">
         <md-icon slot="start">notifications</md-icon>
-        <span slot="headline" >Notifications</span>
-        <span slot="supporting-text">Adjust notification settings for rest timers</span>
+        <span slot="headline" >@UiStrings.Notifications</span>
+        <span slot="supporting-text">@UiStrings.NotificationsSubtitle</span>
     </md-list-item>
 
     <md-list-item type="button" multi-line-supporting-text @onclick="NavigateToBackupAndRestore">
         <md-icon slot="start">settings_backup_restore</md-icon>
-        <span slot="headline" >Export, backup, and restore</span>
-        <span slot="supporting-text">Create and export backups for transfering between devices</span>
+        <span slot="headline" >@UiStrings.ExportBackupRestore</span>
+        <span slot="supporting-text">@UiStrings.ExportBackupRestoreSubtitle</span>
     </md-list-item>
 </md-list>
 <ProFeatures/>
@@ -39,31 +39,31 @@
     <ListTitle Title="Support" />
     <md-list-item type="button" multi-line-supporting-text @onclick=@(OpenUrl("https://github.com/LiamMorrow/LiftLog/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md"))>
         <md-icon slot="start">star</md-icon>
-        <span slot="headline" >Feature request</span>
-        <span slot="supporting-text">Suggest a new feature that you think LiftLog should have!</span>
+        <span slot="headline" >@UiStrings.FeatureRequest</span>
+        <span slot="supporting-text">@UiStrings.FeatureRequestSubtitle</span>
     </md-list-item>
     <md-list-item type="button" multi-line-supporting-text @onclick=@(OpenUrl("https://github.com/LiamMorrow/LiftLog/issues/new?assignees=&labels=bug&projects=&template=bug_report.md"))>
         <md-icon slot="start">bug_report</md-icon>
-        <span slot="headline" >Bug report</span>
-        <span slot="supporting-text">Let us know when you encounter a bug</span>
+        <span slot="headline" >@UiStrings.BugReport</span>
+        <span slot="supporting-text">@UiStrings.BugReportSubtitle</span>
     </md-list-item>
 
     <md-list-item type="button" multi-line-supporting-text @onclick="ShowAppInfo">
         <md-icon slot="start">info</md-icon>
-        <span slot="headline" >App Info</span>
-        <span slot="supporting-text">Display app information</span>
+        <span slot="headline" >@UiStrings.AppInfo</span>
+        <span slot="supporting-text">@UiStrings.AppInfoSubtitle</span>
     </md-list-item>
 
 </md-list>
 
 
 <Dialog @ref="appInfoDialog" type="alert">
-    <span slot="headline">App Info</span>
+    <span slot="headline">@UiStrings.AppInfo</span>
     <span slot="content" class="block text-left">
         LiftLog is an entirely open source app, licensed under the AGPL-3.0 license. You can find the source code on <a class="underline text-primary font-bold" href="https://github.com/LiamMorrow/LiftLog" @onclick=@(OpenUrl("https://github.com/LiamMorrow/LiftLog"))>GitHub</a>.
     </span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" OnClick="() => { appInfoDialog?.Close(); }">Close</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="() => { appInfoDialog?.Close(); }">@UiStrings.Close</AppButton>
     </div>
 </Dialog>
 
@@ -74,7 +74,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Settings"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Settings));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
     }
 

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -6,7 +6,6 @@
 @inject IState<StatsState> StatsState;
 @inject IDispatcher Dispatcher;
 
-@inject IStringLocalizer<UiStrings> UiStrings
 
 <div class="flex justify-between my-2">
     <Select T="string" Options="SessionSelectOptions" Value="StatsState.Value.OverallViewSessionName" ValueChanged="v => {  Dispatcher.Dispatch(new SetOverallViewSessionAction(v)); Dispatcher.Dispatch(new SetStatsIsDirtyAction(true)); Dispatcher.Dispatch(new FetchOverallStatsAction());}"></Select>

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -8,8 +8,17 @@
 
 
 <div class="flex justify-between my-2">
-    <Select T="string" Options="SessionSelectOptions" Value="StatsState.Value.OverallViewSessionName" ValueChanged="v => {  Dispatcher.Dispatch(new SetOverallViewSessionAction(v)); Dispatcher.Dispatch(new SetStatsIsDirtyAction(true)); Dispatcher.Dispatch(new FetchOverallStatsAction());}"></Select>
-    <Select data-cy="stats-time-selector" T="TimeSpan" Options="SelectTimeOptions" Value="StatsState.Value.OverallViewTime" ValueChanged="v => { Dispatcher.Dispatch(new SetOverallViewTimeAction(v)); Dispatcher.Dispatch(new SetStatsIsDirtyAction(true)); Dispatcher.Dispatch(new FetchOverallStatsAction()); }"></Select>
+    <Select
+        T="string"
+        Options="SessionSelectOptions"
+        Value="StatsState.Value.OverallViewSessionName"
+        ValueChanged="HandleSessionSelectChanged" />
+    <Select
+        data-cy="stats-time-selector"
+        T="TimeSpan"
+        Options="SelectTimeOptions"
+        Value="StatsState.Value.OverallViewTime"
+        ValueChanged="HandleTimeSelectChanged" />
 </div>
 <div class="flex flex-col justify-between m-2 mb-5">
     <SearchInput SearchTerm=@SearchTerm OnSearch="@((st)=>{SearchTerm = st; StateHasChanged();})" />
@@ -18,17 +27,17 @@
 {
     <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
         <div>
-            <md-circular-progress aria-label="Session loading" indeterminate four-color></md-circular-progress>
+            <md-circular-progress indeterminate four-color></md-circular-progress>
         </div>
         <span>
-            <p>Calculating...</p>
+            <p>@UiStrings.Calculating</p>
         </span>
     </div>
 }
 else if ((StatsState.Value.OverallView?.SessionStats.Count ?? 0) == 0)
 {
     <EmptyInfo>
-        <p>No data available.<br> Try changing your filters at the top.</p>
+        <p>@UiStrings.NoDataAvailable<br>@UiStrings.TryChangingFilters</p>
     </EmptyInfo>
 }
 else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null)
@@ -36,23 +45,23 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
     var overallStats = StatsState.Value.OverallView;
     <div class="grid grid-rows-2 grid-cols-2 gap-2 mb-2 px-2 @HiddenOnSearch">
         <SingleValueStatisticsCard Class="scale-0 animate-zoom-in">
-            <Title>Average time between sets</Title>
+            <Title>@UiStrings.AverageTimeBetweenSets</Title>
             <Body>
             <TimeSpanFormat TimeSpan="@overallStats.AverageTimeBetweenSets"/>
             </Body>
         </SingleValueStatisticsCard>
         <SingleValueStatisticsCard Class="scale-0 animate-zoom-in" Style="animation-delay: 50ms;">
-            <Title>Average session length</Title>
+            <Title>@UiStrings.AverageSessionLength</Title>
             <Body>
             <TimeSpanFormat TimeSpan="@overallStats.AverageSessionLength" TruncateToMins="true"/>
             </Body>
         </SingleValueStatisticsCard>
         <SingleValueStatisticsCard Class="scale-0 animate-zoom-in" Style="animation-delay: 100ms;">
-            <Title>Most time spent</Title>
+            <Title>@UiStrings.MostTimeSpent</Title>
             <Body>@overallStats.ExerciseMostTimeSpent?.ExerciseName</Body>
         </SingleValueStatisticsCard>
         <SingleValueStatisticsCard Class="scale-0 animate-zoom-in" Style="animation-delay: 150ms;">
-            <Title>Heaviest lift</Title>
+            <Title>@UiStrings.HeaviestLift</Title>
             <Body>
             <div class="flex flex-col justify-center items-center">
                 <WeightFormat Weight="@overallStats.HeaviestLift?.Weight"/>
@@ -72,11 +81,11 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
         @if (SettingsState.Value.ShowBodyweight && overallStats.BodyweightStats.Statistics.Any())
         {
             <Card class=@CardClass >
-                <StatGraphCardContent Title="Bodyweight" Statistics="[overallStats.BodyweightStats]" RenderDelay="TimeSpan.FromMilliseconds(100)"/>
+                <StatGraphCardContent Title="@UiStrings.Bodyweight" Statistics="[overallStats.BodyweightStats]" RenderDelay="TimeSpan.FromMilliseconds(100)"/>
             </Card>
         }
         <Card class=@CardClass>
-            <StatGraphCardContent Title="Sessions" Statistics="overallStats.SessionStats" RenderDelay="TimeSpan.FromMilliseconds(200)"/>
+            <StatGraphCardContent Title="@UiStrings.Sessions" Statistics="overallStats.SessionStats" RenderDelay="TimeSpan.FromMilliseconds(200)"/>
         </Card>
         <CardList KeySelector="context=>context.Item.ExerciseName" Items="@(UnpinnedExercisesToShow.IndexedTuples())" >
             <StatGraphCardContent Title="@context.Item.ExerciseName" Statistics="[context.Item.Statistics, context.Item.OneRepMaxStatistics]" RenderDelay="TimeSpan.FromMilliseconds(200 + context.Index * 200)"/>
@@ -84,7 +93,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
         @if(SearchTerm != "" && !UnpinnedExercisesToShow.Any())
         {
             <EmptyInfo>
-                <p>No exercises found.<br> Try changing your filters at the top.</p>
+                <p>@UiStrings.NoExercisesFound<br>@UiStrings.TryChangingFilters</p>
             </EmptyInfo>
         }
     </div>
@@ -94,17 +103,21 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
 
     private string SearchTerm = "";
 
-    private IEnumerable<ExerciseStatistics> UnpinnedExercisesToShow => StatsState.Value.OverallView?.ExerciseStats.Where(x=>!StatsState.Value.IsExercisePinned(x)).Where(SearchTermMatches) ?? [];
+    private IEnumerable<ExerciseStatistics> UnpinnedExercisesToShow
+        => StatsState.Value.OverallView?.ExerciseStats
+            .Where(x=>!StatsState.Value.IsExercisePinned(x))
+            .Where(SearchTermMatches)
+            ?? [];
 
-    private List<Select<TimeSpan>.SelectOption> SelectTimeOptions =
+    private List<Select<TimeSpan>.SelectOption> SelectTimeOptions =>
     [
-        new("7 days", TimeSpan.FromDays(7)),
-        new("14 days", TimeSpan.FromDays(14)),
-        new("30 days", TimeSpan.FromDays(30)),
-        new("90 days", TimeSpan.FromDays(90)),
-        new("180 days", TimeSpan.FromDays(180)),
-        new("365 days", TimeSpan.FromDays(365)),
-        new("All time", TimeSpan.FromDays(36500)),
+        new(UiStrings.NumDays_Days(7), TimeSpan.FromDays(7)),
+        new(UiStrings.NumDays_Days(14), TimeSpan.FromDays(14)),
+        new(UiStrings.NumDays_Days(30), TimeSpan.FromDays(30)),
+        new(UiStrings.NumDays_Days(90), TimeSpan.FromDays(90)),
+        new(UiStrings.NumDays_Days(180), TimeSpan.FromDays(180)),
+        new(UiStrings.NumDays_Days(365), TimeSpan.FromDays(365)),
+        new(UiStrings.AllTime, TimeSpan.FromDays(36500)),
     ];
 
     private List<Select<string>.SelectOption> SessionSelectOptions = [];
@@ -113,7 +126,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
     {
         base.OnInitialized();
         Dispatcher.Dispatch(new FetchOverallStatsAction());
-        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Statistics()));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Statistics));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
     }
 
@@ -122,8 +135,8 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
         SessionSelectOptions = await SessionService.GetLatestSessionsAsync()
             .Select(x => new Select<string>.SelectOption(x.Blueprint.Name, x.Blueprint.Name))
             .Distinct()
-            .Prepend(new Select<string>.SelectOption("All sessions", null!))
-            .Prepend(new Select<string>.SelectOption("Current sessions", "CURRENT_SESSIONS"))
+            .Prepend(new Select<string>.SelectOption(UiStrings.AllSessions, null!))
+            .Prepend(new Select<string>.SelectOption(UiStrings.CurrentSessions, "CURRENT_SESSIONS"))
             .ToListAsync();
         await base.OnInitializedAsync();
     }
@@ -139,5 +152,19 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
             return true;
         }
         return statistics.ExerciseName.Contains(SearchTerm, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void HandleSessionSelectChanged(string? value)
+    {
+        Dispatcher.Dispatch(new SetOverallViewSessionAction(value));
+        Dispatcher.Dispatch(new SetStatsIsDirtyAction(true));
+        Dispatcher.Dispatch(new FetchOverallStatsAction());
+    }
+
+    private void HandleTimeSelectChanged(TimeSpan value)
+    {
+        Dispatcher.Dispatch(new SetOverallViewTimeAction(value));
+        Dispatcher.Dispatch(new SetStatsIsDirtyAction(true));
+        Dispatcher.Dispatch(new FetchOverallStatsAction());
     }
 }

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -72,7 +72,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
     </div>
 
     <div class="flex flex-col gap-2">
-        @foreach(var pinnedStat in StatsState.Value.GetPinnedExercises().Where(SearchTermMatches).IndexedTuples())
+        @foreach(var pinnedStat in StatsState.Value.GetPinnedExercises().Where(SearchTermMatches).Index())
         {
             <Card class="mx-2">
                 <StatGraphCardContent Title="@pinnedStat.Item.ExerciseName" Statistics="[pinnedStat.Item.Statistics, pinnedStat.Item.OneRepMaxStatistics]" RenderDelay="TimeSpan.FromMilliseconds(200 + pinnedStat.Index * 200)"/>
@@ -87,7 +87,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
         <Card class=@CardClass>
             <StatGraphCardContent Title="@UiStrings.Sessions" Statistics="overallStats.SessionStats" RenderDelay="TimeSpan.FromMilliseconds(200)"/>
         </Card>
-        <CardList KeySelector="context=>context.Item.ExerciseName" Items="@(UnpinnedExercisesToShow.IndexedTuples())" >
+        <CardList KeySelector="context=>context.Item.ExerciseName" Items="@(UnpinnedExercisesToShow.Index())" >
             <StatGraphCardContent Title="@context.Item.ExerciseName" Statistics="[context.Item.Statistics, context.Item.OneRepMaxStatistics]" RenderDelay="TimeSpan.FromMilliseconds(200 + context.Index * 200)"/>
         </CardList>
         @if(SearchTerm != "" && !UnpinnedExercisesToShow.Any())
@@ -111,12 +111,12 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
 
     private List<Select<TimeSpan>.SelectOption> SelectTimeOptions =>
     [
-        new(UiStrings.NumDays_Days(7), TimeSpan.FromDays(7)),
-        new(UiStrings.NumDays_Days(14), TimeSpan.FromDays(14)),
-        new(UiStrings.NumDays_Days(30), TimeSpan.FromDays(30)),
-        new(UiStrings.NumDays_Days(90), TimeSpan.FromDays(90)),
-        new(UiStrings.NumDays_Days(180), TimeSpan.FromDays(180)),
-        new(UiStrings.NumDays_Days(365), TimeSpan.FromDays(365)),
+        new(UiStrings.NumDays(7), TimeSpan.FromDays(7)),
+        new(UiStrings.NumDays(14), TimeSpan.FromDays(14)),
+        new(UiStrings.NumDays(30), TimeSpan.FromDays(30)),
+        new(UiStrings.NumDays(90), TimeSpan.FromDays(90)),
+        new(UiStrings.NumDays(180), TimeSpan.FromDays(180)),
+        new(UiStrings.NumDays(365), TimeSpan.FromDays(365)),
         new(UiStrings.AllTime, TimeSpan.FromDays(36500)),
     ];
 

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -25,14 +25,7 @@
 </div>
 @if (StatsState.Value.IsLoading)
 {
-    <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
-        <div>
-            <md-circular-progress indeterminate four-color></md-circular-progress>
-        </div>
-        <span>
-            <p>@UiStrings.Calculating</p>
-        </span>
-    </div>
+    <Loader LoadingText="@UiStrings.Calculating" />
 }
 else if ((StatsState.Value.OverallView?.SessionStats.Count ?? 0) == 0)
 {

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -6,6 +6,8 @@
 @inject IState<StatsState> StatsState;
 @inject IDispatcher Dispatcher;
 
+@inject IStringLocalizer<UiStrings> UiStrings
+
 <div class="flex justify-between my-2">
     <Select T="string" Options="SessionSelectOptions" Value="StatsState.Value.OverallViewSessionName" ValueChanged="v => {  Dispatcher.Dispatch(new SetOverallViewSessionAction(v)); Dispatcher.Dispatch(new SetStatsIsDirtyAction(true)); Dispatcher.Dispatch(new FetchOverallStatsAction());}"></Select>
     <Select data-cy="stats-time-selector" T="TimeSpan" Options="SelectTimeOptions" Value="StatsState.Value.OverallViewTime" ValueChanged="v => { Dispatcher.Dispatch(new SetOverallViewTimeAction(v)); Dispatcher.Dispatch(new SetStatsIsDirtyAction(true)); Dispatcher.Dispatch(new FetchOverallStatsAction()); }"></Select>
@@ -112,7 +114,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
     {
         base.OnInitialized();
         Dispatcher.Dispatch(new FetchOverallStatsAction());
-        Dispatcher.Dispatch(new SetPageTitleAction("Statistics"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.Statistics()));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction(null));
     }
 

--- a/LiftLog.Ui/ServiceRegistration.cs
+++ b/LiftLog.Ui/ServiceRegistration.cs
@@ -87,6 +87,8 @@ public static class ServiceRegistration
         services.Add<INotificationService, TNotificationService>(lifetime);
         services.Add<IBackupRestoreService, TExporter>(lifetime);
 
+        services.Add<LiftLog.Ui.i18n.TypealizR.TypealizedUiStrings>(lifetime);
+
         services.Add<IAiWorkoutPlanner, ApiBasedAiWorkoutPlanner>(lifetime);
 
         services.Add<SessionService>(lifetime);

--- a/LiftLog.Ui/ServiceRegistration.cs
+++ b/LiftLog.Ui/ServiceRegistration.cs
@@ -10,7 +10,6 @@ using LiftLog.Ui.Store.Feed;
 using LiftLog.Ui.Store.Program;
 using LiftLog.Ui.Store.Settings;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 #if DEBUG
 using Fluxor.Blazor.Web.ReduxDevTools;
 #endif
@@ -68,6 +67,8 @@ public static class ServiceRegistration
         services.Add<ProgressRepository>(lifetime);
         services.Add<PreferencesRepository>(lifetime);
         services.Add<NavigationManagerProvider>(lifetime);
+
+        services.AddLocalization();
 
         services.Add<
             BlazorTransitionableRoute.IRouteTransitionInvoker,

--- a/LiftLog.Ui/Shared/MainLayout.razor
+++ b/LiftLog.Ui/Shared/MainLayout.razor
@@ -38,14 +38,7 @@
                         }
                         else
                         {
-                            <div class="flex flex-col justify-center h-full gap-4 text-on-surface">
-                                <div>
-                                    <md-circular-progress aria-label="Session loading" indeterminate four-color></md-circular-progress>
-                                </div>
-                                <span>
-                                    <p>Loading...</p>
-                                </span>
-                            </div>
+                            <Loader />
                         }
                     </div>
                     <NavBar></NavBar>

--- a/LiftLog.Ui/Shared/Presentation/AiSessionCreator.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiSessionCreator.razor
@@ -1,18 +1,18 @@
 <LabelledForm>
-    <LabelledFormRow Label="What are we working out?" Icon="physical_therapy">
+    <LabelledFormRow Label="@UiStrings.WhatAreYouWorkingOut" Icon="physical_therapy">
         <ChipContainer>
-            @RenderFilterChip("Arms")
-            @RenderFilterChip("Chest")
-            @RenderFilterChip("Back")
-            @RenderFilterChip("Legs")
-            @RenderFilterChip("Triceps")
-            @RenderFilterChip("Biceps")
-            @RenderFilterChip("Quads")
-            @RenderFilterChip("Hamstrings")
-            @RenderFilterChip("Calves")
+            @RenderFilterChip(@UiStrings.Arms)
+            @RenderFilterChip(@UiStrings.Chest)
+            @RenderFilterChip(@UiStrings.BackMuscle)
+            @RenderFilterChip(@UiStrings.Legs)
+            @RenderFilterChip(@UiStrings.Triceps)
+            @RenderFilterChip(@UiStrings.Biceps)
+            @RenderFilterChip(@UiStrings.Quads)
+            @RenderFilterChip(@UiStrings.Hamstrings)
+            @RenderFilterChip(@UiStrings.Calves)
         </ChipContainer>
     </LabelledFormRow>
-    <LabelledFormRow Label="How much volume?" Icon="bar_chart">
+    <LabelledFormRow Label="" Icon="bar_chart">
         <Slider Min="0" Max="100" Value="Value.Volume" ValueChanged="i => OnChange.InvokeAsync(Value with { Volume = i })"
                 Label="@VolumeLabel">
         </Slider>
@@ -29,9 +29,9 @@
     private string VolumeLabel
         => Value.Volume switch
         {
-            <= 30 => "Light",
-            <= 60 => "Medium",
-            _ => "Heavy",
+            <= 30 => UiStrings.VolumeLight,
+            <= 60 => UiStrings.VolumeMedium,
+            _ => UiStrings.VolumeHeavy,
         };
 
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/AdditionalInfoInput.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/AdditionalInfoInput.razor
@@ -1,5 +1,5 @@
-<LabelledFormRow Label="Any additional information?" Icon="info">
-    <TextField label="Goals, injuries, available equipment, etc." TextFieldType=TextFieldType.Outlined type="textarea" inputmode="text" Value="@Value" maxlength=200 OnChange="@(value => OnUpdateAdditionalInfo(value))"/>
+<LabelledFormRow Label="@UiStrings.AdditionalInformationLabel" Icon="info">
+    <TextField label="@UiStrings.AdditionalInformationExtra" TextFieldType=TextFieldType.Outlined type="textarea" inputmode="text" Value="@Value" maxlength=200 OnChange="@(value => OnUpdateAdditionalInfo(value))"/>
 </LabelledFormRow>
 
 @code {

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/AgeSelector.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/AgeSelector.razor
@@ -1,6 +1,6 @@
 @inject IJSRuntime Js
 
-<LabelledFormRow Label="How old are you?" Icon="cake">
+<LabelledFormRow Label="@UiStrings.HowOldAreYou" Icon="cake">
     <TextField TextFieldType=TextFieldType.Outlined type="text" inputmode="numeric" Value="@(Value.ToString())" required OnChange="@(value => OnChanged(value))"/>
 </LabelledFormRow>
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/AiWorkoutWalkthrough.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/AiWorkoutWalkthrough.razor
@@ -18,7 +18,7 @@
 @if(IsInActiveScreen)
 {
     <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
-        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=OnGenerate Disabled="ValidationError is not null">Generate</AppButton>
+        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=OnGenerate Disabled="ValidationError is not null">@UiStrings.Generate</AppButton>
     </Microsoft.AspNetCore.Components.Sections.SectionContent>
 }
 
@@ -80,10 +80,10 @@
         OnAttributesSelected(attributes);
     }
 
-    private string? ValidationError => attributes switch
+    private LocalizedString? ValidationError => attributes switch
     {
-        {DaysPerWeek: 0} => "Please select the number of days per week",
-        {Goals.Count: 0} => "Please select at least one goal",
+        {DaysPerWeek: 0} => UiStrings.SelectNumberOfDays,
+        {Goals.Count: 0} => UiStrings.SelectAtLeastOneGoal,
         _ => null
     };
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/ExperienceLevelSelector.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/ExperienceLevelSelector.razor
@@ -1,9 +1,9 @@
-<LabelledFormRow Label="What is your experience level?" Icon="social_leaderboard">
+<LabelledFormRow Label="@UiStrings.WhatIsYourExperienceLevel" Icon="social_leaderboard">
     <ChipContainer>
-        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Beginner))" Label="Beginner" Selected="Value == Experience.Beginner"/>
-        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Intermediate))" Label="Intermediate" Selected="Value == Experience.Intermediate"/>
-        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Advanced))" Label="Advanced" Selected="Value == Experience.Advanced"/>
-        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Professional))" Label="Professional" Selected="Value == Experience.Professional"/>
+        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Beginner))" Label="@UiStrings.ExperienceBeginner" Selected="Value == Experience.Beginner"/>
+        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Intermediate))" Label="@UiStrings.ExperienceIntermediate" Selected="Value == Experience.Intermediate"/>
+        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Advanced))" Label="@UiStrings.ExperienceAdvanced" Selected="Value == Experience.Advanced"/>
+        <FilterChip OnSelectedChange="@((selected) => OnExperienceSelect(Experience.Professional))" Label="@UiStrings.ExperienceProfessional" Selected="Value == Experience.Professional"/>
     </ChipContainer>
 </LabelledFormRow>
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/GenderSelector.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/GenderSelector.razor
@@ -1,10 +1,10 @@
 
-<LabelledFormRow Label="What is your gender?" Icon="male">
+<LabelledFormRow Label="@UiStrings.WhatIsYourGender" Icon="male">
     <ChipContainer>
-        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.Female))" Label="Female" Selected="Value == Gender.Female"/>
-        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.Male))" Label="Male" Selected="Value == Gender.Male"/>
-        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.Other))" Label="Other" Selected="Value == Gender.Other"/>
-        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.PreferNotToSay))" Label="Prefer not to say" Selected="Value == Gender.PreferNotToSay"/>
+        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.Female))" Label="@UiStrings.GenderFemale" Selected="Value == Gender.Female"/>
+        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.Male))" Label="@UiStrings.GenderMale" Selected="Value == Gender.Male"/>
+        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.Other))" Label="@UiStrings.GenderOther" Selected="Value == Gender.Other"/>
+        <FilterChip OnSelectedChange="@((selected) => OnGenderSelect(Gender.PreferNotToSay))" Label="@UiStrings.GenderPreferNotToSay" Selected="Value == Gender.PreferNotToSay"/>
     </ChipContainer>
 </LabelledFormRow>
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/GoalsSelector.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/GoalsSelector.razor
@@ -1,10 +1,10 @@
 
-<LabelledFormRow Label="What are your goals?" Icon="speed">
+<LabelledFormRow Label="@UiStrings.WhatAreYourGoals" Icon="speed">
     <ChipContainer>
-        @RenderFilterChip("Strength")
-        @RenderFilterChip("Gaining Muscle")
-        @RenderFilterChip("Losing Weight")
-        @RenderFilterChip("Toning")
+        @RenderFilterChip(UiStrings.Strength)
+        @RenderFilterChip(UiStrings.GainingMuscle)
+        @RenderFilterChip(UiStrings.LosingWeight)
+        @RenderFilterChip(UiStrings.Toning)
     </ChipContainer>
 </LabelledFormRow>
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/NumberOfDaysSelector.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/NumberOfDaysSelector.razor
@@ -1,12 +1,12 @@
-<LabelledFormRow Label="How many days per week?" Icon="event">
+<LabelledFormRow Label="@UiStrings.HowManyDaysPerWeek" Icon="event">
     <ChipContainer>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(1))" Label="One" Selected="Value == 1"/>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(2))" Label="Two" Selected="Value == 2"/>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(3))" Label="Three" Selected="Value == 3"/>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(4))" Label="Four" Selected="Value == 4"/>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(5))" Label="Five" Selected="Value == 5"/>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(6))" Label="Six" Selected="Value == 6"/>
-        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(7))" Label="Seven" Selected="Value == 7"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(1))" Label="@UiStrings.One" Selected="Value == 1"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(2))" Label="@UiStrings.Two" Selected="Value == 2"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(3))" Label="@UiStrings.Three" Selected="Value == 3"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(4))" Label="@UiStrings.Four" Selected="Value == 4"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(5))" Label="@UiStrings.Five" Selected="Value == 5"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(6))" Label="@UiStrings.Six" Selected="Value == 6"/>
+        <FilterChip OnSelectedChange="@((selected) => OnNumberOfDaysSelect(7))" Label="@UiStrings.Seven" Selected="Value == 7"/>
     </ChipContainer>
 </LabelledFormRow>
 

--- a/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/WeightSelector.razor
+++ b/LiftLog.Ui/Shared/Presentation/AiWorkoutWalkthrough/WeightSelector.razor
@@ -1,6 +1,6 @@
 @inject IJSRuntime Js
 
-<LabelledFormRow Label="How much do you weigh?" Icon="monitor_weight">
+<LabelledFormRow Label="@UiStrings.HowMuchDoYouWeigh" Icon="monitor_weight">
     <TextField suffix-text="@WeightUnit" TextFieldType=TextFieldType.Outlined type="text" inputmode="decimal" Value="@(Value.ToString())"  required OnChange="@(value => OnChanged(value))"/>
 </LabelledFormRow>
 @code {

--- a/LiftLog.Ui/Shared/Presentation/ConfirmationDialog.razor
+++ b/LiftLog.Ui/Shared/Presentation/ConfirmationDialog.razor
@@ -5,8 +5,8 @@
         @TextContent
     </span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" OnClick="async () => { dialog?.Close(); await OnCancel.InvokeAsync(); }">@CancelText</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="async () => { dialog?.Close(); await OnOk.InvokeAsync(); }">@OkText</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="async () => { dialog?.Close(); await OnCancel.InvokeAsync(); }">@(CancelText ?? UiStrings.Cancel)</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="async () => { dialog?.Close(); await OnOk.InvokeAsync(); }">@(OkText ?? UiStrings.Ok)</AppButton>
     </div>
 </Dialog>
 
@@ -19,13 +19,13 @@
     public RenderFragment TextContent {get;set;} = null!;
 
     [Parameter]
-    public string CancelText {get;set;} = "Cancel";
+    public string? CancelText { get;set; }
 
     [Parameter]
     public EventCallback OnCancel { get; set; }
 
     [Parameter]
-    public string OkText { get; set; } = "Ok";
+    public string? OkText { get; set; }
 
     [Parameter]
     public EventCallback OnOk { get; set; }

--- a/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseEditor.razor
@@ -1,10 +1,11 @@
 @inject IJSRuntime JSRuntime
+
 <div class="flex flex-col gap-2">
 <TextField
     data-cy="exercise-name"
     TextFieldType="TextFieldType.Filled"
     class="w-full mb-2 text-xl text-start"
-    Label="Exercise"
+    Label="@UiStrings.Exercise"
     type="combobox"
     aria-controls="menu"
     aria-autocomplete="list"
@@ -26,7 +27,7 @@
             Value="Exercise.Sets"
             Increment="() => IncrementExerciseSets()"
             Decrement="() => DecrementExerciseSets()"
-            Label="Sets"/>
+            Label="@UiStrings.Sets"/>
     </Card>
     <Card HasPadding=false Type=Card.CardType.Filled class="flex-grow py-5 flex flex-1 justify-center">
         <FixedIncrementer
@@ -34,14 +35,14 @@
             Value="Exercise.RepsPerSet"
             Increment="() => IncrementExerciseRepsPerSet()"
             Decrement="() => DecrementExerciseRepsPerSet()"
-            Label="Reps"/>
+            Label="@UiStrings.Reps"/>
     </Card>
 </div>
 <TextField
     data-cy="exercise-notes"
     TextFieldType="TextFieldType.Filled"
     class="w-full mb-2 text-xl text-start resize-y"
-    Label="Plan Notes"
+    Label="@UiStrings.PlanNotes"
     type="textarea"
     SelectAllOnFocus="false"
     Value="@Exercise.Notes"
@@ -53,7 +54,7 @@
     data-cy="exercise-link"
     TextFieldType="TextFieldType.Filled"
     class="w-full mb-2 text-xl text-start resize-y"
-    Label="External Link"
+    Label="@UiStrings.ExternalLink"
     type="text"
     placeholder="https://"
     SelectAllOnFocus="false"
@@ -68,7 +69,7 @@
     <Card Type=Card.CardType.Elevated class="w-full flex flex-col gap-6 items-start">
         <EditableIncrementer
             Increment="0.1m"
-            Label="Progressive Overload"
+            Label="@UiStrings.ProgressiveOverload"
             data-cy="exercise-auto-increase"
             Suffix=@WeightSuffix
             Value="Exercise.WeightIncreaseOnSuccess"
@@ -76,7 +77,7 @@
         <md-divider></md-divider>
 
         <div class="w-full">
-            <Switch Label="Superset next exercise" data-cy="exercise-superset" Value="Exercise.SupersetWithNext" OnSwitched="supersets => SetExerciseSupersetsNext(supersets)"/>
+            <Switch Label="@UiStrings.SupersetNextExercise" data-cy="exercise-superset" Value="Exercise.SupersetWithNext" OnSwitched="supersets => SetExerciseSupersetsNext(supersets)"/>
         </div>
 
         <md-divider></md-divider>

--- a/LiftLog.Ui/Shared/Presentation/FeedItemCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/FeedItemCardContent.razor
@@ -6,7 +6,7 @@
         </TitleContent>
         <MainContent>
             <SessionSummary ShowSets=true Session="sessionFeedItem.Session"></SessionSummary>
-            <span class="text-start mt-2"><span class="text-primary font-bold">@(User.DisplayName)</span> completed a workout!</span>
+            <span class="text-start mt-2"><LimitedHtml Value="@UiStrings.FeedUserCompletedAWorkout(User.DisplayName)" /></span>
         </MainContent>
     </SplitCardControl>
 }

--- a/LiftLog.Ui/Shared/Presentation/FeedUserCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/FeedUserCardContent.razor
@@ -1,10 +1,10 @@
 <SplitCardControl>
     <TitleContent>
         <div class="flex justify-between items-center">
-            <ItemTitle Title="@(User.Name ?? "Anonymous User")" />
+            <ItemTitle Title="@(User.Name ?? UiStrings.AnonymousUser)" />
             @if (User.AesKey is null)
             {
-                <span class="text-xs text-tertiary">Awaiting Response</span>
+                <span class="text-xs text-tertiary">@UiStrings.AwaitingResponse</span>
             }
         </div>
     </TitleContent>
@@ -13,12 +13,12 @@
     </Actions>
     <MainContent>
         <div class="flex flex-col gap-4">
-            <TextField Value=@(User.Nickname ?? "") OnChange="val => UpdateUser(User with { Nickname = val })" label="Nickname"/>
+            <TextField Value=@(User.Nickname ?? "") OnChange="val => UpdateUser(User with { Nickname = val })" label="@UiStrings.Nickname"/>
 
             @if (User.CurrentPlan is not [])
             {
                 <AppButton Type="AppButtonType.Text" OnClick=ViewUserPlan>
-                    View their plan
+                    @UiStrings.ViewTheirPlan
                 </AppButton>
             }
         </div>

--- a/LiftLog.Ui/Shared/Presentation/FollowRequestCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/FollowRequestCardContent.razor
@@ -1,8 +1,8 @@
 <div class="flex flex-col gap-4">
-    <span><span class="text-primary font-bold">@(FollowRequest.Name ?? "Anonymous User")</span> wants to follow you!</span>
+    <LimitedHtml Value="@UiStrings.UserWantsToFollowYou(FollowRequest.Name ?? "Anonymous User")" />
     <div class="flex gap-4 justify-around">
-        <AppButton Type="AppButtonType.Text" OnClick="Deny">Deny</AppButton>
-        <AppButton Type="AppButtonType.Primary" OnClick="Accept">Accept</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="Deny">@UiStrings.Deny</AppButton>
+        <AppButton Type="AppButtonType.Primary" OnClick="Accept">@UiStrings.Accept</AppButton>
     </div>
 </div>
 

--- a/LiftLog.Ui/Shared/Presentation/FollowerCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/FollowerCardContent.razor
@@ -1,13 +1,13 @@
 <SplitCardControl>
     <TitleContent>
-        <div class="flex flex-col gap-4">
-            <span><span class="text-primary font-bold">@(User.Name ?? "Anonymous User")</span> is following you!</span>
+        <div class="flex flex-col">
+            <LimitedHtml Value="@UiStrings.UserIsFollowingYou(User.Name ?? "Anonymous User")" />
         </div>
     </TitleContent>
     <MainContent>
         @if (ShowFollowBack)
         {
-            <AppButton Type=AppButtonType.Text OnClick=@OnFollowBack>Follow @(User.Name ?? "Anonymous User") back</AppButton>
+            <AppButton Type=AppButtonType.Text OnClick=@OnFollowBack>@UiStrings.FollowUserBack(User.Name ?? "Anonymous User")</AppButton>
         }
     </MainContent>
     <Actions>

--- a/LiftLog.Ui/Shared/Presentation/FullScreenDialog.razor
+++ b/LiftLog.Ui/Shared/Presentation/FullScreenDialog.razor
@@ -14,7 +14,7 @@
                     <span class="mr-auto">@Title</span>
                     @if(Action != null)
                     {
-                        <AppButton Type="AppButtonType.Text" OnClick="()=>{OnAction.InvokeAsync();Close();}">@Action</AppButton>
+                        <AppButton data-cy="dialog-action" Type="AppButtonType.Text" OnClick="()=>{OnAction.InvokeAsync();Close();}">@Action</AppButton>
                     }
                 </div>
             </div>

--- a/LiftLog.Ui/Shared/Presentation/LimitedHtml.razor
+++ b/LiftLog.Ui/Shared/Presentation/LimitedHtml.razor
@@ -7,7 +7,7 @@
     }
     if (isHighlighted)
     {
-        <span class="@HighlightClass">@text</span>
+        <span class="@EmClass">@text</span>
     }
     else
     {
@@ -20,5 +20,5 @@
 {
     [Parameter] [EditorRequired] public string Value { get; set; } = null!;
 
-    [Parameter] public string HighlightClass { get; set; } = "font-bold text-primary";
+    [Parameter] public string EmClass { get; set; } = "font-bold text-primary";
 }

--- a/LiftLog.Ui/Shared/Presentation/LimitedHtml.razor
+++ b/LiftLog.Ui/Shared/Presentation/LimitedHtml.razor
@@ -1,0 +1,24 @@
+<span>
+@foreach(var (isHighlighted, text, insertBrBefore) in ParseLimitedHtml())
+{
+    if (insertBrBefore)
+    {
+        <br />
+    }
+    if (isHighlighted)
+    {
+        <span class="@HighlightClass">@text</span>
+    }
+    else
+    {
+        <span>@text</span>
+    }
+}
+</span>
+
+@code
+{
+    [Parameter] [EditorRequired] public string Value { get; set; } = null!;
+
+    [Parameter] public string HighlightClass { get; set; } = "font-bold text-primary";
+}

--- a/LiftLog.Ui/Shared/Presentation/LimitedHtml.razor.cs
+++ b/LiftLog.Ui/Shared/Presentation/LimitedHtml.razor.cs
@@ -1,0 +1,50 @@
+namespace LiftLog.Ui.Shared.Presentation;
+
+public partial class LimitedHtml
+{
+    private IEnumerable<(bool IsHighlighted, string Text, bool HasBreakBefore)> ParseLimitedHtml()
+    {
+        var currentIndex = 0;
+        var closed = true;
+        const string HIGHLIGHT_TAG = "<em>";
+        const string HIGHLIGHT_TAG_CLOSING = "</em>";
+
+        while (currentIndex < Value.Length)
+        {
+            var findTag = closed ? HIGHLIGHT_TAG : HIGHLIGHT_TAG_CLOSING;
+            var index = Value.IndexOf(findTag, currentIndex);
+
+            if (index == -1)
+            {
+                var remainingText = Value.Substring(currentIndex);
+                if (!closed)
+                {
+                    remainingText = HIGHLIGHT_TAG + remainingText;
+                }
+                // split on br and return each part
+                // if the index is odd, it means the previous part had a <br> tag so it should be inserted
+                var parts = remainingText.Split("<br>");
+                for (var i = 0; i < parts.Length; i++)
+                {
+                    yield return (!closed, parts[i], i % 2 == 1);
+                }
+                break;
+            }
+
+            closed = !closed;
+            var innerText = Value.Substring(currentIndex, index - currentIndex);
+            if (!string.IsNullOrEmpty(innerText))
+            {
+                // split on br and return each part
+                // if the index is odd, it means the previous part had a <br> tag so it should be inserted
+                var parts = innerText.Split("<br>");
+                for (var i = 0; i < parts.Length; i++)
+                {
+                    yield return (!closed, parts[i], i % 2 == 1);
+                }
+            }
+
+            currentIndex = index + findTag.Length;
+        }
+    }
+}

--- a/LiftLog.Ui/Shared/Presentation/Loader.razor
+++ b/LiftLog.Ui/Shared/Presentation/Loader.razor
@@ -3,11 +3,21 @@
         <md-circular-progress aria-label="Loading" indeterminate four-color></md-circular-progress>
     </div>
     <span>
-        <p>@LoadingText</p>
+        @if(ChildContent is not null)
+        {
+            @ChildContent
+        }
+        else
+        {
+            <p>@(LoadingText ?? UiStrings.GenericLoading)</p>
+        }
     </span>
 </div>
 
 @code {
     [Parameter]
-    public string LoadingText { get; set; } = "Loading...";
+    public string? LoadingText { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
 }

--- a/LiftLog.Ui/Shared/Presentation/ManageWorkoutCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/ManageWorkoutCardContent.razor
@@ -7,8 +7,8 @@
         <IconButton Type="IconButtonType.Standard" OnClick="@(() => OnMoveSessionDown())" Icon="arrow_downward"/>
         <IconButton Type="IconButtonType.Standard" OnClick="@(() => _menu?.Open())" Icon="more_horiz" id="@moreButtonId" />
         <Menu @ref="_menu" anchor="@moreButtonId" >
-            <MenuItem Icon="delete" Label="Remove" OnClick="() => OnRemoveSession()"/>
-            <MenuItem Icon="content_copy" Label="Duplicate" OnClick="() => OnDuplicateSession()"/>
+            <MenuItem Icon="delete" Label="@UiStrings.Remove" OnClick="() => OnRemoveSession()"/>
+            <MenuItem Icon="content_copy" Label="@UiStrings.Duplicate" OnClick="() => OnDuplicateSession()"/>
         </Menu>
     </Actions>
     <MainContent>

--- a/LiftLog.Ui/Shared/Presentation/PreviousExerciseViewer.razor
+++ b/LiftLog.Ui/Shared/Presentation/PreviousExerciseViewer.razor
@@ -15,7 +15,7 @@
 @if(!PreviousRecordedExercises.Any())
 {
     <EmptyInfo >
-    You have never done this exercise before
+    @UiStrings.NeverDoneThisExerciseBefore
     </EmptyInfo>
 }
 </div>

--- a/LiftLog.Ui/Shared/Presentation/ProgramListItem.razor
+++ b/LiftLog.Ui/Shared/Presentation/ProgramListItem.razor
@@ -8,9 +8,9 @@
         @RenderActiveBadge()
         <IconButton id="@_iconButtonId" Type="IconButtonType.Standard" Icon="more_horiz" OnClick=@(() => _menu?.Open())></IconButton>
         <Menu anchor="@_iconButtonId" @ref="_menu">
-            <MenuItem Icon="delete" disabled="@IsActive" Label="Remove" OnClick="() => OnRemove.InvokeAsync()"/>
-            <MenuItem Icon="content_copy" Label="Duplicate" OnClick="() => OnDuplicate.InvokeAsync()"/>
-            <MenuItem Icon="share" Label="Share" OnClick="() => OnShare.InvokeAsync()"/>
+            <MenuItem Icon="delete" disabled="@IsActive" Label="@UiStrings.Remove" OnClick="() => OnRemove.InvokeAsync()"/>
+            <MenuItem Icon="content_copy" Label="@UiStrings.Duplicate" OnClick="() => OnDuplicate.InvokeAsync()"/>
+            <MenuItem Icon="share" Label="@UiStrings.Share" OnClick="() => OnShare.InvokeAsync()"/>
         </Menu>
     </div>
 </md-list-item>
@@ -44,7 +44,7 @@
 
     [Parameter] public EventCallback OnShare { get; set; }
 
-    private string SupportingText => $"Edited: {ProgramBlueprint.LastEdited.ToShortDateString()}";
+    private string SupportingText => UiStrings.EditedOn(ProgramBlueprint.LastEdited.ToShortDateString());
 
     private string FocusClass => IsFocused ? "bg-secondary-container text-on-secondary-container " : "";
 
@@ -62,10 +62,10 @@
     {
         if (IsActive)
         {
-            return @<div class="flex flex-col justify-center"><span class="rounded-full relative bg-secondary-container text-on-secondary-container px-3 py-2 text-md" @onclick:stopPropagation="true" @onclick:preventDefault="true" >Active<md-ripple></md-ripple></span></div>;
+            return @<div class="flex flex-col justify-center"><span class="rounded-full relative bg-secondary-container text-on-secondary-container px-3 py-2 text-md" @onclick:stopPropagation="true" @onclick:preventDefault="true" >@UiStrings.Active<md-ripple></md-ripple></span></div>;
         }
 
-        return @<AppButton Type="AppButtonType.Text" OnClick="()=>OnUse.InvokeAsync()">Use</AppButton>;
+        return @<AppButton Type="AppButtonType.Text" OnClick="()=>OnUse.InvokeAsync()">@UiStrings.UseWorkout</AppButton>;
     }
 
 }

--- a/LiftLog.Ui/Shared/Presentation/RestEditorGroup.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestEditorGroup.razor
@@ -2,18 +2,18 @@
     <span class="text-lg">Rest</span>
     <div class="w-full flex justify-center">
         <md-outlined-segmented-button-set>
-            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Short)"  selected="@(!_isCustom && Rest == Rest.Short)" label="Short"></md-outlined-segmented-button>
-            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Medium)" selected="@(!_isCustom && Rest == Rest.Medium)" label="Medium"></md-outlined-segmented-button>
-            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Long)"   selected="@(!_isCustom && Rest == Rest.Long)" label="Long"></md-outlined-segmented-button>
-            <md-outlined-segmented-button @onsegmented-button-interaction="HandleCustomSelectedChanged"        selected="@(_isCustom)" label="Custom"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Short)"  selected="@(!_isCustom && Rest == Rest.Short)" label="@UiStrings.RestShort"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Medium)" selected="@(!_isCustom && Rest == Rest.Medium)" label="@UiStrings.RestMedium"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleSelectedChanged(Rest.Long)"   selected="@(!_isCustom && Rest == Rest.Long)" label="@UiStrings.RestLong"></md-outlined-segmented-button>
+            <md-outlined-segmented-button @onsegmented-button-interaction="HandleCustomSelectedChanged"        selected="@(_isCustom)" label="@UiStrings.Custom"></md-outlined-segmented-button>
         </md-outlined-segmented-button-set>
     </div>
     @if (_isCustom)
     {
         <div class="flex flex-col w-full items-center justify-between gap-2">
-            <RestEditor Label="Min Rest" Rest="Rest.MinRest" OnRestUpdated="rest => OnRestUpdated(Rest with { MinRest = rest })"></RestEditor>
-            <RestEditor Label="Max Rest" Rest="Rest.MaxRest" OnRestUpdated="rest => OnRestUpdated(Rest with { MaxRest = rest })"></RestEditor>
-            <RestEditor Label="Failure Rest" Rest="Rest.FailureRest" OnRestUpdated="rest => OnRestUpdated(Rest with { FailureRest = rest })"></RestEditor>
+            <RestEditor Label="@UiStrings.MinRest" Rest="Rest.MinRest" OnRestUpdated="rest => OnRestUpdated(Rest with { MinRest = rest })"></RestEditor>
+            <RestEditor Label="@UiStrings.MaxRest" Rest="Rest.MaxRest" OnRestUpdated="rest => OnRestUpdated(Rest with { MaxRest = rest })"></RestEditor>
+            <RestEditor Label="@UiStrings.FailureRest" Rest="Rest.FailureRest" OnRestUpdated="rest => OnRestUpdated(Rest with { FailureRest = rest })"></RestEditor>
         </div>
     }
     else

--- a/LiftLog.Ui/Shared/Presentation/RestFormat.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestFormat.razor
@@ -3,19 +3,19 @@
 {
     <LimitedHtml
         Value="@UiStrings.RestSingular(Rest.MinRest.ToString(TimespanFormatStr))"
-        HighlightClass="@HighlightClass" />
+        EmClass="@EmClass" />
 }
 else
 {
     <LimitedHtml
         Value="@UiStrings.RestBetween(Rest.MinRest.ToString(TimespanFormatStr), Rest.MaxRest.ToString(TimespanFormatStr))"
-        HighlightClass="@HighlightClass" />
+        EmClass="@EmClass" />
 }
 @code {
 
     private const string TimespanFormatStr = @"m\:ss";
 
-    private string HighlightClass => "font-bold " + (Highlight ? "text-primary" : "");
+    private string EmClass => "font-bold " + (Highlight ? "text-primary" : "");
 
     [Parameter]
     [EditorRequired]

--- a/LiftLog.Ui/Shared/Presentation/RestFormat.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestFormat.razor
@@ -1,15 +1,21 @@
 
 @if (Rest.MinRest >= Rest.MaxRest)
 {
-    <span>Rest <span class="font-bold @(Highlight ? "text-primary" :"")">@(Rest.MinRest.ToString(TimespanFormatStr))</span></span>
+    <LimitedHtml
+        Value="@UiStrings.RestSingular(Rest.MinRest.ToString(TimespanFormatStr))"
+        HighlightClass="@HighlightClass" />
 }
 else
 {
-    <span>Rest between <span class="font-bold @(Highlight ? "text-primary" :"")">@(Rest.MinRest.ToString(TimespanFormatStr))</span> and <span class="font-bold @(Highlight ? "text-primary" :"")">@(Rest.MaxRest.ToString(TimespanFormatStr))</span></span>
+    <LimitedHtml
+        Value="@UiStrings.RestBetween(Rest.MinRest.ToString(TimespanFormatStr), Rest.MaxRest.ToString(TimespanFormatStr))"
+        HighlightClass="@HighlightClass" />
 }
 @code {
 
     private const string TimespanFormatStr = @"m\:ss";
+
+    private string HighlightClass => "font-bold " + (Highlight ? "text-primary" : "");
 
     [Parameter]
     [EditorRequired]

--- a/LiftLog.Ui/Shared/Presentation/RestTimer.razor
+++ b/LiftLog.Ui/Shared/Presentation/RestTimer.razor
@@ -2,7 +2,9 @@
     <div class="flex items-center justify-between">
         @if (Failed)
         {
-            <span>Rest <span class="font-bold">@(Rest.FailureRest.ToString(TimespanFormatStr))</span></span>
+            <LimitedHtml
+                Value="@UiStrings.RestSingular(Rest.FailureRest.ToString(TimespanFormatStr))"
+                EmClass="font-bold" />
         }
         else {
             <RestFormat Highlight=false Rest="@Rest" />

--- a/LiftLog.Ui/Shared/Presentation/SearchInput.razor
+++ b/LiftLog.Ui/Shared/Presentation/SearchInput.razor
@@ -8,7 +8,7 @@
             bg-surface-container-high px-12 py-4
             placeholder-on-surface-variant
             focus:outline-none focus:border-none"
-        placeholder="Search"
+        placeholder="@UiStrings.Search"
         @bind="SearchTerm"
         @oninput="e=>OnSearch.InvokeAsync(e.Value as string)" >
     </input>

--- a/LiftLog.Ui/Shared/Presentation/SessionSummaryTitle.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionSummaryTitle.razor
@@ -16,6 +16,6 @@
     [Parameter] public bool IsFilled { get; set; }
 
     private string FormattedDate => Session.Date.Year == DateTime.Now.Year
-        ? Session.Date.ToString("dddd d MMMM", CultureInfo.InvariantCulture)
-        : Session.Date.ToString("dddd d MMMM", CultureInfo.InvariantCulture) + " " + Session.Date.Year;
+        ? Session.Date.ToString("dddd d MMMM")
+        : Session.Date.ToString("dddd d MMMM") + " " + Session.Date.Year;
 }

--- a/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/StatGraphCardContent.razor
@@ -11,19 +11,11 @@
 <div class="flex flex-col gap-2 items-start" @ref="cardContent" >
 @if (ShowTitle)
 {
-
     <ItemTitle Title="@(Title)" />
 }
 @if (IsLoading)
 {
-    <div class="flex flex-col justify-center h-full gap-4 text-on-surface mx-auto">
-        <div>
-            <md-circular-progress aria-label="Stats progress" indeterminate four-color></md-circular-progress>
-        </div>
-        <span>
-            <p>Loading...</p>
-        </span>
-    </div>
+    <Loader />
 }
 else
 {

--- a/LiftLog.Ui/Shared/Presentation/ThemeChooser.razor
+++ b/LiftLog.Ui/Shared/Presentation/ThemeChooser.razor
@@ -1,10 +1,10 @@
 @inject IJSRuntime JSRuntime
 
     <md-list-item class="text-left" multi-line-supporting-text>
-        <span slot="headline" >Theme</span>
+        <span slot="headline" >@UiStrings.Theme</span>
     </md-list-item>
     <div class="flex items-center gap-4 w-full  overflow-x-auto p-2">
-        <AppButton OnClick="() => HandleColorChange(null)" Type="AppButtonType.Text"><md-focus-ring @ref="_focusRing" visible="@(Seed == null)"></md-focus-ring>Default</AppButton>
+        <AppButton OnClick="() => HandleColorChange(null)" Type="AppButtonType.Text"><md-focus-ring @ref="_focusRing" visible="@(Seed == null)"></md-focus-ring>@UiStrings.Default</AppButton>
         <div class="gap-2 flex">
             @ColorBall(FromHex("AA0000"))
             @ColorBall(FromHex("00AA00"))

--- a/LiftLog.Ui/Shared/Presentation/WeightDialog.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightDialog.razor
@@ -1,10 +1,10 @@
 <Dialog
     @ref="dialog"
     style="--md-dialog-container-max-block-size: 500px;">
-    <span slot="headline">@Label</span>
+    <span slot="headline">@(Label ?? UiStrings.Weight)</span>
     <div slot="content">
         <div class="flex flex-col gap-2">
-            <TextField data-cy="weight-input" label="@Label" required="@(!AllowNull)" suffix-text="@WeightSuffix" TextFieldType="TextFieldType.Outlined" Value="@(EditorWeight.ToString())" OnChange="HandleInputChange" type="text" inputmode="decimal" step="@NonZeroIncrement"/>
+            <TextField data-cy="weight-input" label="@(Label ?? UiStrings.Weight)" required="@(!AllowNull)" suffix-text="@WeightSuffix" TextFieldType="TextFieldType.Outlined" Value="@(EditorWeight.ToString())" OnChange="HandleInputChange" type="text" inputmode="decimal" step="@NonZeroIncrement"/>
             <div class="flex justify-between">
                 <AppButton data-cy="decrement-weight" Type="AppButtonType.OutlineSecondary" OnClick="OnWeightDecrementClick">
                     <md-icon slot="icon">remove</md-icon><WeightFormat Weight="NonZeroIncrement"/>
@@ -16,8 +16,8 @@
         </div>
     </div>
     <div slot="actions" class="flex gap-1">
-        <AppButton dialog-action="close" OnClick="OnCloseClick" Type="AppButtonType.Text">Close</AppButton>
-        <AppButton dialog-action="save" dialog-focus OnClick="OnSaveClick" Type="AppButtonType.Text">Save</AppButton>
+        <AppButton dialog-action="close" OnClick="OnCloseClick" Type="AppButtonType.Text">@UiStrings.Close</AppButton>
+        <AppButton dialog-action="save" dialog-focus OnClick="OnSaveClick" Type="AppButtonType.Text">@UiStrings.Save</AppButton>
     </div>
 </Dialog>
 
@@ -28,7 +28,7 @@
 
     [EditorRequired] [Parameter] public decimal? Weight { get; set; } = null!;
 
-    [Parameter] public string Label { get; set; } = "Weight";
+    [Parameter] public string? Label { get; set; }
 
     [EditorRequired] [Parameter] public decimal Increment { get; set; } = 2.5m;
 

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -1,7 +1,4 @@
-﻿
-@inject IStringLocalizer<UiStrings> UiStrings
-
-@{
+﻿@{
     var displayedExercise = RecordedExercise;
     var setToStartNext = RecordedExercise.PotentialSets.IndexOf(x => x.Set is null);
     var previousNotes = PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise?.Notes ?? "";

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -1,4 +1,7 @@
-﻿@{
+﻿
+@inject IStringLocalizer<UiStrings> UiStrings
+
+@{
     var displayedExercise = RecordedExercise;
     var setToStartNext = RecordedExercise.PotentialSets.IndexOf(x => x.Set is null);
     var previousNotes = PreviousRecordedExercises?.FirstOrDefault()?.RecordedExercise?.Notes ?? "";
@@ -20,9 +23,9 @@
                     <div>
                         <IconButton data-cy="more-exercise-btn" class="self-end" Type="IconButtonType.Standard" OnClick="() => { _menu?.Open(); }" Icon="more_horiz" id="@moreButtonId"/>
                         <Menu @ref="_menu" anchor="@moreButtonId">
-                            <MenuItem Label="Edit" Icon="edit" data-cy="exercise-edit-menu-button" OnClick="OnEditExercise"/>
-                            <MenuItem data-cy="exercise-notes-btn" Label="Notes" Icon="notes" OnClick="OnOpenNotesButtonClick"/>
-                            <MenuItem Label="Remove" Icon="delete" OnClick="OnRemoveExercise"/>
+                            <MenuItem Label="@(UiStrings.Edit())" Icon="edit" data-cy="exercise-edit-menu-button" OnClick="OnEditExercise"/>
+                            <MenuItem data-cy="exercise-notes-btn" Label="@(UiStrings.Notes())" Icon="notes" OnClick="OnOpenNotesButtonClick"/>
+                            <MenuItem Label="@(UiStrings.Remove())" Icon="delete" OnClick="OnRemoveExercise"/>
                             @if(Uri.IsWellFormedUriString(displayedExercise.Blueprint.Link, UriKind.Absolute))
                             {
                                 <MenuItem Label="Open Link" Icon="open_in_new" OnClick="OnOpenLink"/>

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -20,12 +20,12 @@
                     <div>
                         <IconButton data-cy="more-exercise-btn" class="self-end" Type="IconButtonType.Standard" OnClick="() => { _menu?.Open(); }" Icon="more_horiz" id="@moreButtonId"/>
                         <Menu @ref="_menu" anchor="@moreButtonId">
-                            <MenuItem Label="@(UiStrings.Edit())" Icon="edit" data-cy="exercise-edit-menu-button" OnClick="OnEditExercise"/>
-                            <MenuItem data-cy="exercise-notes-btn" Label="@(UiStrings.Notes())" Icon="notes" OnClick="OnOpenNotesButtonClick"/>
-                            <MenuItem Label="@(UiStrings.Remove())" Icon="delete" OnClick="OnRemoveExercise"/>
+                            <MenuItem Label="@UiStrings.Edit" Icon="edit" data-cy="exercise-edit-menu-button" OnClick="OnEditExercise"/>
+                            <MenuItem data-cy="exercise-notes-btn" Label="@(UiStrings.Notes)" Icon="notes" OnClick="OnOpenNotesButtonClick"/>
+                            <MenuItem Label="@UiStrings.Remove" Icon="delete" OnClick="OnRemoveExercise"/>
                             @if(Uri.IsWellFormedUriString(displayedExercise.Blueprint.Link, UriKind.Absolute))
                             {
-                                <MenuItem Label="Open Link" Icon="open_in_new" OnClick="OnOpenLink"/>
+                                <MenuItem Label="@UiStrings.OpenLink" Icon="open_in_new" OnClick="OnOpenLink"/>
                             }
                         </Menu>
                     </div>

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="flex justify-start flex-wrap gap-2">
-        @foreach (var (set, i) in displayedExercise.PotentialSets.IndexedTuples())
+        @foreach (var (i, set) in displayedExercise.PotentialSets.Index())
         {
             <PotentialSetCounter
                 @key=i

--- a/LiftLog.Ui/Shared/Smart/AndroidNotificationAlert.razor
+++ b/LiftLog.Ui/Shared/Smart/AndroidNotificationAlert.razor
@@ -13,10 +13,8 @@
     CancelText="Disable Notifications"
     OnCancel="DisableNotifications"
     SectionName="AndroidNotificationDialog">
-    <Headline>Enable Notifications?</Headline>
-    <TextContent>Newer Android devices require an additional permission to ensure that rest notifications are delivered on time.
-        Without this permission, they will arrive late and largely be useless.
-        On the next screen, please grant LiftLog the permission.</TextContent>
+    <Headline>@UiStrings.EnableNotificationsQuestion</Headline>
+    <TextContent>@UiStrings.AndroidNotificationPermissionExplanation</TextContent>
 </ConfirmationDialog>
 
 @code

--- a/LiftLog.Ui/Shared/Smart/AppReviewRequest.razor
+++ b/LiftLog.Ui/Shared/Smart/AppReviewRequest.razor
@@ -5,18 +5,18 @@
 @inject IDispatcher Dispatcher
 
 <Dialog @ref="rateDialog">
-    <span slot="headline">Enjoying LiftLog?</span>
-    <span slot="content" class="block text-left">If so, would you take a minute to leave a @ReviewType on @AppStore?</span>
+    <span slot="headline">@UiStrings.EnjoyingLiftLogQuestion</span>
+    <span slot="content" class="block text-left">@UiStrings.EnjoyingLiftLogMessage(ReviewType, AppStore)</span>
     <div slot="actions" class="flex">
-        <AppButton Type="AppButtonType.Text" class="mr-auto" OnClick="Never">Never</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="NotNow">Not Now</AppButton>
+        <AppButton Type="AppButtonType.Text" class="mr-auto" OnClick="Never">@UiStrings.Never</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="NotNow">@UiStrings.NotNow</AppButton>
         @if(DeviceService.GetDeviceType() == DeviceType.Web)
         {
-            <AppButton Type="AppButtonType.Text" OnClick="Rate" target="_blank" href="https://github.com/LiamMorrow/LiftLog">Rate</AppButton>
+            <AppButton Type="AppButtonType.Text" OnClick="Rate" target="_blank" href="https://github.com/LiamMorrow/LiftLog">@UiStrings.Rate</AppButton>
         }
         else
         {
-            <AppButton Type="AppButtonType.Text" OnClick="Rate">Rate</AppButton>
+            <AppButton Type="AppButtonType.Text" OnClick="Rate">@UiStrings.Rate</AppButton>
         }
     </div>
 </Dialog>
@@ -34,8 +34,8 @@
 
     private string ReviewType => DeviceService.GetDeviceType() switch
     {
-        DeviceType.Web => "star",
-        _ => "review"
+        DeviceType.Web => UiStrings.GithubStar,
+        _ => UiStrings.Review
     };
 
     private void Never()

--- a/LiftLog.Ui/Shared/Smart/BackupAlert.razor
+++ b/LiftLog.Ui/Shared/Smart/BackupAlert.razor
@@ -4,15 +4,14 @@
 @inject IDispatcher Dispatcher
 
 <Dialog @ref="dialog" @ondialog-cancel="No" type="alert">
-    <span slot="headline">Back up data</span>
+    <span slot="headline">@UiStrings.BackUpData</span>
     <span slot="content" class="block text-left">
-        It has been a while since you last created a backup. It is HIGHLY recommended you back up your data regularly to prevent data loss.
-        Would you like to back up your data now?
+        @UiStrings.BackUpDataReminder
     </span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" OnClick="DontAsk">Don't ask again</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="No">No</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="BackUp">Yes</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="DontAsk">@UiStrings.DontAskAgain</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="No">@UiStrings.No</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="BackUp">@UiStrings.Yes</AppButton>
     </div>
 </Dialog>
 

--- a/LiftLog.Ui/Shared/Smart/FeedIdentityManager.razor
+++ b/LiftLog.Ui/Shared/Smart/FeedIdentityManager.razor
@@ -11,27 +11,27 @@
     <Remote Value="FeedIdentity" Retry="CreateFeedIdentity">
         <div class="text-on-surface flex flex-col gap-4">
             <LabelledForm>
-                <LabelledFormRow Label="Your Name" Icon="person">
-                <TextField Value="@context.Name" label="Optional" OnChange=@SetName/>
+                <LabelledFormRow Label="@UiStrings.YourName" Icon="person">
+                <TextField Value="@context.Name" label="@UiStrings.Optional" OnChange=@SetName/>
                 </LabelledFormRow>
                 <FeedShareUrl/>
                 </LabelledForm>
             <md-list>
-                <ListSwitch Headline="Publish workouts" SupportingText="Publish workouts as you complete them" Value=@context.PublishWorkouts OnSwitched="SetPublishWorkouts"/>
-                <ListSwitch Headline="Publish bodyweight" SupportingText="Publish your bodyweight with your workouts"  Value=@context.PublishBodyweight OnSwitched="SetPublishBodyweight"/>
-                <ListSwitch Headline="Publish plan" SupportingText="Publish your current plan for your followers to see and import" Value=@context.PublishPlan OnSwitched="SetPublishPlan"/>
+                <ListSwitch Headline="@UiStrings.PublishWorkout" SupportingText="@UiStrings.PublishWorkoutSubtitle" Value=@context.PublishWorkouts OnSwitched="SetPublishWorkouts"/>
+                <ListSwitch Headline="@UiStrings.PublishBodyweight" SupportingText="@UiStrings.PublishBodyweightSubtitle"  Value=@context.PublishBodyweight OnSwitched="SetPublishBodyweight"/>
+                <ListSwitch Headline="@UiStrings.PublishPlan" SupportingText="@UiStrings.PublishPlanSubtitle" Value=@context.PublishPlan OnSwitched="SetPublishPlan"/>
             </md-list>
-            <AppButton Type=AppButtonType.Text OnClick="@(() => stopPublishingDialog?.Open())">Reset account</AppButton>
+            <AppButton Type=AppButtonType.Text OnClick="@(() => stopPublishingDialog?.Open())">@UiStrings.ResetAccount</AppButton>
         </div>
     </Remote>
 </div>
 
 <Dialog @ref="stopPublishingDialog">
-    <span slot="headline">Reset account</span>
-    <span slot="content" class="block text-left">This will delete your data on the servers and unsubscribe you from all feeds. You will need to resubscribe and share a new link if you want to share your workouts again.</span>
+    <span slot="headline">@UiStrings.ResetAccount</span>
+    <span slot="content" class="block text-left">@UiStrings.ResetAccountMessage</span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" OnClick="@(() => stopPublishingDialog?.Close())">Cancel</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="StopPublishing">Delete</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="@(() => stopPublishingDialog?.Close())">@UiStrings.Cancel</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="StopPublishing">@UiStrings.ResetAccount</AppButton>
     </div>
 </Dialog>
 

--- a/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
+++ b/LiftLog.Ui/Shared/Smart/FeedShareUrl.razor
@@ -3,8 +3,8 @@
 
 @if (FeedState.Value.Identity is not null)
 {
-    <TextField Value="@GetShareUrl()" label="Share Link" readonly="readonly" OnClick="HandleShareUrlClick"/>
-    <span class="text-sm text-on-surface mt-1">Only those with the link can see what you've shared.</span>
+    <TextField Value="@GetShareUrl()" label="@UiStrings.ShareLink" readonly="readonly" OnClick="HandleShareUrlClick"/>
+    <span class="text-sm text-on-surface mt-1">@UiStrings.OnlyThoseWithTheLinkCanSee</span>
 }
 
 @code {

--- a/LiftLog.Ui/Shared/Smart/NavBar.razor
+++ b/LiftLog.Ui/Shared/Smart/NavBar.razor
@@ -7,19 +7,21 @@
 @inject IState<SettingsState> SettingsState
 @inject IDispatcher Dispatcher
 @inject InsetsManager InsetsManager
+@inject IStringLocalizer<UiStrings> UiStrings
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
+
 <nav class="flex flex-col bg-surface-container text-on-surface">
     <div class="flex justify-around py-3">
-        <NavButton IsActive=@IsRouteMatch("(/$|^$|/session/?)") Navigate="NavigateToWorkout" Icon="fitness_center" Text="Workout"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("(/$|^$|/session/?)") Navigate="NavigateToWorkout" Icon="fitness_center" Text="@(UiStrings.Workout())"></NavButton>
         @if (SettingsState.Value.ShowFeed)
         {
-            <NavButton IsActive=@IsRouteMatch("/feed(/?.*)") Navigate="NavigateToFeed" Icon="forum" Text="Feed" ShowBadge=@(FeedState.Value.FollowRequests.Any())></NavButton>
+            <NavButton IsActive=@IsRouteMatch("/feed(/?.*)") Navigate="NavigateToFeed" Icon="forum" Text="@(UiStrings.Feed())" ShowBadge=@(FeedState.Value.FollowRequests.Any())></NavButton>
         }
-        <NavButton IsActive=@IsRouteMatch("/stats(/?.*)") Navigate="NavigateToStats" Icon="analytics" Text="Stats"></NavButton>
-        <NavButton IsActive=@IsRouteMatch("/history(/?.*)") Navigate="NavigateToHistory" Icon="history" Text="History"></NavButton>
-        <NavButton IsActive=@IsRouteMatch("/settings(/?.*)") Navigate="NavigateToSettings" Icon="settings" Text="Settings"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("/stats(/?.*)") Navigate="NavigateToStats" Icon="analytics" Text="@(UiStrings.Stats())"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("/history(/?.*)") Navigate="NavigateToHistory" Icon="history" Text="@(UiStrings.History())"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("/settings(/?.*)") Navigate="NavigateToSettings" Icon="settings" Text="@(UiStrings.Settings())"></NavButton>
     </div>
     <div style="height: @BottomInset"></div>
 </nav>

--- a/LiftLog.Ui/Shared/Smart/NavBar.razor
+++ b/LiftLog.Ui/Shared/Smart/NavBar.razor
@@ -7,7 +7,6 @@
 @inject IState<SettingsState> SettingsState
 @inject IDispatcher Dispatcher
 @inject InsetsManager InsetsManager
-@inject IStringLocalizer<UiStrings> UiStrings
 
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 

--- a/LiftLog.Ui/Shared/Smart/NavBar.razor
+++ b/LiftLog.Ui/Shared/Smart/NavBar.razor
@@ -13,14 +13,14 @@
 
 <nav class="flex flex-col bg-surface-container text-on-surface">
     <div class="flex justify-around py-3">
-        <NavButton IsActive=@IsRouteMatch("(/$|^$|/session/?)") Navigate="NavigateToWorkout" Icon="fitness_center" Text="@(UiStrings.Workout())"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("(/$|^$|/session/?)") Navigate="NavigateToWorkout" Icon="fitness_center" Text="@UiStrings.Workout"></NavButton>
         @if (SettingsState.Value.ShowFeed)
         {
-            <NavButton IsActive=@IsRouteMatch("/feed(/?.*)") Navigate="NavigateToFeed" Icon="forum" Text="@(UiStrings.Feed())" ShowBadge=@(FeedState.Value.FollowRequests.Any())></NavButton>
+            <NavButton IsActive=@IsRouteMatch("/feed(/?.*)") Navigate="NavigateToFeed" Icon="forum" Text="@UiStrings.Feed" ShowBadge=@(FeedState.Value.FollowRequests.Any())></NavButton>
         }
-        <NavButton IsActive=@IsRouteMatch("/stats(/?.*)") Navigate="NavigateToStats" Icon="analytics" Text="@(UiStrings.Stats())"></NavButton>
-        <NavButton IsActive=@IsRouteMatch("/history(/?.*)") Navigate="NavigateToHistory" Icon="history" Text="@(UiStrings.History())"></NavButton>
-        <NavButton IsActive=@IsRouteMatch("/settings(/?.*)") Navigate="NavigateToSettings" Icon="settings" Text="@(UiStrings.Settings())"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("/stats(/?.*)") Navigate="NavigateToStats" Icon="analytics" Text="@UiStrings.Stats"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("/history(/?.*)") Navigate="NavigateToHistory" Icon="history" Text="@UiStrings.History"></NavButton>
+        <NavButton IsActive=@IsRouteMatch("/settings(/?.*)") Navigate="NavigateToSettings" Icon="settings" Text="@UiStrings.Settings"></NavButton>
     </div>
     <div style="height: @BottomInset"></div>
 </nav>

--- a/LiftLog.Ui/Shared/Smart/ProFeatures.razor
+++ b/LiftLog.Ui/Shared/Smart/ProFeatures.razor
@@ -12,30 +12,30 @@
 
 <md-list>
     <div class="flex justify-between items-center">
-        <ListTitle Title="Pro Features" />
+        <ListTitle Title="@UiStrings.ProFeatures" />
         @RenderLockedPro()
     </div>
     <md-list-item type="button" class="text-left" multi-line-supporting-text disabled=@(!AppState.Value.ProState.IsPro) @onclick="NavigateToAiPlanner">
         <md-icon slot="start">bolt</md-icon>
-        <span slot="headline">AI Program Planner</span>
-        <span slot="supporting-text">Use AI to generate an entire program suited to your goals</span>
+        <span slot="headline">@UiStrings.AiPlanner</span>
+        <span slot="supporting-text">@UiStrings.AiPlannerSubtitle</span>
     </md-list-item>
     <md-list-item type="button" class="text-left" multi-line-supporting-text disabled=@(!AppState.Value.ProState.IsPro) @onclick="NavigateToAiSessionCreator">
         <md-icon slot="start">auto_awesome</md-icon>
-        <span slot="headline">AI Session Creator</span>
-        <span slot="supporting-text">Generate a workout session to import into your plan or complete now!</span>
+        <span slot="headline">@UiStrings.AiSessionCreator</span>
+        <span slot="supporting-text">@UiStrings.AiSessionCreatorSubtitle</span>
     </md-list-item>
 </md-list>
 
 <Dialog @ref="upgradeDialog">
-    <span slot="headline">Upgrade to Pro</span>
+    <span slot="headline">@UiStrings.UpgradeToPro</span>
     <span slot="content" class="block text-left">
-        This will unlock the AI planner, which will generate a plan tailored
-        specifically to you and your goals. <br/>This is a one time purchase of @RenderPrice().
+        <LimitedHtml Value="@UiStrings.UpgradeToProDescription" />
+        @RenderPrice()
     </span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" OnClick="() => upgradeDialog?.Close()">Close</AppButton>
-        <AppButton Type="AppButtonType.Text" OnClick="UpgradeToPro">Upgrade</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="() => upgradeDialog?.Close()">@UiStrings.Close</AppButton>
+        <AppButton Type="AppButtonType.Text" OnClick="UpgradeToPro">@UiStrings.Upgrade</AppButton>
     </div>
 
 </Dialog>
@@ -57,7 +57,7 @@
             return null;
         }
 
-        return @<AppButton class="mr-2" OnClick="() => { upgradeDialog?.Open(); }"><md-icon slot="icon">lock</md-icon>Unlock</AppButton>;
+        return @<AppButton class="mr-2" OnClick="() => { upgradeDialog?.Open(); }"><md-icon slot="icon">lock</md-icon>@UiStrings.Unlock</AppButton>;
     }
 
     private RenderFragment RenderPrice()

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -4,6 +4,8 @@
 @inject IState<CurrentSessionState> CurrentSessionState
 @inject IDispatcher Dispatcher
 
+@inject IStringLocalizer<UiStrings> UiStrings
+
 @if(Session.Blueprint.Notes != "")
 {
     <Card class="my-2 mx-7 gap-4 text-start flex items-center" Type=Card.CardType.Filled>
@@ -121,7 +123,7 @@ else
     </span>
     <div slot="actions">
         <AppButton Type="AppButtonType.Text" slot="footer" OnClick="() => { _removeExerciseDialog?.Close(); }">Cancel</AppButton>
-        <AppButton Type="AppButtonType.Text" slot="footer" OnClick="RemoveExerciseHandler">Remove</AppButton>
+        <AppButton Type="AppButtonType.Text" slot="footer" OnClick="RemoveExerciseHandler">@(UiStrings.Remove())</AppButton>
     </div>
 </Dialog>
 

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -15,12 +15,12 @@
 @if (!Session.RecordedExercises.Any())
 {
     <EmptyInfo class="my-8">
-        <p>Session contains no exercises.</p>
+        <p>@UiStrings.SessionContainsNoExercises</p>
     </EmptyInfo>
 }
 else
 {
-    <ItemList Items="Session.RecordedExercises.IndexedTuples()">
+    <ItemList Items="Session.RecordedExercises.Index()">
         <WeightedExercise
             @key=context.Index
             RecordedExercise="context.Item"
@@ -42,8 +42,8 @@ else
 @if (ShowBodyweight)
 {
     <Card class="flex justify-between items-center mx-2" Type=Card.CardType.Filled >
-        <span class="text-xl font-bold">Bodyweight</span>
-        <WeightDisplay AllowNull=true Weight=Session.Bodyweight UpdateWeight="UpdateBodyweight" Increment="0.1m" Label="Bodyweight"/>
+        <span class="text-xl font-bold">@UiStrings.Bodyweight</span>
+        <WeightDisplay AllowNull=true Weight=Session.Bodyweight UpdateWeight="UpdateBodyweight" Increment="0.1m" Label="@UiStrings.Bodyweight"/>
     </Card>
 }
 
@@ -56,7 +56,7 @@ else
                 <md-icon
                     slot="icon">
                     assignment_add
-                </md-icon>Update Plan
+                </md-icon>@UiStrings.UpdatePlan
             </AppButton>
         }
     </div>
@@ -65,7 +65,7 @@ else
 {
     <FloatingBottomContainer>
         <Fab>
-            <FloatingButton size="small" variant="surface" aria-label="Add Exercise" label="Add Exercise" OnClick="BeginAddExercise"><md-icon slot="icon">add</md-icon></FloatingButton>
+            <FloatingButton size="small" variant="surface" aria-label="Add Exercise" label="@UiStrings.AddExercise" OnClick="BeginAddExercise"><md-icon slot="icon">add</md-icon></FloatingButton>
         </Fab>
         <AdditionalContent>@RenderSnackBar()</AdditionalContent>
     </FloatingBottomContainer>
@@ -81,12 +81,18 @@ else
 {
     <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
         <AppButton class="text-lg" Type=AppButtonType.Text OnClick=SaveSession data-cy="save-session-button">
-            @(SessionTarget == SessionTarget.WorkoutSession ? "Finish" : "Save")
+            @(SessionTarget == SessionTarget.WorkoutSession ? UiStrings.Finish : UiStrings.Save)
         </AppButton>
     </Microsoft.AspNetCore.Components.Sections.SectionContent>
 }
 
-<FullScreenDialog @ref=_editExerciseDialog Title=@(_exerciseToEditIndex is null ? "Add Exercise" : "Edit Exercise") Action="Update" OnAction="EditExerciseHandler" OnClose="@(() => _exerciseToEditIndex = null)">
+<FullScreenDialog
+    @ref=_editExerciseDialog
+    Title=@(_exerciseToEditIndex is null ? UiStrings.AddExercise : UiStrings.EditExercise)
+    Action="@(_exerciseToEditIndex is null ? UiStrings.Add : UiStrings.Update)"
+    OnAction="EditExerciseHandler"
+    OnClose="@(() => _exerciseToEditIndex = null)"
+    >
         <ExerciseEditor Exercise="editingExerciseBlueprint" UpdateExercise="(ex) => {editingExerciseBlueprint = ex; StateHasChanged();}" />
 </FullScreenDialog>
 
@@ -95,7 +101,7 @@ else
     {
         var exercise = Session.RecordedExercises[setAdditionalActions.Value.ExerciseIndex];
         var set = exercise.PotentialSets[setAdditionalActions.Value.PotentialSetIndex];
-        <span slot="headline" class="select-none">Select Reps</span>
+        <span slot="headline" class="select-none">@UiStrings.SelectReps</span>
         <span slot="content" >
         <PotentialSetAdditionalActions
             Set="set"
@@ -107,17 +113,16 @@ else
             OnDeleteSet=@(()=>{})></PotentialSetAdditionalActions>
         </span>
         <div slot="actions">
-            <AppButton Type="AppButtonType.Text" OnClick="@(() => setAdditionalActionsDialog?.Close())">Cancel</AppButton>
+            <AppButton Type="AppButtonType.Text" OnClick="@(() => setAdditionalActionsDialog?.Close())">@UiStrings.Cancel</AppButton>
         </div>
     }
 </Dialog>
 
 
 <Dialog @ref="_removeExerciseDialog">
-    <span slot="headline">Remove Exercise?</span>
+    <span slot="headline">@UiStrings.RemoveExerciseQuestion</span>
     <span slot="content" class="block text-left">
-        Exercise will be removed from the current session, future sessions will
-        not be impacted.
+        @UiStrings.RemoveExerciseMessage
     </span>
     <div slot="actions">
         <AppButton Type="AppButtonType.Text" slot="footer" OnClick="() => { _removeExerciseDialog?.Close(); }">@UiStrings.Cancel</AppButton>
@@ -126,23 +131,23 @@ else
 </Dialog>
 
 <Dialog @ref="_updatePlanDialog">
-    <span slot="headline">Update Plan</span>
+    <span slot="headline">@UiStrings.UpdatePlan</span>
     <span slot="content" class="block text-left">
-        The plan will be updated with the current session's exercises.
+        @UiStrings.PlanWillBeUpdated
         @if (SessionWithSameNameInPlan)
         {
-            <span>Would you like to update the existing session <span class="font-bold text-primary">@Session.Blueprint.Name</span>, or add a new session?</span>
+            <LimitedHtml Value=@(UiStrings.UpdateExistingWorkout(Session.Blueprint.Name))/>
         }
     </span>
     <div slot="actions">
         <div class="flex justify-between flex-grow">
-            <AppButton Type="AppButtonType.Text" slot="footer" OnClick="@(() => _updatePlanDialog?.Close())">Cancel</AppButton>
+            <AppButton Type="AppButtonType.Text" slot="footer" OnClick="@(() => _updatePlanDialog?.Close())">@UiStrings.Cancel</AppButton>
             <div>
-                <AppButton Type="AppButtonType.Text" slot="footer" OnClick="HandleAddAsNewSession">Add</AppButton>
+                <AppButton Type="AppButtonType.Text" slot="footer" OnClick="HandleAddAsNewSession">@UiStrings.Add</AppButton>
                 @if (SessionWithSameNameInPlan)
                 {
                     <AppButton Type="AppButtonType.Text" slot="footer" OnClick="HandleUpdateInPlan">
-                        <span>Update</span>
+                        @UiStrings.Update
                     </AppButton>
                 }
             </div>
@@ -372,7 +377,7 @@ else
     {
         if (Session.Blueprint is SessionBlueprint blueprint)
         {
-            var blueprintIndex = ProgramState.Value.GetActivePlanSessionBlueprints().IndexedTuples().First(x => x.Item.Name == blueprint.Name).Index;
+            var blueprintIndex = ProgramState.Value.GetActivePlanSessionBlueprints().Index().First(x => x.Item.Name == blueprint.Name).Index;
             Dispatcher.Dispatch(new SetProgramSessionAction(ProgramState.Value.ActivePlanId, blueprintIndex, blueprint));
         }
     }

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -4,8 +4,6 @@
 @inject IState<CurrentSessionState> CurrentSessionState
 @inject IDispatcher Dispatcher
 
-@inject IStringLocalizer<UiStrings> UiStrings
-
 @if(Session.Blueprint.Notes != "")
 {
     <Card class="my-2 mx-7 gap-4 text-start flex items-center" Type=Card.CardType.Filled>

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -120,8 +120,8 @@ else
         not be impacted.
     </span>
     <div slot="actions">
-        <AppButton Type="AppButtonType.Text" slot="footer" OnClick="() => { _removeExerciseDialog?.Close(); }">Cancel</AppButton>
-        <AppButton Type="AppButtonType.Text" slot="footer" OnClick="RemoveExerciseHandler">@(UiStrings.Remove())</AppButton>
+        <AppButton Type="AppButtonType.Text" slot="footer" OnClick="() => { _removeExerciseDialog?.Close(); }">@UiStrings.Cancel</AppButton>
+        <AppButton Type="AppButtonType.Text" slot="footer" OnClick="RemoveExerciseHandler">@UiStrings.Remove</AppButton>
     </div>
 </Dialog>
 

--- a/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
@@ -32,7 +32,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.ShardPlan));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.SharedPlan));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/"));
     }
 

--- a/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
@@ -2,7 +2,7 @@
 
 <div class="text-on-surface text-left">
     <h2 class="text-xl font-bold text-primary mx-4">@ProgramBlueprint.Name</h2>
-    <p class=" mx-4">This plan has been shared with you.</p>
+    <p class=" mx-4">@UiStrings.PlanSharedWithYou</p>
     <CardList Items="ProgramBlueprint.Sessions">
         <SplitCardControl>
             <TitleContent>
@@ -18,7 +18,7 @@
 @if(IsInActiveScreen)
 {
     <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
-        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=OnImport >Import</AppButton>
+        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=OnImport >@UiStrings.Import</AppButton>
     </Microsoft.AspNetCore.Components.Sections.SectionContent>
 }
 @code {
@@ -32,7 +32,7 @@
     protected override void OnInitialized()
     {
         base.OnInitialized();
-        Dispatcher.Dispatch(new SetPageTitleAction("Shared Plan"));
+        Dispatcher.Dispatch(new SetPageTitleAction(UiStrings.ShardPlan));
         Dispatcher.Dispatch(new SetBackNavigationUrlAction("/"));
     }
 

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using Fluxor;
 using Google.Protobuf;
 using LiftLog.Lib.Services;
+using LiftLog.Ui.i18n.TypealizR;
 using LiftLog.Ui.Models;
 using LiftLog.Ui.Models.ExportedDataDao;
 using LiftLog.Ui.Models.ProgramBlueprintDao;
@@ -19,7 +20,7 @@ using Microsoft.Extensions.Logging;
 
 namespace LiftLog.Ui.Store.Settings;
 
-public class SettingsEffects(
+internal class SettingsEffects(
     ProgressRepository progressRepository,
     IState<SettingsState> settingsState,
     IState<ProgramState> programState,
@@ -30,7 +31,8 @@ public class SettingsEffects(
     ILogger<SettingsEffects> logger,
     PreferencesRepository preferencesRepository,
     PlaintextExportService plaintextExportService,
-    HttpClient httpClient
+    HttpClient httpClient,
+    TypealizedUiStrings uiStrings
 )
 {
     [EffectMethod]
@@ -264,7 +266,7 @@ public class SettingsEffects(
         {
             logger.LogWarning(ex, "Failed to backup data to remote server [connection failure]");
             dispatcher.Dispatch(
-                new ToastAction("Failed to backup data to remote server [connection failure]")
+                new ToastAction(uiStrings.FailedToBackupToRemote + " [connection failure]")
             );
         }
         catch (HttpRequestException ex)
@@ -275,15 +277,13 @@ public class SettingsEffects(
                 ex.StatusCode
             );
             dispatcher.Dispatch(
-                new ToastAction("Failed to backup data to remote server [" + ex.StatusCode + "]")
+                new ToastAction(uiStrings.FailedToBackupToRemote + " [" + ex.StatusCode + "]")
             );
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to backup data to remote server [unknown]");
-            dispatcher.Dispatch(
-                new ToastAction("Failed to backup data to remote server [unknown]")
-            );
+            dispatcher.Dispatch(new ToastAction(uiStrings.FailedToBackupToRemote + " [unknown]"));
         }
     }
 

--- a/LiftLog.Ui/_Imports.razor
+++ b/LiftLog.Ui/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.Extensions.Localization
 @using Microsoft.Extensions.Logging
 @using Microsoft.JSInterop
 @using LiftLog.Ui.Shared
@@ -28,5 +29,6 @@
 @using LiftLog.Ui.Store.Stats
 @using LiftLog.Ui.Store.AiSessionCreator
 @using LiftLog.Ui.Store.Feed
+@using LiftLog.Ui.i18n
 @using BlazorTransitionableRoute
 @using LiftLog.Ui.Shared.Smart.Tips

--- a/LiftLog.Ui/_Imports.razor
+++ b/LiftLog.Ui/_Imports.razor
@@ -32,3 +32,4 @@
 @using LiftLog.Ui.i18n
 @using BlazorTransitionableRoute
 @using LiftLog.Ui.Shared.Smart.Tips
+@inject IStringLocalizer<UiStrings> UiStrings

--- a/LiftLog.Ui/_Imports.razor
+++ b/LiftLog.Ui/_Imports.razor
@@ -32,4 +32,4 @@
 @using LiftLog.Ui.i18n
 @using BlazorTransitionableRoute
 @using LiftLog.Ui.Shared.Smart.Tips
-@inject IStringLocalizer<UiStrings> UiStrings
+@inject LiftLog.Ui.i18n.TypealizR.TypealizedUiStrings UiStrings;

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -261,7 +261,7 @@
     <value>All time</value>
     <comment/>
   </data>
-  <data name="{NumDays}Days" xml:space="preserve">
+  <data name="{NumDays}NumDays" xml:space="preserve">
     <value>{0} days</value>
     <comment/>
   </data>
@@ -272,5 +272,461 @@
   <data name="CurrentSessions" xml:space="preserve">
     <value>Current sessions</value>
     <comment/>
+  </data>
+  <data name="NotPublishingWorkouts" xml:space="preserve">
+    <value>You are not publishing your workouts</value>
+    <comment/>
+  </data>
+  <data name="StartPublishing" xml:space="preserve">
+    <value>Start publishing</value>
+    <comment/>
+  </data>
+  <data name="NothingHereYet" xml:space="preserve">
+    <value>Nothing here yet!</value>
+    <comment/>
+  </data>
+  <data name="NoFollowingData" xml:space="preserve">
+    <value>Nobody you're following has published anything yet! Come back later.</value>
+    <comment/>
+  </data>
+  <data name="StartFollowingSomeone" xml:space="preserve">
+    <value>Start following someone!</value>
+    <comment/>
+  </data>
+  <data name="NotFollowingAnyone" xml:space="preserve">
+    <value>You're not currently following anyone, ask a friend for their share link to start!</value>
+    <comment/>
+  </data>
+  <data name="NobodyFollowingYou" xml:space="preserve">
+    <value>Nobody is following you yet!</value>
+    <comment/>
+  </data>
+  <data name="ShareLinkToGetFollowers" xml:space="preserve">
+    <value>Share your link with friends to get followers</value>
+    <comment/>
+  </data>
+  <data name="Unfollow" xml:space="preserve">
+    <value>Unfollow</value>
+    <comment/>
+  </data>
+  <data name="UnfollowUser" xml:space="preserve">
+    <value>Unfollow user</value>
+    <comment/>
+  </data>
+  <data name="RemoveFollower" xml:space="preserve">
+    <value>Remove follower</value>
+    <comment/>
+  </data>
+  <data name="RemoveFollowerMsgPart1" xml:space="preserve">
+    <value>This will stop</value>
+    <comment/>
+  </data>
+  <data name="RemoveFollowerMsgPart2" xml:space="preserve">
+    <value>from following you and remove all your content from their device.</value>
+    <comment/>
+  </data>
+  <data name="Unfollow{User}Msg" xml:space="preserve">
+    <value>This will unfollow &lt;em&gt;{0}&lt;/em&gt; and remove all their content on your device.</value>
+    <comment/>
+  </data>
+  <data name="SessionContainsNoExercises" xml:space="preserve">
+    <value>Session contains no exercises.</value>
+    <comment/>
+  </data>
+  <data name="UpdatePlan" xml:space="preserve">
+    <value>Update plan</value>
+    <comment/>
+  </data>
+  <data name="AddExercise" xml:space="preserve">
+    <value>Add Exercise</value>
+    <comment/>
+  </data>
+  <data name="Finish" xml:space="preserve">
+    <value>Finish</value>
+    <comment/>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Save</value>
+    <comment/>
+  </data>
+  <data name="EditExercise" xml:space="preserve">
+    <value>Edit Exercise</value>
+    <comment/>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Update</value>
+    <comment/>
+  </data>
+  <data name="Add" xml:space="preserve">
+    <value>Add</value>
+    <comment/>
+  </data>
+  <data name="SelectReps" xml:space="preserve">
+    <value>Select Reps</value>
+    <comment/>
+  </data>
+  <data name="RemoveExerciseQuestion" xml:space="preserve">
+    <value>Remove exercise?</value>
+    <comment/>
+  </data>
+  <data name="RemoveExerciseMessage" xml:space="preserve">
+    <value>Exercise will be removed from the current session, future sessions will not be impacted.</value>
+    <comment/>
+  </data>
+  <data name="UpdateExistingWorkout{Name}" xml:space="preserve">
+    <value>Would you like to update the existing workout named &lt;em&gt;{0}&lt;/em&gt;, or add a new workout?</value>
+    <comment/>
+  </data>
+  <data name="PlanWillBeUpdated" xml:space="preserve">
+    <value>The plan will be updated with the current session's exercises.</value>
+    <comment/>
+  </data>
+  <data name="Exercise" xml:space="preserve">
+    <value>Exercise</value>
+    <comment>noun form of exercise</comment>
+  </data>
+  <data name="Sets" xml:space="preserve">
+    <value>Sets</value>
+    <comment>Noun form for sets, as in number of sets in an exercise</comment>
+  </data>
+  <data name="Reps" xml:space="preserve">
+    <value>Reps</value>
+    <comment>Noun form for exercise reps, as in repetitions</comment>
+  </data>
+  <data name="PlanNotes" xml:space="preserve">
+    <value>Plan Notes</value>
+    <comment/>
+  </data>
+  <data name="SessionNotes" xml:space="preserve">
+    <value>Session Notes</value>
+    <comment/>
+  </data>
+  <data name="ExternalLink" xml:space="preserve">
+    <value>External Link</value>
+    <comment>The name for a HTTPS url link outside of the app </comment>
+  </data>
+  <data name="ProgressiveOverload" xml:space="preserve">
+    <value>Progressive Overload</value>
+    <comment/>
+  </data>
+  <data name="SupersetNextExercise" xml:space="preserve">
+    <value>Superset next exercise</value>
+    <comment/>
+  </data>
+  <data name="RestShort" xml:space="preserve">
+    <value>Short</value>
+    <comment>A short period of rest</comment>
+  </data>
+  <data name="RestMedium" xml:space="preserve">
+    <value>Medium</value>
+    <comment>A medium period of rest</comment>
+  </data>
+  <data name="RestLong" xml:space="preserve">
+    <value>Long</value>
+    <comment>A long period of rest</comment>
+  </data>
+  <data name="Custom" xml:space="preserve">
+    <value>Custom</value>
+    <comment>As in customized</comment>
+  </data>
+  <data name="MinRest" xml:space="preserve">
+    <value>Min Rest</value>
+    <comment/>
+  </data>
+  <data name="MaxRest" xml:space="preserve">
+    <value>Max Rest</value>
+    <comment/>
+  </data>
+  <data name="FailureRest" xml:space="preserve">
+    <value>Failure Rest</value>
+    <comment/>
+  </data>
+  <data name="RestSingular{Time}" xml:space="preserve">
+    <value>Rest &lt;em&gt;{0}&lt;/em&gt;</value>
+    <comment/>
+  </data>
+  <data name="RestBetween{Time1}{Time2}" xml:space="preserve">
+    <value>Rest between &lt;em&gt;{0}&lt;/em&gt; and &lt;em&gt;{0}&lt;/em&gt;</value>
+    <comment/>
+  </data>
+  <data name="Date" xml:space="preserve">
+    <value>Date</value>
+    <comment>as in calendar date</comment>
+  </data>
+  <data name="CompleteAndComeBack" xml:space="preserve">
+    <value>Complete a session and check again.</value>
+    <comment/>
+  </data>
+  <data name="NoSessionsInMonth{Month}" xml:space="preserve">
+    <value>Nothing recorded in {0}&lt;br&gt;Complete a session or switch to another month to view your sessions.</value>
+    <comment/>
+  </data>
+  <data name="DeleteSessionMessage{SessionName}{Date}" xml:space="preserve">
+    <value>The session named &lt;em&gt;{0}&lt;/em&gt;, on {1} will be deleted from history. This cannot be undone.</value>
+    <comment/>
+  </data>
+  <data name="DeleteSessionQuestion" xml:space="preserve">
+    <value>Delete Session?</value>
+    <comment/>
+  </data>
+  <data name="Delete" xml:space="preserve">
+    <value>Delete</value>
+    <comment/>
+  </data>
+  <data name="ManagePlans" xml:space="preserve">
+    <value>Manage plans</value>
+    <comment/>
+  </data>
+  <data name="ManagePlansSubtitle" xml:space="preserve">
+    <value>Setup your workout plans</value>
+    <comment/>
+  </data>
+  <data name="AppConfiguration" xml:space="preserve">
+    <value>App configuration</value>
+    <comment/>
+  </data>
+  <data name="AppConfigurationSubtitle" xml:space="preserve">
+    <value>Adjust weight units, theme, and other misc. settings</value>
+    <comment/>
+  </data>
+  <data name="Notifications" xml:space="preserve">
+    <value>Notifications</value>
+    <comment/>
+  </data>
+  <data name="NotificationsSubtitle" xml:space="preserve">
+    <value>Adjust notification settings for rest timers</value>
+    <comment/>
+  </data>
+  <data name="ExportBackupRestore" xml:space="preserve">
+    <value>Export, backup, and restore</value>
+    <comment/>
+  </data>
+  <data name="ExportBackupRestoreSubtitle" xml:space="preserve">
+    <value>Create and export backups for transferring between devices</value>
+    <comment/>
+  </data>
+  <data name="FeatureRequest" xml:space="preserve">
+    <value>Feature request</value>
+    <comment/>
+  </data>
+  <data name="FeatureRequestSubtitle" xml:space="preserve">
+    <value>Suggest a new feature that you think LiftLog should have!</value>
+    <comment/>
+  </data>
+  <data name="BugReport" xml:space="preserve">
+    <value>Bug report</value>
+    <comment/>
+  </data>
+  <data name="BugReportSubtitle" xml:space="preserve">
+    <value>Let us know when you encounter a bug</value>
+    <comment/>
+  </data>
+  <data name="AppInfo" xml:space="preserve">
+    <value>App info</value>
+    <comment/>
+  </data>
+  <data name="AppInfoSubtitle" xml:space="preserve">
+    <value>Display app information</value>
+    <comment/>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+    <comment>as in the opposite of open, close a dialog</comment>
+  </data>
+  <data name="SavedPlans" xml:space="preserve">
+    <value>Saved Plans</value>
+    <comment/>
+  </data>
+  <data name="AddPlan" xml:space="preserve">
+    <value>Add plan</value>
+    <comment/>
+  </data>
+  <data name="SelectedPlan{Plan}" xml:space="preserve">
+    <value>Selected &lt;em&gt;{0}&lt;/em&gt;</value>
+    <comment/>
+  </data>
+  <data name="RestNotifications" xml:space="preserve">
+    <value>Rest notifications</value>
+    <comment>the title for the rest notifications toggle</comment>
+  </data>
+  <data name="RestNotificationsSubtitle" xml:space="preserve">
+    <value>Show a notification when the rest timer is up</value>
+    <comment/>
+  </data>
+  <data name="PlanName" xml:space="preserve">
+    <value>Plan Name</value>
+    <comment/>
+  </data>
+  <data name="NoWorkoutsInPlan" xml:space="preserve">
+    <value>No workouts in plan&lt;br&gt; Add a workout to get started.</value>
+    <comment/>
+  </data>
+  <data name="AddWorkout" xml:space="preserve">
+    <value>Add workout</value>
+    <comment/>
+  </data>
+  <data name="UseWorkout" xml:space="preserve">
+    <value>Use</value>
+    <comment/>
+  </data>
+  <data name="ManageWorkout{Workout}" xml:space="preserve">
+    <value>Manage {0}</value>
+    <comment/>
+  </data>
+  <data name="WorkoutName" xml:space="preserve">
+    <value>Workout Name</value>
+    <comment/>
+  </data>
+  <data name="WorkoutNotes" xml:space="preserve">
+    <value>Workout Notes</value>
+    <comment/>
+  </data>
+  <data name="NoExercisesAdded" xml:space="preserve">
+    <value>No exercises added yet</value>
+    <comment/>
+  </data>
+  <data name="Exercises" xml:space="preserve">
+    <value>Exercises</value>
+    <comment>Multiple noun exercises</comment>
+  </data>
+  <data name="RemoveExerciseFromWorkoutMessage{Exercise}{Session}" xml:space="preserve">
+    <value>This will remove the exercise &lt;em&gt;{0}&lt;/em&gt; from &lt;em&gt;{1}&lt;/em&gt;.</value>
+    <comment/>
+  </data>
+  <data name="BackUpDataSubtitle" xml:space="preserve">
+    <value>Export your data to a file for backup or transfer</value>
+    <comment/>
+  </data>
+  <data name="RestoreData" xml:space="preserve">
+    <value>Restore data</value>
+    <comment/>
+  </data>
+  <data name="RestoreDataSubtitle" xml:space="preserve">
+    <value>Import data from a file to restore</value>
+    <comment/>
+  </data>
+  <data name="AutomaticRemoteBackup" xml:space="preserve">
+    <value>Automatic remote backup</value>
+    <comment/>
+  </data>
+  <data name="PlaintextExport" xml:space="preserve">
+    <value>Plaintext export</value>
+    <comment/>
+  </data>
+  <data name="PlaintextExportSubtitle" xml:space="preserve">
+    <value>Export your data in a plaintext format such as CSV for use in other applications</value>
+    <comment/>
+  </data>
+  <data name="AutomaticRemoteBackupSubtitle" xml:space="preserve">
+    <value>Send backups to a remote server. Advanced users only</value>
+    <comment/>
+  </data>
+  <data name="ImportFeedDataQuestion" xml:space="preserve">
+    <value>Import feed data?</value>
+    <comment/>
+  </data>
+  <data name="ImportFeedDataQuestionMessage" xml:space="preserve">
+    <value>This backup includes a feed account. Would you like to import it?&lt;br&gt;You will lose access to your current account without a backup.&lt;br&gt;&lt;em&gt;This will replace your current account and cannot be undone!&lt;/em&gt;</value>
+    <comment/>
+  </data>
+  <data name="ImportVerb" xml:space="preserve">
+    <value>Import</value>
+    <comment>Import as a verb</comment>
+  </data>
+  <data name="IncludeFeed" xml:space="preserve">
+    <value>Include feed</value>
+    <comment>Include feed data in the backup</comment>
+  </data>
+  <data name="JustMyData" xml:space="preserve">
+    <value>Just my data</value>
+    <comment>A button saying to include only our data in the backup, and no feed content</comment>
+  </data>
+  <data name="BackupFeedAccount" xml:space="preserve">
+    <value>Backup feed account</value>
+    <comment/>
+  </data>
+  <data name="BackupFeedAccountMessage" xml:space="preserve">
+    <value>Include your feed account and followed users in this backup?&lt;br&gt;&lt;em&gt;Caution: This would allow anyone with this backup to post feed content with your account&lt;/em&gt;</value>
+    <comment/>
+  </data>
+  <data name="UseImperialUnits" xml:space="preserve">
+    <value>Use imperial units</value>
+    <comment/>
+  </data>
+  <data name="UseImperialUnitsSubtitle" xml:space="preserve">
+    <value>Use pounds in favour of kilograms</value>
+    <comment/>
+  </data>
+  <data name="ShowBodyweight" xml:space="preserve">
+    <value>Show bodyweight</value>
+    <comment/>
+  </data>
+  <data name="ShowBodyweightSubtitle" xml:space="preserve">
+    <value>Enable bodyweight tracking and statistics</value>
+    <comment/>
+  </data>
+  <data name="ShowFeed" xml:space="preserve">
+    <value>Show feed</value>
+    <comment/>
+  </data>
+  <data name="ShowFeedSubtitle" xml:space="preserve">
+    <value>Display the feed in the navigation bar</value>
+    <comment/>
+  </data>
+  <data name="StatusBarFix" xml:space="preserve">
+    <value>Status bar fix</value>
+    <comment/>
+  </data>
+  <data name="StatusBarFixSubtitle" xml:space="preserve">
+    <value>Fixes the status bar overlapping the page title controls on some devices</value>
+    <comment/>
+  </data>
+  <data name="ShowTips" xml:space="preserve">
+    <value>Show tips</value>
+    <comment/>
+  </data>
+  <data name="ShowTipsSubtitle" xml:space="preserve">
+    <value>Show tips on how to use the app</value>
+    <comment/>
+  </data>
+  <data name="ResetTips" xml:space="preserve">
+    <value>Reset tips</value>
+    <comment/>
+  </data>
+  <data name="PlaintextExportDescription" xml:space="preserve">
+    <value>This feature allows you to export your data in a plaintext format such as CSV for use in other applications. It is not intended for backup purposes. For backups, please use the backup feature. LiftLog cannot restore data from plaintext exports.</value>
+    <comment/>
+  </data>
+  <data name="ReadDocumentation" xml:space="preserve">
+    <value>Read documentation</value>
+    <comment/>
+  </data>
+  <data name="PlaintextExportFormat" xml:space="preserve">
+    <value>Format</value>
+    <comment>The export format type for the plaintext export</comment>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>Export</value>
+    <comment>Export as a verb</comment>
+  </data>
+  <data name="RemoteBackupDescription" xml:space="preserve">
+    <value>This is an advanced feature which enables LiftLog to send backups to a remote server.&lt;br&gt;Please read the documentation for instructions on how to set up a remote server.</value>
+    <comment/>
+  </data>
+  <data name="Endpoint" xml:space="preserve">
+    <value>Endpoint</value>
+    <comment/>
+  </data>
+  <data name="ApiKey" xml:space="preserve">
+    <value>API Key</value>
+    <comment/>
+  </data>
+  <data name="BackupFeedAccountSubtitle" xml:space="preserve">
+    <value>Include your feed account data in backups</value>
+    <comment/>
+  </data>
+  <data name="Test" xml:space="preserve">
+    <value>Test</value>
+    <comment>The button for testing the remote backup</comment>
   </data>
 </root>

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Freeform Session" xml:space="preserve">
+    <value>Freeform Session</value>
+    <comment/>
+  </data>
+</root>

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -157,4 +157,12 @@
     <value>Statistics</value>
     <comment/>
   </data>
+  <data name="Feed_Following" xml:space="preserve">
+    <value>Following</value>
+    <comment/>
+  </data>
+  <data name="Feed_Followers" xml:space="preserve">
+    <value>Followers</value>
+    <comment/>
+  </data>
 </root>

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -215,7 +215,7 @@
   </data>
   <data name="Cancel" xml:space="preserve">
     <value>Cancel</value>
-    <comment/>
+    <comment>As a verb</comment>
   </data>
   <data name="Calculating" xml:space="preserve">
     <value>Calculating...</value>
@@ -728,5 +728,437 @@
   <data name="Test" xml:space="preserve">
     <value>Test</value>
     <comment>The button for testing the remote backup</comment>
+  </data>
+  <data name="GeneratingAiPlan" xml:space="preserve">
+    <value>Generating AI plan...&lt;br&gt;&lt;em&gt;This may take up to 3 minutes&lt;/em&gt;</value>
+    <comment/>
+  </data>
+  <data name="NoteAboutTweakingAiPlan" xml:space="preserve">
+    <value>Note: you can tweak this plan after you accept it. Just head to the Manage Plan page in settings.</value>
+    <comment/>
+  </data>
+  <data name="Accept" xml:space="preserve">
+    <value>Accept</value>
+    <comment>As a verb</comment>
+  </data>
+  <data name="Regenerate" xml:space="preserve">
+    <value>Regenerate</value>
+    <comment>Recreate the ai plan</comment>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Retry</value>
+    <comment>Generic retry verb</comment>
+  </data>
+  <data name="AiPlanner" xml:space="preserve">
+    <value>AI Planner</value>
+    <comment/>
+  </data>
+  <data name="Back" xml:space="preserve">
+    <value>Back</value>
+    <comment>As in, go back to the previous screen</comment>
+  </data>
+  <data name="AddToPlan" xml:space="preserve">
+    <value>Add to plan</value>
+    <comment>A button to add the session to the user's plan</comment>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>Start</value>
+    <comment>A verb for beginnning the workout</comment>
+  </data>
+  <data name="Generate" xml:space="preserve">
+    <value>Generate</value>
+    <comment>Verb for generating an ai plan</comment>
+  </data>
+  <data name="SelectAtLeastOneArea" xml:space="preserve">
+    <value>Please select at least one area to workout</value>
+    <comment>Area referring to the area of the body, like a muscle</comment>
+  </data>
+  <data name="AiSessionCreator" xml:space="preserve">
+    <value>AI Session Creator</value>
+    <comment/>
+  </data>
+  <data name="Theme" xml:space="preserve">
+    <value>Theme</value>
+    <comment>As in the general colours of the app</comment>
+  </data>
+  <data name="Default" xml:space="preserve">
+    <value>Default</value>
+    <comment>The default, as a noun</comment>
+  </data>
+  <data name="AdditionalInformationLabel" xml:space="preserve">
+    <value>Any additional information?</value>
+    <comment/>
+  </data>
+  <data name="AdditionalInformationExtra" xml:space="preserve">
+    <value>Goals, injuries, available equipment, etc.</value>
+    <comment/>
+  </data>
+  <data name="HowOldAreYou" xml:space="preserve">
+    <value>How old are you?</value>
+    <comment/>
+  </data>
+  <data name="SelectAtLeastOneGoal" xml:space="preserve">
+    <value>Please select at least one goal</value>
+    <comment/>
+  </data>
+  <data name="SelectNumberOfDays" xml:space="preserve">
+    <value>Please select the number of days per week</value>
+    <comment/>
+  </data>
+  <data name="WhatIsYourGender" xml:space="preserve">
+    <value>What is your gender?</value>
+    <comment/>
+  </data>
+  <data name="GenderFemale" xml:space="preserve">
+    <value>Female</value>
+    <comment/>
+  </data>
+  <data name="GenderMale" xml:space="preserve">
+    <value>Male</value>
+    <comment/>
+  </data>
+  <data name="GenderOther" xml:space="preserve">
+    <value>Other</value>
+    <comment>A gender other than female or male</comment>
+  </data>
+  <data name="GenderPreferNotToSay" xml:space="preserve">
+    <value>Prefer not to say</value>
+    <comment>The user prefers not to say their gender</comment>
+  </data>
+  <data name="WhatAreYourGoals" xml:space="preserve">
+    <value>What are your goals?</value>
+    <comment/>
+  </data>
+  <data name="Toning" xml:space="preserve">
+    <value>Toning</value>
+    <comment>As in getting more muscular definition</comment>
+  </data>
+  <data name="LosingWeight" xml:space="preserve">
+    <value>Lowing Weight</value>
+    <comment/>
+  </data>
+  <data name="GainingMuscle" xml:space="preserve">
+    <value>Gaining Muscle</value>
+    <comment/>
+  </data>
+  <data name="Strength" xml:space="preserve">
+    <value>Strength</value>
+    <comment/>
+  </data>
+  <data name="WhatIsYourExperienceLevel" xml:space="preserve">
+    <value>What is your experience level?</value>
+    <comment/>
+  </data>
+  <data name="ExperienceProfessional" xml:space="preserve">
+    <value>Professional</value>
+    <comment/>
+  </data>
+  <data name="ExperienceAdvanced" xml:space="preserve">
+    <value>Advanced</value>
+    <comment/>
+  </data>
+  <data name="ExperienceIntermediate" xml:space="preserve">
+    <value>Intermediate</value>
+    <comment/>
+  </data>
+  <data name="ExperienceBeginner" xml:space="preserve">
+    <value>Beginner</value>
+    <comment/>
+  </data>
+  <data name="One" xml:space="preserve">
+    <value>One</value>
+    <comment/>
+  </data>
+  <data name="Two" xml:space="preserve">
+    <value>Two</value>
+    <comment/>
+  </data>
+  <data name="Three" xml:space="preserve">
+    <value>Three</value>
+    <comment/>
+  </data>
+  <data name="Four" xml:space="preserve">
+    <value>Four</value>
+    <comment/>
+  </data>
+  <data name="Five" xml:space="preserve">
+    <value>Five</value>
+    <comment/>
+  </data>
+  <data name="Six" xml:space="preserve">
+    <value>Six</value>
+    <comment/>
+  </data>
+  <data name="Seven" xml:space="preserve">
+    <value>Seven</value>
+    <comment/>
+  </data>
+  <data name="HowManyDaysPerWeek" xml:space="preserve">
+    <value>How many days per week?</value>
+    <comment/>
+  </data>
+  <data name="HowMuchDoYouWeigh" xml:space="preserve">
+    <value>How much do you weigh?</value>
+    <comment/>
+  </data>
+  <data name="Arms" xml:space="preserve">
+    <value>Arms</value>
+    <comment/>
+  </data>
+  <data name="Chest" xml:space="preserve">
+    <value>Chest</value>
+    <comment/>
+  </data>
+  <data name="BackMuscle" xml:space="preserve">
+    <value>Back</value>
+    <comment>As in a person's back muscles</comment>
+  </data>
+  <data name="Legs" xml:space="preserve">
+    <value>Legs</value>
+    <comment/>
+  </data>
+  <data name="Triceps" xml:space="preserve">
+    <value>Triceps</value>
+    <comment/>
+  </data>
+  <data name="Biceps" xml:space="preserve">
+    <value>Biceps</value>
+    <comment/>
+  </data>
+  <data name="Quads" xml:space="preserve">
+    <value>Quads</value>
+    <comment/>
+  </data>
+  <data name="Hamstrings" xml:space="preserve">
+    <value>Hamstrings</value>
+    <comment/>
+  </data>
+  <data name="Calves" xml:space="preserve">
+    <value>Calves</value>
+    <comment/>
+  </data>
+  <data name="WhatAreYouWorkingOut" xml:space="preserve">
+    <value>What are we working out?</value>
+    <comment/>
+  </data>
+  <data name="HowMuchVolume" xml:space="preserve">
+    <value>How much volume?</value>
+    <comment/>
+  </data>
+  <data name="VolumeLight" xml:space="preserve">
+    <value>Light</value>
+    <comment>As in the opposite of heavy</comment>
+  </data>
+  <data name="VolumeMedium" xml:space="preserve">
+    <value>Medium</value>
+    <comment>As in the middle of light and heavy</comment>
+  </data>
+  <data name="VolumeHeavy" xml:space="preserve">
+    <value>Heavy</value>
+    <comment/>
+  </data>
+  <data name="Ok" xml:space="preserve">
+    <value>Ok</value>
+    <comment/>
+  </data>
+  <data name="FeedUserCompletedAWorkout{UserName}" xml:space="preserve">
+    <value>&lt;em&gt;{0}&lt;/em&gt; completed a workout!</value>
+    <comment/>
+  </data>
+  <data name="AnonymousUser" xml:space="preserve">
+    <value>Anonymous User</value>
+    <comment/>
+  </data>
+  <data name="AwaitingResponse" xml:space="preserve">
+    <value>Awaiting Response</value>
+    <comment/>
+  </data>
+  <data name="Nickname" xml:space="preserve">
+    <value>Nickname</value>
+    <comment/>
+  </data>
+  <data name="ViewTheirPlan" xml:space="preserve">
+    <value>View their plan</value>
+    <comment/>
+  </data>
+  <data name="UserIsFollowingYou{User}" xml:space="preserve">
+    <value>&lt;em&gt;{0}&lt;/em&gt; is following you!</value>
+    <comment/>
+  </data>
+  <data name="FollowUserBack{User}" xml:space="preserve">
+    <value>Follow {0} back</value>
+    <comment/>
+  </data>
+  <data name="UserWantsToFollowYou{User}" xml:space="preserve">
+    <value>&lt;em&gt;{0}&lt;/em&gt; wants to follow you!</value>
+    <comment/>
+  </data>
+  <data name="Deny" xml:space="preserve">
+    <value>Deny</value>
+    <comment/>
+  </data>
+  <data name="GenericLoading" xml:space="preserve">
+    <value>Loading...</value>
+    <comment/>
+  </data>
+  <data name="Duplicate" xml:space="preserve">
+    <value>Duplicate</value>
+    <comment/>
+  </data>
+  <data name="NeverDoneThisExerciseBefore" xml:space="preserve">
+    <value>You have never done this exercise before</value>
+    <comment/>
+  </data>
+  <data name="Share" xml:space="preserve">
+    <value>Share</value>
+    <comment>Verb</comment>
+  </data>
+  <data name="EditedOn{Date}" xml:space="preserve">
+    <value>Edited: {0}</value>
+    <comment/>
+  </data>
+  <data name="Active" xml:space="preserve">
+    <value>Active</value>
+    <comment/>
+  </data>
+  <data name="Search" xml:space="preserve">
+    <value>Search</value>
+    <comment/>
+  </data>
+  <data name="Weight" xml:space="preserve">
+    <value>Weight</value>
+    <comment/>
+  </data>
+  <data name="EnableNotificationsQuestion" xml:space="preserve">
+    <value>Enable Notifications?</value>
+    <comment/>
+  </data>
+  <data name="AndroidNotificationPermissionExplanation" xml:space="preserve">
+    <value>Newer Android devices require an additional permission to ensure that rest notifications are delivered on time. Without this permission, they will arrive late and largely be useless. On the next screen, please grant LiftLog the permission.</value>
+    <comment/>
+  </data>
+  <data name="EnjoyingLiftLogQuestion" xml:space="preserve">
+    <value>Enjoying LiftLog?</value>
+    <comment/>
+  </data>
+  <data name="EnjoyingLiftLogMessage{Type}{Store}" xml:space="preserve">
+    <value>If so, would you take a minute to leave a {0} on {1}?</value>
+    <comment/>
+  </data>
+  <data name="NotNow" xml:space="preserve">
+    <value>Not now</value>
+    <comment/>
+  </data>
+  <data name="Rate" xml:space="preserve">
+    <value>Rate</value>
+    <comment/>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Never</value>
+    <comment/>
+  </data>
+  <data name="GithubStar" xml:space="preserve">
+    <value>star</value>
+    <comment>as in a star on github</comment>
+  </data>
+  <data name="Review" xml:space="preserve">
+    <value>review</value>
+    <comment>as in a review on the app store</comment>
+  </data>
+  <data name="Optional" xml:space="preserve">
+    <value>Optional</value>
+    <comment/>
+  </data>
+  <data name="YourName" xml:space="preserve">
+    <value>Your Name</value>
+    <comment/>
+  </data>
+  <data name="PublishWorkout" xml:space="preserve">
+    <value>Publish workout</value>
+    <comment/>
+  </data>
+  <data name="PublishBodyweight" xml:space="preserve">
+    <value>Publish bodyweight</value>
+    <comment/>
+  </data>
+  <data name="PublishPlan" xml:space="preserve">
+    <value>Publish plan</value>
+    <comment/>
+  </data>
+  <data name="PublishWorkoutSubtitle" xml:space="preserve">
+    <value>Publish workouts as you complete them</value>
+    <comment/>
+  </data>
+  <data name="PublishPlanSubtitle" xml:space="preserve">
+    <value>Publish your current plan for your followers to see and import</value>
+    <comment/>
+  </data>
+  <data name="PublishBodyweightSubtitle" xml:space="preserve">
+    <value>Publish your bodyweight with your workouts</value>
+    <comment/>
+  </data>
+  <data name="ResetAccount" xml:space="preserve">
+    <value>Reset account</value>
+    <comment/>
+  </data>
+  <data name="ResetAccountMessage" xml:space="preserve">
+    <value>This will delete your data on the servers and unsubscribe you from all feeds. You will need to resubscribe and share a new link if you want to share your workouts again.</value>
+    <comment/>
+  </data>
+  <data name="OnlyThoseWithTheLinkCanSee" xml:space="preserve">
+    <value>Only those with the link can see what you've shared.</value>
+    <comment/>
+  </data>
+  <data name="ShareLink" xml:space="preserve">
+    <value>Share link</value>
+    <comment/>
+  </data>
+  <data name="Unlock" xml:space="preserve">
+    <value>Unlock</value>
+    <comment/>
+  </data>
+  <data name="ProFeatures" xml:space="preserve">
+    <value>Pro Features</value>
+    <comment/>
+  </data>
+  <data name="AiPlannerSubtitle" xml:space="preserve">
+    <value>Use AI to generate an entire program suited to your goals</value>
+    <comment/>
+  </data>
+  <data name="AiSessionCreatorSubtitle" xml:space="preserve">
+    <value>Generate a workout session to import into your plan or complete now!</value>
+    <comment/>
+  </data>
+  <data name="UpgradeToPro" xml:space="preserve">
+    <value>Upgrade to Pro</value>
+    <comment/>
+  </data>
+  <data name="UpgradeToProDescription" xml:space="preserve">
+    <value>This will unlock the AI planner, which will generate a plan tailored specifically to you and your goals. &lt;br&gt;This is a one time purchase of:</value>
+    <comment>The price immediately follows this, so translations will need to be worded in such a way that this is possible</comment>
+  </data>
+  <data name="Upgrade" xml:space="preserve">
+    <value>Upgrade</value>
+    <comment/>
+  </data>
+  <data name="PlanSharedWithYou" xml:space="preserve">
+    <value>This plan has been shared with you.</value>
+    <comment/>
+  </data>
+  <data name="SharedPlan" xml:space="preserve">
+    <value>Shared Plan</value>
+    <comment/>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Settings saved</value>
+    <comment/>
+  </data>
+  <data name="BackupSentSuccessfully" xml:space="preserve">
+    <value>Backup sent successfully</value>
+    <comment/>
+  </data>
+  <data name="FailedToBackupToRemote" xml:space="preserve">
+    <value>Failed to backup to remote server</value>
+    <comment/>
   </data>
 </root>

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -629,7 +629,7 @@
     <value>This backup includes a feed account. Would you like to import it?&lt;br&gt;You will lose access to your current account without a backup.&lt;br&gt;&lt;em&gt;This will replace your current account and cannot be undone!&lt;/em&gt;</value>
     <comment/>
   </data>
-  <data name="ImportVerb" xml:space="preserve">
+  <data name="Import" xml:space="preserve">
     <value>Import</value>
     <comment>Import as a verb</comment>
   </data>
@@ -1159,6 +1159,14 @@
   </data>
   <data name="FailedToBackupToRemote" xml:space="preserve">
     <value>Failed to backup to remote server</value>
+    <comment/>
+  </data>
+  <data name="ImportTheirPlan" xml:space="preserve">
+    <value>Import their plan</value>
+    <comment/>
+  </data>
+  <data name="ImportTheirPlanMessage{user}" xml:space="preserve">
+    <value>This will import &lt;em&gt;{0}'s&lt;/em&gt; plan.  It will not overwrite your existing plan.</value>
     <comment/>
   </data>
 </root>

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -121,4 +121,40 @@
     <value>Freeform Session</value>
     <comment/>
   </data>
+  <data name="Edit" xml:space="preserve">
+    <value>Edit</value>
+    <comment/>
+  </data>
+  <data name="Notes" xml:space="preserve">
+    <value>Notes</value>
+    <comment/>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Remove</value>
+    <comment/>
+  </data>
+  <data name="Workout" xml:space="preserve">
+    <value>Workout</value>
+    <comment/>
+  </data>
+  <data name="Feed" xml:space="preserve">
+    <value>Feed</value>
+    <comment/>
+  </data>
+  <data name="Stats" xml:space="preserve">
+    <value>Stats</value>
+    <comment/>
+  </data>
+  <data name="History" xml:space="preserve">
+    <value>History</value>
+    <comment/>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Settings</value>
+    <comment/>
+  </data>
+  <data name="Statistics" xml:space="preserve">
+    <value>Statistics</value>
+    <comment/>
+  </data>
 </root>

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -165,4 +165,112 @@
     <value>Followers</value>
     <comment/>
   </data>
+  <data name="SessionInProgress" xml:space="preserve">
+    <value>There is already a current session in progress, start a new one without saving?</value>
+    <comment/>
+  </data>
+  <data name="ReplaceCurrentSession" xml:space="preserve">
+    <value>Replace current session</value>
+    <comment/>
+  </data>
+  <data name="NoPlanCreated" xml:space="preserve">
+    <value>No plan created yet!</value>
+    <comment/>
+  </data>
+  <data name="AddWorkouts" xml:space="preserve">
+    <value>Add Workouts</value>
+    <comment/>
+  </data>
+  <data name="SelectAPlan" xml:space="preserve">
+    <value>Select a plan</value>
+    <comment/>
+  </data>
+  <data name="UpcomingWorkouts" xml:space="preserve">
+    <value>Upcoming Workouts</value>
+    <comment/>
+  </data>
+  <data name="BackUpData" xml:space="preserve">
+    <value>Back up data</value>
+    <comment/>
+  </data>
+  <data name="BackUpDataReminder" xml:space="preserve">
+    <value>It has been a while since you last created a backup. It is HIGHLY recommended you back up your data regularly to prevent data loss. Would you like to back up your data now?</value>
+    <comment/>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+    <comment/>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+    <comment/>
+  </data>
+  <data name="DontAskAgain" xml:space="preserve">
+    <value>Don't ask again</value>
+    <comment/>
+  </data>
+  <data name="OpenLink" xml:space="preserve">
+    <value>Open Link</value>
+    <comment/>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment/>
+  </data>
+  <data name="Calculating" xml:space="preserve">
+    <value>Calculating...</value>
+    <comment/>
+  </data>
+  <data name="NoDataAvailable" xml:space="preserve">
+    <value>No data available</value>
+    <comment/>
+  </data>
+  <data name="TryChangingFilters" xml:space="preserve">
+    <value>Try changing the filters at the top</value>
+    <comment/>
+  </data>
+  <data name="AverageTimeBetweenSets" xml:space="preserve">
+    <value>Average time between sets</value>
+    <comment/>
+  </data>
+  <data name="HeaviestLift" xml:space="preserve">
+    <value>Heaviest lift</value>
+    <comment/>
+  </data>
+  <data name="MostTimeSpent" xml:space="preserve">
+    <value>Most time spent</value>
+    <comment/>
+  </data>
+  <data name="AverageSessionLength" xml:space="preserve">
+    <value>Average session length</value>
+    <comment/>
+  </data>
+  <data name="Bodyweight" xml:space="preserve">
+    <value>Bodyweight</value>
+    <comment/>
+  </data>
+  <data name="Sessions" xml:space="preserve">
+    <value>Sessions</value>
+    <comment/>
+  </data>
+  <data name="NoExercisesFound" xml:space="preserve">
+    <value>No exercises found.</value>
+    <comment/>
+  </data>
+  <data name="AllTime" xml:space="preserve">
+    <value>All time</value>
+    <comment/>
+  </data>
+  <data name="{NumDays}Days" xml:space="preserve">
+    <value>{0} days</value>
+    <comment/>
+  </data>
+  <data name="AllSessions" xml:space="preserve">
+    <value>All sessions</value>
+    <comment/>
+  </data>
+  <data name="CurrentSessions" xml:space="preserve">
+    <value>Current sessions</value>
+    <comment/>
+  </data>
 </root>

--- a/LiftLog.Web/wwwroot/index.html
+++ b/LiftLog.Web/wwwroot/index.html
@@ -49,6 +49,5 @@
     <script src="_content/LiftLog.Ui/app-utils.js"></script>
     <script src="_content/LiftLog.Ui/bundle.js"></script>
     <script src="/crypto-utils.js"></script>
-    <!-- End Single Page Apps for GitHub Pages -->
   </body>
 </html>

--- a/release_notes/whatsnew-en-AU
+++ b/release_notes/whatsnew-en-AU
@@ -1,3 +1,1 @@
-You can now submit bug reports and feature requests directly from the app!
-
-Additionally, external links for exercises can now be opened from the exercise overflow menu.
+The app can now be translated into your language! Interested in submitting translations? Go to settings and submit your translations!


### PR DESCRIPTION
This PR goes through all components and user messages and replaces their hardcoded usage with LocalizableString.  This performs a lookup on a resx file for their specific locale.  Right now only English is supported (and if a locale is missing a string, it will fallback to english, so translations don't have to be done all at once).

To add a translation, simply clone the UiStrings.resx file and add a region (e.g. `UiStrings.es.resx`), and replace the values with the localized variant.

Fixes: #339 