### PR TITLE
fix: Previously lifted exercise chips split

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -31,7 +31,7 @@ jobs:
           ELECTRON_ENABLE_LOGGING: 1
         with:
           start: npm run server-ci
-          wait-on: http://localhost:5000
+          wait-on: http://localhost:5001
           working-directory: ./LiftLog.Cypress
       - name: Upload screenshots
         uses: actions/upload-artifact@v4

--- a/LiftLog.Cypress/cypress.config.js
+++ b/LiftLog.Cypress/cypress.config.js
@@ -8,7 +8,7 @@ module.exports = defineConfig({
     viewportHeight: 800,
     viewportWidth: 400,
     defaultCommandTimeout: 10000,
-    baseUrl: 'http://127.0.0.1:5000',
+    baseUrl: 'http://127.0.0.1:5001',
     video: true
   },
 });

--- a/LiftLog.Ui/Pages/Feed/FeedUserPlanPage.razor
+++ b/LiftLog.Ui/Pages/Feed/FeedUserPlanPage.razor
@@ -14,7 +14,7 @@
 <div class="flex flex-col gap-4">
     <CardList Items="plan">
         <SessionSummaryTitle Session="context.GetEmptySession()" IsFilled="false"/>
-        <SessionSummary Session="context.GetEmptySession()" ShowSets="true" ShowWeight="false"/>
+        <SessionSummary Session="context.GetEmptySession()" IsFilled="false" />
     </CardList>
     <div>
         <AppButton OnClick="() => importPlanDialog?.Open()" Icon="assignment">@UiStrings.ImportTheirPlan</AppButton>

--- a/LiftLog.Ui/Pages/History/HistoryPage.razor
+++ b/LiftLog.Ui/Pages/History/HistoryPage.razor
@@ -38,7 +38,7 @@ else
                 <SessionSummaryTitle IsFilled="true" Session="context" ></SessionSummaryTitle>
             </TitleContent>
             <MainContent>
-                <SessionSummary Session="context" ShowSets="true"></SessionSummary>
+                <SessionSummary Session="context" ></SessionSummary>
             </MainContent>
 
         </SplitCardControl>

--- a/LiftLog.Ui/Pages/Index.razor
+++ b/LiftLog.Ui/Pages/Index.razor
@@ -50,7 +50,7 @@ else
                 <SessionSummaryTitle IsFilled="context.Item.IsStarted" Session="context.Item" />
             </TitleContent>
             <MainContent>
-                <SessionSummary ShowSets=true Session="context.Item" IsFilled="false"></SessionSummary>
+                <SessionSummary Session="context.Item" IsFilled="false"></SessionSummary>
             </MainContent>
         </SplitCardControl>
     </CardList>

--- a/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor
@@ -1,71 +1,36 @@
- @{
-    var splitWeights = (Exercise.PerSetWeight
-        && Exercise.PotentialSets.DistinctBy(x=>x.Set?.RepsCompleted).Count() != 1);
-    var numCompletedSets = Exercise.PotentialSets.Count(x => x.Set != null);
-    var maxNumReps = Exercise.PotentialSets.Max(x => x.Set?.RepsCompleted ?? 0);
 
-    var (numSets, numReps) = IsFilled switch
-    {
-        true => (numCompletedSets, maxNumReps),
-        false => (Exercise.Blueprint.Sets, Exercise.Blueprint.RepsPerSet)
-    };
-}
-<span class="flex items-center">
+<span class="flex items-center gap-2">
     @if(ShowName)
     {
         <span>@Exercise.Blueprint.Name</span>
     }
-    @if(ShowSets || ShowWeight)
-    {
-        @if(!splitWeights)
+    <span class="flex ml-auto overflow-x-auto gap-1">
+        @if(IsFilled)
         {
-        <span class="flex justify-around ml-auto items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
-
-            @if (ShowSets)
+            @foreach(var chip in GetWeightAndRepsChips())
             {
-                <span>@(numSets)x@(numReps)
+                <span class="flex items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
+                    <span>@(chip.RepsCompleted?.ToString() ?? "-")</span><span class="text-2xs">@@</span>
+                    <WeightFormat Weight="@chip.Weight"/>
                 </span>
-                @if(ShowWeight)
-                {
-                    <span class="text-2xs">@@</span>
-                }
             }
-
-            @if (ShowWeight)
-            {
-                <WeightFormat Weight="@Exercise.MaxWeight"/>
-            }
-        </span>
-        }
-
-        @if (ShowWeight && splitWeights)
+        } else
         {
-            <span class="flex ml-auto flex-wrap justify-end gap-1">
-                @foreach(var set in Exercise.PotentialSets)
-                {
-                    if(set.Set?.RepsCompleted == null)
-                    {
-                        continue;
-                    }
-                    <span class="flex items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
-                        @if (ShowSets){
-                            <span>@(set.Set?.RepsCompleted ?? Exercise.Blueprint.RepsPerSet)</span><span class="text-2xs">@@</span>
-                        }
-                        <WeightFormat Weight="@set.Weight"/>
-                    </span>
-                }
-            </span>
+
+            @foreach(var chip in GetPlannedChipData())
+            {
+                <span class="flex items-center gap-0.5 bg-surface-container-highest text-on-surface-variant rounded-md py-1 px-2">
+                    <span>@(chip.NumSets)x@(chip.RepTarget)</span><span class="text-2xs">@@</span>
+                    <WeightFormat Weight="@chip.Weight"/>
+                </span>
+            }
         }
-    }
+    </span>
 </span>
 
 @code
 {
     [EditorRequired] [Parameter] public RecordedExercise Exercise { get; set; } = null!;
-
-    [Parameter] public bool ShowSets { get; set; }
-
-    [Parameter] public bool ShowWeight { get; set; }
 
     [Parameter] public bool ShowName { get; set; }
 

--- a/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor.cs
+++ b/LiftLog.Ui/Shared/Presentation/ExerciseSummary.razor.cs
@@ -1,0 +1,30 @@
+namespace LiftLog.Ui.Shared.Presentation;
+
+public record WeightAndRepsChipData(int? RepsCompleted, int RepTarget, decimal Weight);
+
+public record PotentialSetChipData(int RepTarget, int NumSets, decimal Weight);
+
+public partial class ExerciseSummary
+{
+    private IEnumerable<WeightAndRepsChipData> GetWeightAndRepsChips()
+    {
+        var chips = Exercise.PotentialSets.Select(set => new WeightAndRepsChipData(
+            set.Set?.RepsCompleted,
+            Exercise.Blueprint.RepsPerSet,
+            set.Weight
+        ));
+
+        return chips;
+    }
+
+    private IEnumerable<PotentialSetChipData> GetPlannedChipData()
+    {
+        return Exercise
+            .PotentialSets.GroupBy(x => x.Weight)
+            .Select(x => new PotentialSetChipData(
+                Exercise.Blueprint.RepsPerSet,
+                x.Count(),
+                x.First().Weight
+            ));
+    }
+}

--- a/LiftLog.Ui/Shared/Presentation/FeedItemCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/FeedItemCardContent.razor
@@ -5,7 +5,7 @@
             <SessionSummaryTitle IsFilled="true" Session="sessionFeedItem.Session" />
         </TitleContent>
         <MainContent>
-            <SessionSummary ShowSets=true Session="sessionFeedItem.Session"></SessionSummary>
+            <SessionSummary Session="sessionFeedItem.Session"></SessionSummary>
             <span class="text-start mt-2"><LimitedHtml Value="@UiStrings.FeedUserCompletedAWorkout(User.DisplayName)" /></span>
         </MainContent>
     </SplitCardControl>

--- a/LiftLog.Ui/Shared/Presentation/ManageWorkoutCardContent.razor
+++ b/LiftLog.Ui/Shared/Presentation/ManageWorkoutCardContent.razor
@@ -12,7 +12,7 @@
         </Menu>
     </Actions>
     <MainContent>
-        <SessionSummary Session="SessionBlueprint.GetEmptySession()" ShowSets="true" ShowWeight="false"/>
+        <SessionSummary Session="SessionBlueprint.GetEmptySession()" IsFilled="false"/>
     </MainContent>
 </SplitCardControl>
 

--- a/LiftLog.Ui/Shared/Presentation/PreviousExerciseViewer.razor
+++ b/LiftLog.Ui/Shared/Presentation/PreviousExerciseViewer.razor
@@ -5,8 +5,6 @@
         <span>@exercise.DateTime.Date.ToShortDateString()</span>
         <ExerciseSummary
             Exercise=exercise.RecordedExercise
-            ShowSets=true
-            ShowWeight=true
             ShowName=false />
     </div>
     <md-divider class="last:hidden"></md-divider>

--- a/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
+++ b/LiftLog.Ui/Shared/Presentation/SessionSummary.razor
@@ -4,8 +4,6 @@
     {
        <ExerciseSummary
             Exercise=exercise
-            ShowSets=ShowSets
-            ShowWeight=ShowWeight
             IsFilled=IsFilled
             ShowName=true />
         <md-divider class="last:hidden"></md-divider>
@@ -16,9 +14,6 @@
 {
     [EditorRequired] [Parameter] public Session Session { get; set; } = null!;
 
-    [Parameter] public bool ShowSets { get; set; }
-
-    [Parameter] public bool ShowWeight { get; set; } = true;
 
     [Parameter] public bool IsFilled { get; set; } = true;
 }

--- a/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SharedProgramBlueprintComponent.razor
@@ -9,7 +9,7 @@
                 <SessionSummaryTitle Session="context.GetEmptySession()" />
             </TitleContent>
             <MainContent>
-                <SessionSummary Session="context.GetEmptySession()" ShowSets="true" ShowWeight="false"/>
+                <SessionSummary Session="context.GetEmptySession()" IsFilled="false"/>
             </MainContent>
         </SplitCardControl>
     </CardList>

--- a/LiftLog.Web/Properties/AssemblyInfo.cs
+++ b/LiftLog.Web/Properties/AssemblyInfo.cs
@@ -1,4 +1,1 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 [assembly: System.Runtime.Versioning.SupportedOSPlatform("browser")]

--- a/LiftLog.Web/Properties/launchSettings.json
+++ b/LiftLog.Web/Properties/launchSettings.json
@@ -3,11 +3,11 @@
     "LiftLog.Web": {
       "commandName": "Project",
       "launchBrowser": false,
-      "launchUrl": "https://0.0.0.0:5001",
+      "launchUrl": "https://0.0.0.0:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://0.0.0.0:5001;http://0.0.0.0:5000",
+      "applicationUrl": "https://0.0.0.0:5002;http://0.0.0.0:5001",
       "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/debug?browser={browserInspectUri}"
     }
   }


### PR DESCRIPTION
A regression caused the history / previously done exercise chips to show the same amount of reps and weight, no matter how much was actually lifted. This PR fixes this behaviour, and displays the chips in a scrolling panel rather than stacked.

Fixes: #404 #408

For a workout completed as such:
<img width="328" alt="image" src="https://github.com/user-attachments/assets/66bee2fd-a980-401f-b748-8462ee65742e" />

Previously:
<img width="363" alt="image" src="https://github.com/user-attachments/assets/1998fde4-442f-47e7-a774-7f495928bd6b" />



Now:
<img width="358" alt="image" src="https://github.com/user-attachments/assets/20f06e28-c571-4433-a231-c877c39d3692" />
