### PR TITLE
Overhaul per set weight

### DIFF
--- a/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/completing-a-session.cy.js
@@ -102,6 +102,10 @@ describe('Completing a session', () => {
         cy.getA('[data-cy=weight-display]').first().should('contain.text', '20kg')
         cy.getA('[data-cy=per-rep-weight-btn]').first().click()
 
+        // Update top level weight - which should update all sets which aren't completed and have the same weight (i.e. the last set)
+        cy.getA('[data-cy=weight-display]').first().should('not.be.visible')
+
+
         // Update the weight of the second set to be lower than the top level weight
         cy.getA('[data-cy=set-weight-button]').eq(1).click()
         cy.dialog().find('[data-cy=decrement-weight]:visible').click()
@@ -109,23 +113,17 @@ describe('Completing a session', () => {
         cy.getA('[data-cy=set-weight-button]').eq(1).should('contain.text', '17.5kg')
         cy.getA('[data-cy=set-weight-button]').eq(2).should('contain.text', '20kg')
 
-        // Update top level weight - which should update all sets which aren't completed and have the same weight (i.e. the last set)
-        cy.getA('[data-cy=weight-display]').first().click()
-        cy.dialog().find('[data-cy=decrement-weight]').first().click().click().click()
-        cy.dialog().find('[slot="actions"]:visible').find('[dialog-action=save]').click()
+
         cy.getA('[data-cy=set-weight-button]').eq(0).should('contain.text', '20kg')
         cy.getA('[data-cy=set-weight-button]').eq(1).should('contain.text', '17.5kg')
-        cy.getA('[data-cy=set-weight-button]').eq(2).should('contain.text', '12.5kg')
-
-        // We reduced top level weight to 12.5
-        cy.getA('[data-cy=weight-display]').first().should('contain.text', '12.5kg')
+        cy.getA('[data-cy=set-weight-button]').eq(2).should('contain.text', '20kg')
 
         // Complete all sets
         for (let i = 1; i <= 6; i++) {
           cy.getA('.repcount').eq(i).click()
         }
 
-        cy.getA('.snackbar').should('be.visible').should('contain.text', 'This session').should('contain.text', '650')
+        cy.getA('.snackbar').should('be.visible').should('contain.text', 'This session').should('contain.text', '687.5')
         cy.get('[data-cy=save-session-button]').click()
 
         cy.getA('[data-cy=session-summary-title]').eq(0).should('contain.text', 'Workout B')
@@ -133,7 +131,9 @@ describe('Completing a session', () => {
 
         cy.getA('[data-cy=weighted-exercise]').eq(0).should('contain.text', 'Squat')
         // Since all sets were completed - with at least one of the sets having equal or higher weight than the top level, the weight should have increased
-        cy.getA('[data-cy=weight-display]').first().should('contain.text', '15kg')
+        cy.getA('[data-cy=set-weight-button]').eq(0).should('contain.text', '22.5kg')
+        cy.getA('[data-cy=set-weight-button]').eq(1).should('contain.text', '20kg')
+        cy.getA('[data-cy=set-weight-button]').eq(2).should('contain.text', '22.5kg')
       })
 
       it('can complete a workout and change the number of reps with it not adding progressive overload', () => {

--- a/LiftLog.Cypress/cypress/e2e/settings.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/settings.cy.js
@@ -106,7 +106,7 @@ function assertCorrectWeightUnitsOnAllPages(units) {
   cy.navigate('Workout')
   cy.navigate('Workout')
   cy.getA('[data-cy=session-summary]').first().should('contain.text', units).click()
-  cy.getA('[data-cy=weight-display]').first().should('contain.text', units).click()
+  cy.getA('[data-cy=weight-display]').eq(1).should('contain.text', units).click()
   cy.dialog().find('md-outlined-text-field').get('.suffix', { includeShadowDom: true }).should('contain.text', units)
   cy.dialog().find('[dialog-action=close]').click()
 }

--- a/LiftLog.Cypress/cypress/e2e/settings.cy.js
+++ b/LiftLog.Cypress/cypress/e2e/settings.cy.js
@@ -23,8 +23,6 @@ describe('Settings', () => {
       it('should display weights in the correct units on all pages', () => {
         assertCorrectWeightUnitsOnAllPages('kg')
         cy.navigate('Settings')
-        // Navigate twice, because settings remembers its last page when you click it
-        cy.navigate('Settings')
         cy.containsA('App configuration').click()
         cy.containsA('Use imperial units').click()
         assertCorrectWeightUnitsOnAllPages('lbs')
@@ -35,11 +33,41 @@ describe('Settings', () => {
       it('should hide and show it on all pages', () => {
         assertShowsBodyweightOnAllPages(true)
         cy.navigate('Settings')
-        // Navigate twice, because settings remembers its last page when you click it
-        cy.navigate('Settings')
         cy.containsA('App configuration').click()
         cy.containsA('Show bodyweight').click()
         assertShowsBodyweightOnAllPages(false)
+      })
+    })
+  })
+
+  describe('When a user selects a plan', () => {
+    beforeEach(() => {
+      cy.navigate('Settings')
+      // Disable tips
+      cy.containsA('App configuration').click()
+      cy.containsA('Show tips').click()
+      cy.navigate('Settings')
+      cy.containsA('Manage plans').click()
+      cy.containsA("Starting Strength").parent('md-list-item').find('[data-cy=use-plan-btn]').click()
+      cy.navigate('Workout')
+    })
+
+    describe('and updates the individual weight setting', () => {
+      it('should display the correct weight on the workout page', () => {
+        cy.navigate('Settings')
+        cy.containsA('App configuration').click()
+        cy.getA('[data-cy=split-weight-toggle]').click()
+        cy.navigate('Workout')
+        cy.getA('[data-cy=session-summary]').first().click()
+        cy.getA('[data-cy="set-weight-button"]').should('be.visible')
+
+        cy.navigate('Settings')
+        cy.containsA('App configuration').click()
+        cy.getA('[data-cy=split-weight-toggle]').click()
+        cy.navigate('Workout')
+        cy.navigate('Workout')
+        cy.getA('[data-cy=session-summary]').first().click()
+        cy.getA('[data-cy="set-weight-button"]').should('not.be.visible')
       })
     })
   })

--- a/LiftLog.Cypress/cypress/support/commands.js
+++ b/LiftLog.Cypress/cypress/support/commands.js
@@ -34,7 +34,7 @@ Cypress.Commands.add('containsA', (selector, opts) => {
 
 
 Cypress.Commands.add('navigate', (navButtonText) => {
-    return cy.get('nav').contains(navButtonText).click()
+    return cy.get('nav').contains(navButtonText).click().click()
 })
 
 Cypress.Commands.add('dialog', () => {

--- a/LiftLog.Lib/Models/BlueprintModels.cs
+++ b/LiftLog.Lib/Models/BlueprintModels.cs
@@ -22,7 +22,6 @@ public record SessionBlueprint(
         {
             return new RecordedExercise(
                 e,
-                0,
                 Enumerable.Repeat(new PotentialSet(null, 0), e.Sets).ToImmutableList(),
                 null,
                 false

--- a/LiftLog.Lib/Models/SessionModels.cs
+++ b/LiftLog.Lib/Models/SessionModels.cs
@@ -126,7 +126,6 @@ public record Session(
 
 public record RecordedExercise(
     ExerciseBlueprint Blueprint,
-    decimal Weight,
     ImmutableListValue<PotentialSet> PotentialSets,
     string? Notes,
     bool PerSetWeight
@@ -136,8 +135,7 @@ public record RecordedExercise(
     /// An exercise is considered a success if ALL sets are successful, with ANY of the sets >= the top level weight
     /// </summary>
     public bool IsSuccessForProgressiveOverload =>
-        PotentialSets.All(x => x.Set is not null && x.Set.RepsCompleted >= Blueprint.RepsPerSet)
-        && PotentialSets.Any(x => x.Weight >= Weight);
+        PotentialSets.All(x => x.Set is not null && x.Set.RepsCompleted >= Blueprint.RepsPerSet);
 
     [NotNullIfNotNull(nameof(FirstRecordedSet))]
     public PotentialSet? LastRecordedSet =>
@@ -159,9 +157,9 @@ public record RecordedExercise(
     public bool HasRemainingSets => PotentialSets.Any(x => x.Set is null);
 
     public decimal MaxWeightLifted =>
-        PerSetWeight
-            ? PotentialSets.Where(x => x.Set is not null).Select(x => x.Weight).Append(Weight).Max()
-            : Weight;
+        PotentialSets.Where(x => x.Set is not null).Select(x => x.Weight).Append(0).Max();
+
+    public decimal MaxWeight => PotentialSets.Select(x => x.Weight).Append(0).Max();
 }
 
 public record RecordedSet(int RepsCompleted, TimeOnly CompletionTime);

--- a/LiftLog.Ui/Models/CurrentSessionStateDao/CurrentSessionStateDaoV1.cs
+++ b/LiftLog.Ui/Models/CurrentSessionStateDao/CurrentSessionStateDaoV1.cs
@@ -11,17 +11,6 @@ internal record CurrentSessionStateDaoV1(
     [property: JsonPropertyName("LatestSetTimerNotificationId")] Guid? LatestSetTimerNotificationId
 )
 {
-    public static CurrentSessionStateDaoV1 FromModel(CurrentSessionState currentState) =>
-        new(
-            WorkoutSession: currentState.WorkoutSession is not null
-                ? SessionDaoV1.FromModel(currentState.WorkoutSession)
-                : null,
-            HistorySession: currentState.HistorySession is not null
-                ? SessionDaoV1.FromModel(currentState.HistorySession)
-                : null,
-            LatestSetTimerNotificationId: currentState.LatestSetTimerNotificationId
-        );
-
     public CurrentSessionState ToModel() =>
         new(
             IsHydrated: true,

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV1.cs
@@ -10,9 +10,6 @@ internal record SessionHistoryDaoV1(
         ImmutableListValue<SessionDaoV1> CompletedSessions
 )
 {
-    public static SessionHistoryDaoV1 FromModel(SessionHistoryDaoContainer model) =>
-        new(model.CompletedSessions.Values.Select(SessionDaoV1.FromModel).ToImmutableList());
-
     public SessionHistoryDaoContainer ToModel() =>
         new(CompletedSessions.ToImmutableDictionary(x => x.Id, x => x.ToModel()));
 }
@@ -26,25 +23,6 @@ internal record SessionDaoV1(
     [property: JsonPropertyName("Bodyweight")] decimal? Bodyweight
 )
 {
-    public static SessionDaoV1 FromModel(Lib.Models.Session model) =>
-        new(
-            model.Id,
-            SessionBlueprintDaoV1.FromModel(model.Blueprint),
-            model
-                .RecordedExercises.Select(x => RecordedExerciseDaoV1.FromModel(model.Date, x))
-                .ToImmutableList(),
-            new DateTimeOffset(
-                model.Date.Year,
-                model.Date.Month,
-                model.Date.Day,
-                0,
-                0,
-                0,
-                TimeSpan.Zero
-            ),
-            model.Bodyweight
-        );
-
     public Lib.Models.Session ToModel() =>
         new(
             Id,
@@ -63,24 +41,9 @@ internal record RecordedExerciseDaoV1(
     [property: JsonPropertyName("PerSetWeight")] bool PerSetWeight
 )
 {
-    public static RecordedExerciseDaoV1 FromModel(
-        DateOnly sessionDate,
-        Lib.Models.RecordedExercise model
-    ) =>
-        new(
-            ExerciseBlueprintDaoV1.FromModel(model.Blueprint),
-            model.Weight,
-            model
-                .PotentialSets.Select(x => RecordedSetDaoV1.FromModel(sessionDate, x))
-                .ToImmutableList(),
-            model.Notes,
-            model.PerSetWeight
-        );
-
     public Lib.Models.RecordedExercise ToModel() =>
         new(
             Blueprint.ToModel(),
-            Kilograms,
             RecordedSets
                 .Select(x => x?.ToModel(this) ?? new Lib.Models.PotentialSet(null, Kilograms))
                 .ToImmutableList(),

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.cs
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.cs
@@ -64,7 +64,7 @@ internal partial class RecordedExerciseDaoV2
 {
     public RecordedExerciseDaoV2(
         ExerciseBlueprintDaoV2 exerciseBlueprint,
-        decimal weight,
+        decimal? weight,
         IEnumerable<PotentialSetDaoV2> potentialSets,
         string? notes,
         bool perSetWeight
@@ -80,7 +80,7 @@ internal partial class RecordedExerciseDaoV2
     public static RecordedExerciseDaoV2 FromModel(Lib.Models.RecordedExercise model) =>
         new(
             ExerciseBlueprintDaoV2.FromModel(model.Blueprint),
-            model.Weight,
+            null,
             model.PotentialSets.Select(PotentialSetDaoV2.FromModel),
             model.Notes,
             model.PerSetWeight
@@ -89,7 +89,6 @@ internal partial class RecordedExerciseDaoV2
     public Lib.Models.RecordedExercise ToModel() =>
         new(
             ExerciseBlueprint.ToModel(),
-            Weight,
             PotentialSets.Select(x => x.ToModel()).ToImmutableList(),
             Notes,
             PerSetWeight

--- a/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.proto
+++ b/LiftLog.Ui/Models/SessionHistoryDao/SessionHistoryDaoV2.proto
@@ -21,7 +21,7 @@ message SessionDaoV2 {
 
 message RecordedExerciseDaoV2 {
     LiftLog.Ui.Models.SessionBlueprintDao.ExerciseBlueprintDaoV2 exercise_blueprint = 1;
-    LiftLog.Ui.Models.DecimalValue weight = 2;
+    optional LiftLog.Ui.Models.DecimalValue weight = 2; // deprecated
     repeated PotentialSetDaoV2 potential_sets = 3;
     optional google.protobuf.StringValue notes = 4;
     bool per_set_weight = 5;

--- a/LiftLog.Ui/Pages/Settings/AppConfigPage.razor
+++ b/LiftLog.Ui/Pages/Settings/AppConfigPage.razor
@@ -8,6 +8,7 @@
 <md-list>
     <ListSwitch Headline="@UiStrings.UseImperialUnits" SupportingText="@UiStrings.UseImperialUnitsSubtitle" Value="@SettingsState.Value.UseImperialUnits" OnSwitched="SetUseImperialUnits" />
     <ListSwitch Headline="@UiStrings.ShowBodyweight" SupportingText="@UiStrings.ShowBodyweightSubtitle" Value="@SettingsState.Value.ShowBodyweight" OnSwitched="SetShowBodyweight" />
+    <ListSwitch data-cy="split-weight-toggle" Headline="@UiStrings.SplitWeightByDefault" SupportingText="@UiStrings.SplitWeightByDefaultSubtitle" Value="@SettingsState.Value.SplitWeightByDefault" OnSwitched="SetSplitWeightByDefault" />
     <ListSwitch Headline="@UiStrings.ShowFeed" SupportingText="@UiStrings.ShowFeedSubtitle" Value="@SettingsState.Value.ShowFeed" OnSwitched="SetShowFeed" />
 
     <ListSwitch Headline="@UiStrings.ShowTips" SupportingText="@UiStrings.ShowTipsSubtitle" Value="@SettingsState.Value.ShowTips" OnSwitched="SetShowTips" />
@@ -41,6 +42,9 @@
 
     private void SetShowTips(bool value)
         => Dispatcher.Dispatch(new SetShowTipsAction(value));
+
+    private void SetSplitWeightByDefault(bool value)
+        => Dispatcher.Dispatch(new SetSplitWeightByDefaultAction(value));
 
     private void ResetTips()
         => Dispatcher.Dispatch(new SetTipToShowAction(1));

--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -58,7 +58,7 @@ else if (!StatsState.Value.IsLoading && StatsState.Value.OverallView is not null
             <Body>
             <div class="flex flex-col justify-center items-center">
                 <WeightFormat Weight="@overallStats.HeaviestLift?.Weight"/>
-                <span>@overallStats.HeaviestLift?.Blueprint.Name</span>
+                <span>@overallStats.HeaviestLift?.ExerciseName</span>
             </div>
             </Body>
         </SingleValueStatisticsCard>

--- a/LiftLog.Ui/Repository/PreferencesRepository.cs
+++ b/LiftLog.Ui/Repository/PreferencesRepository.cs
@@ -195,4 +195,14 @@ public class PreferencesRepository(IPreferenceStore preferenceStore)
     {
         return await preferenceStore.GetItemAsync("backupReminder") is "True" or null;
     }
+
+    public async Task SetSplitWeightByDefaultAsync(bool splitWeightByDefault)
+    {
+        await preferenceStore.SetItemAsync("splitWeightByDefault", splitWeightByDefault.ToString());
+    }
+
+    public async Task<bool> GetSplitWeightByDefaultAsync()
+    {
+        return await preferenceStore.GetItemAsync("splitWeightByDefault") is "True";
+    }
 }

--- a/LiftLog.Ui/Services/SessionService.cs
+++ b/LiftLog.Ui/Services/SessionService.cs
@@ -93,17 +93,13 @@ public class SessionService(
         RecordedExercise GetNextExercise(ExerciseBlueprint e)
         {
             var lastExercise = latestRecordedExercises.GetValueOrDefault(e);
-            var weight = lastExercise switch
-            {
-                null => 0,
-                { IsSuccessForProgressiveOverload: true } => lastExercise.Weight
-                    + e.WeightIncreaseOnSuccess,
-                _ => lastExercise.Weight,
-            };
             var potentialSets = lastExercise switch
             {
                 null or { PerSetWeight: false } => Enumerable.Repeat(
-                    new PotentialSet(null, weight),
+                    new PotentialSet(
+                        null,
+                        lastExercise?.PotentialSets.FirstOrDefault()?.Weight ?? 0
+                    ),
                     e.Sets
                 ),
                 { IsSuccessForProgressiveOverload: true } => lastExercise.PotentialSets.Select(
@@ -113,7 +109,6 @@ public class SessionService(
             };
             return new RecordedExercise(
                 e,
-                weight,
                 potentialSets.ToImmutableList(),
                 null,
                 splitWeightByDefault || (lastExercise?.PerSetWeight ?? false)

--- a/LiftLog.Ui/Services/SessionService.cs
+++ b/LiftLog.Ui/Services/SessionService.cs
@@ -100,10 +100,21 @@ public class SessionService(
                     + e.WeightIncreaseOnSuccess,
                 _ => lastExercise.Weight,
             };
+            var potentialSets = lastExercise switch
+            {
+                null or { PerSetWeight: false } => Enumerable.Repeat(
+                    new PotentialSet(null, weight),
+                    e.Sets
+                ),
+                { IsSuccessForProgressiveOverload: true } => lastExercise.PotentialSets.Select(
+                    x => new PotentialSet(null, x.Weight + e.WeightIncreaseOnSuccess)
+                ),
+                _ => lastExercise.PotentialSets.Select(x => new PotentialSet(null, x.Weight)),
+            };
             return new RecordedExercise(
                 e,
                 weight,
-                Enumerable.Repeat(new PotentialSet(null, weight), e.Sets).ToImmutableList(),
+                potentialSets.ToImmutableList(),
                 null,
                 splitWeightByDefault || (lastExercise?.PerSetWeight ?? false)
             );

--- a/LiftLog.Ui/Services/SessionService.cs
+++ b/LiftLog.Ui/Services/SessionService.cs
@@ -3,10 +3,12 @@ using Fluxor;
 using LiftLog.Lib;
 using LiftLog.Lib.Models;
 using LiftLog.Ui.Store.CurrentSession;
+using LiftLog.Ui.Store.Settings;
 
 namespace LiftLog.Ui.Services;
 
 public class SessionService(
+    IState<SettingsState> settingsState,
     IState<CurrentSessionState> currentSessionState,
     ProgressRepository progressRepository
 )
@@ -87,6 +89,7 @@ public class SessionService(
         IReadOnlyDictionary<KeyedExerciseBlueprint, RecordedExercise> latestRecordedExercises
     )
     {
+        var splitWeightByDefault = settingsState.Value.SplitWeightByDefault;
         RecordedExercise GetNextExercise(ExerciseBlueprint e)
         {
             var lastExercise = latestRecordedExercises.GetValueOrDefault(e);
@@ -102,7 +105,7 @@ public class SessionService(
                 weight,
                 Enumerable.Repeat(new PotentialSet(null, weight), e.Sets).ToImmutableList(),
                 null,
-                lastExercise?.PerSetWeight ?? false
+                splitWeightByDefault || (lastExercise?.PerSetWeight ?? false)
             );
         }
 

--- a/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor
@@ -1,7 +1,6 @@
  @{
     var splitWeights = (Exercise.PerSetWeight
-        && !Exercise.PotentialSets.All(s => s.Weight == Exercise.Weight))
-        || Exercise.PotentialSets.DistinctBy(x=>x.Set?.RepsCompleted).Count() != 1;
+        && Exercise.PotentialSets.DistinctBy(x=>x.Set?.RepsCompleted).Count() != 1);
     var numCompletedSets = Exercise.PotentialSets.Count(x => x.Set != null);
     var maxNumReps = Exercise.PotentialSets.Max(x => x.Set?.RepsCompleted ?? 0);
 
@@ -34,7 +33,7 @@
 
             @if (ShowWeight)
             {
-                <WeightFormat Weight="@Exercise.Weight"/>
+                <WeightFormat Weight="@Exercise.MaxWeight"/>
             }
         </span>
         }

--- a/LiftLog.Ui/Shared/Presentation/ListSwitch.razor
+++ b/LiftLog.Ui/Shared/Presentation/ListSwitch.razor
@@ -2,7 +2,7 @@
 <md-list-item type="button" class="text-start" @onclick="()=>OnSwitched.InvokeAsync(!Value)" >
         <span slot="headline" >@Headline</span>
         <span slot="supporting-text" >@SupportingText</span>
-    <md-switch slot="end" @attributes="AdditionalAttributes" @ref="_switchRef" @onchange="HandleInput" selected="@Value"></md-switch>
+    <md-switch  @attributes="AdditionalAttributes" slot="end" @ref="_switchRef" @onchange="HandleInput" selected="@Value"></md-switch>
 </md-list-item>
 
 @code{

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -41,7 +41,7 @@
             [transition:height_150ms_cubic-bezier(0.4,0,0.2,1),margin_150ms_cubic-bezier(0.4,0,0.2,1),width_150ms_cubic-bezier(0.4,0,0.2,1),transform_400ms]
             @WeightDisplayScale">
             <WeightDisplay
-                Weight="displayedExercise.Weight"
+                Weight="displayedExercise.MaxWeight"
                 Increment="displayedExercise.Blueprint.WeightIncreaseOnSuccess"
                 UpdateWeight="w => { if (w is not null) UpdateWeightForExercise(w.Value); }"
                 IsReadonly="IsReadonly"/>

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -37,13 +37,16 @@
                 </div>
             }
         </div>
-        <div class="self-start -m-3 -mt-4">
+        <div class="self-start
+            [transition:height_150ms_cubic-bezier(0.4,0,0.2,1),margin_150ms_cubic-bezier(0.4,0,0.2,1),width_150ms_cubic-bezier(0.4,0,0.2,1),transform_400ms]
+            @WeightDisplayScale">
             <WeightDisplay
                 Weight="displayedExercise.Weight"
                 Increment="displayedExercise.Blueprint.WeightIncreaseOnSuccess"
                 UpdateWeight="w => { if (w is not null) UpdateWeightForExercise(w.Value); }"
                 IsReadonly="IsReadonly"/>
         </div>
+
     </div>
     <div class="flex justify-start flex-wrap gap-2">
         @foreach (var (i, set) in displayedExercise.PotentialSets.Index())
@@ -153,6 +156,8 @@
     [Parameter] public bool IsReadonly { get; set; } = false;
 
     [EditorRequired] [Parameter] public bool ShowPreviousButton { get; set; }
+
+    private string WeightDisplayScale => !RecordedExercise.PerSetWeight ? "h-12 -m-3 -mt-4" : "h-0 m-0";
 
     private void HandleNotesChange(string value)
     {

--- a/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
+++ b/LiftLog.Ui/Shared/Presentation/WeightedExercise.razor
@@ -157,7 +157,7 @@
 
     [EditorRequired] [Parameter] public bool ShowPreviousButton { get; set; }
 
-    private string WeightDisplayScale => !RecordedExercise.PerSetWeight ? "h-12 -m-3 -mt-4" : "h-0 m-0";
+    private string WeightDisplayScale => !RecordedExercise.PerSetWeight ? "h-12 -m-3 -mt-4" : "h-0 m-0 overflow-hidden";
 
     private void HandleNotesChange(string value)
     {

--- a/LiftLog.Ui/Store/AiSessionCreator/AiSessionCreatorEffects.cs
+++ b/LiftLog.Ui/Store/AiSessionCreator/AiSessionCreatorEffects.cs
@@ -23,7 +23,7 @@ public class ProgramEffects(
         {
             var latestExercises = (await progressRepository.GetLatestRecordedExercisesAsync())
                 .GroupBy(x => x.Key.Name)
-                .ToImmutableDictionary(x => x.Key, x => x.First().Value.Weight);
+                .ToImmutableDictionary(x => x.Key, x => x.First().Value.MaxWeightLifted);
 
             var generatedSession = await aiWorkoutPlanner.GenerateSessionAsync(
                 new(

--- a/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
+++ b/LiftLog.Ui/Store/CurrentSession/CurrentSessionReducers.cs
@@ -100,7 +100,7 @@ public static class CurrentSessionReducers
                 .Range(0, newExerciseBlueprint.Sets)
                 .Select(index =>
                     existingExercise.PotentialSets.ElementAtOrDefault(index)
-                    ?? new PotentialSet(null, existingExercise.Weight)
+                    ?? new PotentialSet(null, existingExercise.MaxWeight)
                 )
                 .ToImmutableList(),
         };
@@ -134,7 +134,6 @@ public static class CurrentSessionReducers
         var newExerciseBlueprint = action.ExerciseBlueprint;
         var newExercise = new RecordedExercise(
             newExerciseBlueprint,
-            0,
             Enumerable
                 .Repeat(new PotentialSet(null, 0), newExerciseBlueprint.Sets)
                 .ToImmutableList(),
@@ -255,7 +254,7 @@ public static class CurrentSessionReducers
     {
         var session = ActiveSession(state, action.Target) ?? throw new Exception();
         var exerciseAtIndex = session.RecordedExercises[action.ExerciseIndex];
-        var previousWeight = exerciseAtIndex.Weight;
+        var previousWeight = exerciseAtIndex.MaxWeight;
         var newPotentialSets = exerciseAtIndex
             .PotentialSets.Select(set =>
                 !exerciseAtIndex.PerSetWeight || (set.Weight == previousWeight && set.Set is null)
@@ -275,7 +274,6 @@ public static class CurrentSessionReducers
                     action.ExerciseIndex,
                     exerciseAtIndex with
                     {
-                        Weight = action.Weight,
                         PotentialSets = newPotentialSets,
                     }
                 ),

--- a/LiftLog.Ui/Store/Settings/SettingsActions.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsActions.cs
@@ -53,3 +53,5 @@ public record SetLastBackupTimeAction(DateTimeOffset Time);
 public record SetBackupReminderAction(bool ShowReminder);
 
 public record ExportPlainTextAction(PlaintextExportFormat Format);
+
+public record SetSplitWeightByDefaultAction(bool SplitWeightByDefault);

--- a/LiftLog.Ui/Store/Settings/SettingsEffects.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsEffects.cs
@@ -221,6 +221,15 @@ internal class SettingsEffects(
     }
 
     [EffectMethod]
+    public async Task HandleSetSplitWeightByDefaultAction(
+        SetSplitWeightByDefaultAction action,
+        IDispatcher _
+    )
+    {
+        await preferencesRepository.SetSplitWeightByDefaultAsync(action.SplitWeightByDefault);
+    }
+
+    [EffectMethod]
     public async Task ExecuteRemoteBackup(ExecuteRemoteBackupAction action, IDispatcher dispatcher)
     {
         var (endpoint, apiKey, includeFeedAccount) = action.Settings;

--- a/LiftLog.Ui/Store/Settings/SettingsReducers.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsReducers.cs
@@ -94,4 +94,10 @@ public static class SettingsReducers
         SettingsState state,
         SetLastSuccessfulRemoteBackupHashAction action
     ) => state with { LastSuccessfulRemoteBackupHash = action.Hash };
+
+    [ReducerMethod]
+    public static SettingsState SetSplitWeightByDefault(
+        SettingsState state,
+        SetSplitWeightByDefaultAction action
+    ) => state with { SplitWeightByDefault = action.SplitWeightByDefault };
 }

--- a/LiftLog.Ui/Store/Settings/SettingsState.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsState.cs
@@ -18,7 +18,8 @@ public record SettingsState(
     RemoteBackupSettings RemoteBackupSettings,
     string LastSuccessfulRemoteBackupHash,
     DateTimeOffset LastBackupTime,
-    bool BackupReminder
+    bool BackupReminder,
+    bool SplitWeightByDefault
 )
 {
     public static SettingsState Default =>
@@ -37,7 +38,8 @@ public record SettingsState(
             RemoteBackupSettings: new RemoteBackupSettings(string.Empty, string.Empty, false),
             LastSuccessfulRemoteBackupHash: string.Empty,
             LastBackupTime: DateTimeOffset.MinValue,
-            BackupReminder: true
+            BackupReminder: true,
+            SplitWeightByDefault: false
         );
 }
 

--- a/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
+++ b/LiftLog.Ui/Store/Settings/SettingsStateInitMiddleware.cs
@@ -24,7 +24,8 @@ public class SettingsStateInitMiddleware(
                 remoteBackupSettings,
                 lastSuccessfulRemoteBackupHash,
                 lastBackupTime,
-                backupReminder
+                backupReminder,
+                splitWeightByDefault
             ) = await (
                 preferencesRepository.GetUseImperialUnitsAsync(),
                 preferencesRepository.GetShowBodyweightAsync(),
@@ -35,7 +36,8 @@ public class SettingsStateInitMiddleware(
                 preferencesRepository.GetRemoteBackupSettingsAsync(),
                 preferencesRepository.GetLastSuccessfulRemoteBackupHashAsync(),
                 preferencesRepository.GetLastBackupTimeAsync(),
-                preferencesRepository.GetBackupReminderAsync()
+                preferencesRepository.GetBackupReminderAsync(),
+                preferencesRepository.GetSplitWeightByDefaultAsync()
             );
 
             var state = (SettingsState)store.Features[nameof(SettingsFeature)].GetState() with
@@ -51,6 +53,7 @@ public class SettingsStateInitMiddleware(
                 LastSuccessfulRemoteBackupHash = lastSuccessfulRemoteBackupHash,
                 LastBackupTime = lastBackupTime,
                 BackupReminder = backupReminder,
+                SplitWeightByDefault = splitWeightByDefault,
             };
             store.Features[nameof(SettingsFeature)].RestoreState(state);
             sw.Stop();

--- a/LiftLog.Ui/Store/Stats/StatsEffects.cs
+++ b/LiftLog.Ui/Store/Stats/StatsEffects.cs
@@ -131,7 +131,9 @@ public class StatsEffects(
                     new GranularStatisticView(
                         AverageTimeBetweenSets: averageTimeBetweenSets,
                         AverageSessionLength: averageSessionLength,
-                        HeaviestLift: heaviestLift,
+                        HeaviestLift: heaviestLift is null
+                            ? null
+                            : new(heaviestLift.Blueprint.Name, heaviestLift.MaxWeightLifted),
                         ExerciseMostTimeSpent: exerciseMostTimeSpent,
                         ExerciseStats: exerciseStats,
                         SessionStats: sessionStats,

--- a/LiftLog.Ui/Store/Stats/StatsState.cs
+++ b/LiftLog.Ui/Store/Stats/StatsState.cs
@@ -46,7 +46,7 @@ public record TimeTrackedStatistic(DateTime DateTime, decimal Value);
 public record GranularStatisticView(
     TimeSpan AverageTimeBetweenSets,
     TimeSpan AverageSessionLength,
-    RecordedExercise? HeaviestLift,
+    HeaviestLift? HeaviestLift,
     TimeSpentExercise? ExerciseMostTimeSpent,
     ImmutableListValue<ExerciseStatistics> ExerciseStats,
     ImmutableListValue<StatisticOverTime> SessionStats,
@@ -54,3 +54,5 @@ public record GranularStatisticView(
 );
 
 public record TimeSpentExercise(string ExerciseName, TimeSpan TimeSpent);
+
+public record HeaviestLift(string ExerciseName, decimal Weight);

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -904,4 +904,10 @@
   <data name="BackupRemindersSubtitle" xml:space="preserve">
     <value>Periodically suggest a backup when you have not backed up in a while</value>
   </data>
+  <data name="SplitWeightByDefault" xml:space="preserve">
+    <value>Individual weights per set</value>
+  </data>
+  <data name="SplitWeightByDefaultSubtitle" xml:space="preserve">
+    <value>Allow you to set the weight of each exercise set by default</value>
+  </data>
 </root>

--- a/tests/LiftLog.Tests.App/Reducers/CurrentSessionReducerTests.cs
+++ b/tests/LiftLog.Tests.App/Reducers/CurrentSessionReducerTests.cs
@@ -22,7 +22,6 @@ public class CurrentSessionReducerTests
                   exercise with
                   {
                     PerSetWeight = false,
-                    Weight = 10m,
                     PotentialSets = Sessions
                       .CreatePotentialSet(10m, isEmpty: true)
                       .Repeat(exercise.Blueprint.Sets - 1)
@@ -39,7 +38,6 @@ public class CurrentSessionReducerTests
                   exercise with
                   {
                     PerSetWeight = true,
-                    Weight = 20m,
                     PotentialSets = Sessions
                       .CreatePotentialSet(20m, isEmpty: true)
                       .Repeat(exercise.Blueprint.Sets - 1)
@@ -84,7 +82,9 @@ public class CurrentSessionReducerTests
           };
         });
 
-        It("Should only update sets which are incomplete")
+        It(
+            "Should  not update the weight of any set, as top level weight isn't possible to be updated when PerSetWeight is true"
+          )
           .When(() =>
           {
             var action = new UpdateExerciseWeightAction(
@@ -95,12 +95,11 @@ public class CurrentSessionReducerTests
 
             var newState = CurrentSessionReducers.UpdateExerciseWeight(_initialState, action);
 
-            newState.WorkoutSession!.RecordedExercises[1].Weight.Should().Be(50m);
             newState
               .WorkoutSession!.RecordedExercises[1]
               .PotentialSets.Take(2)
               .Should()
-              .AllSatisfy(x => x.Weight.Should().Be(50m));
+              .AllSatisfy(x => x.Weight.Should().Be(20m));
             newState.WorkoutSession!.RecordedExercises[1].PotentialSets[2].Weight.Should().Be(60m);
           });
       });
@@ -119,7 +118,6 @@ public class CurrentSessionReducerTests
 
             var newState = CurrentSessionReducers.UpdateExerciseWeight(_initialState, action);
 
-            newState.WorkoutSession!.RecordedExercises[0].Weight.Should().Be(50m);
             newState
               .WorkoutSession!.RecordedExercises[0]
               .PotentialSets.Should()

--- a/tests/LiftLog.Tests.App/Serialization/SerializationTests.cs
+++ b/tests/LiftLog.Tests.App/Serialization/SerializationTests.cs
@@ -11,36 +11,6 @@ public class SerializationTests
   [Describe("Serialization")]
   public static void Spec()
   {
-    Describe("SessionHistoryDaoV1")
-      .As(() =>
-      {
-        It("Serializes then deserializes to an equivalent object")
-          .When(() =>
-          {
-            var session = Sessions.CreateSession();
-            var sessionHistoryDao = SessionHistoryDaoV1.FromModel(
-              new SessionHistoryDaoContainer(
-                CompletedSessions: new Dictionary<Guid, Session>
-                {
-                  { session.Id, session },
-                }.ToImmutableDictionary()
-              )
-            );
-
-            var serialized = JsonSerializer.Serialize(
-              sessionHistoryDao,
-              StorageJsonContext.Context.SessionHistoryDaoV1
-            );
-            var deserialized = JsonSerializer.Deserialize(
-              serialized,
-              StorageJsonContext.Context.SessionHistoryDaoV1
-            );
-
-            deserialized!.Should().Be(sessionHistoryDao);
-            deserialized!.ToModel().CompletedSessions.First().Value.Should().Be(session);
-          });
-      });
-
     Describe("SessionHistoryDaoV2")
       .As(() =>
       {

--- a/tests/LiftLog.Tests.App/Sessions.cs
+++ b/tests/LiftLog.Tests.App/Sessions.cs
@@ -35,7 +35,6 @@ public static class Sessions
     return (transform ?? (e => e)).Invoke(
       new RecordedExercise(
         Blueprint: exerciseBlueprint,
-        Weight: 0m,
         PotentialSets: Enumerable
           .Range(0, exerciseBlueprint.Sets)
           .Select(


### PR DESCRIPTION
Splitting each set into having its own weight has always kept this idea of "main" weight, which is the top level weight.  Progressive overload was driven by this main weight, and the next time a user completed an exercise, LiftLog would ignore the "per set" weight choices from the previous session.  This PR does two things:
1. When specifying per set weight, there is no longer a "main" weight
2. The next time you start an exercise, each set inherits the weight of the previous session's set (plus progressive overload)

This essentially removes the idea of a "main" weight, and in most places just replaces it with any of the set's weights (we use max).

Note that there is no "main" weight on squats since it is split by set
<img width="387" alt="image" src="https://github.com/user-attachments/assets/5c3257a0-8922-465d-8f9b-8823280f11cb" />
