### PR TITLE
Fix minor typo in German Translation

### DIFF
--- a/LiftLog.Ui/i18n/UiStrings.de.resx
+++ b/LiftLog.Ui/i18n/UiStrings.de.resx
@@ -611,7 +611,7 @@
     <value>Generieren</value>
   </data>
   <data name="SelectAtLeastOneArea" xml:space="preserve">
-    <value>Bitte mindestens einen Bereich für das Workout auswhälen</value>
+    <value>Bitte mindestens einen Bereich für das Workout auswählen</value>
   </data>
   <data name="AiSessionCreator" xml:space="preserve">
     <value>KI Session-Generator</value>


### PR DESCRIPTION
This just fixes a minor typo I did not notice before.

Sorry for making you apply the other changes manually rather than simply creating an MR in the first place. 
