### PR TITLE
Add confirmation dialog before finishing workout session

### DIFF
--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -390,7 +390,8 @@ OnClose="@(() => _exerciseToEditIndex = null)"
 
     private void BeginSaveSession()
     {
-        if (SessionTarget == SessionTarget.WorkoutSession)
+        // check if workout session has exercises remaining
+        if (SessionTarget == SessionTarget.WorkoutSession && Session?.IsComplete == false)
         {
             // display confirmation message
             finishWorkoutDialogue?.Open();

--- a/LiftLog.Ui/Shared/Smart/SessionComponent.razor
+++ b/LiftLog.Ui/Shared/Smart/SessionComponent.razor
@@ -22,21 +22,21 @@ else
 {
     <ItemList Items="Session.RecordedExercises.Index()">
         <WeightedExercise
-            @key=context.Index
-            RecordedExercise="context.Item"
-            ToStartNext=@(Session.NextExercise == context.Item)
-            CycleRepCountForSet=CycleRepCountForExerciseSet(context.Index)
-            ShowAdditionalActionsForSet=@(ShowAdditionalActionsForExerciseSet(context.Index))
-            UpdateWeightForExercise=UpdateWeightForExerciseWrapper(context.Index)
-            PreviousRecordedExercises=@(PreviouslyCompleted.GetValueOrDefault(context.Item.Blueprint, []))
-            ToggleExercisePerSetWeight=@(() => ToggleExercisePerSetWeight(context.Index))
-            UpdateWeightForSet=@((setIndex, weight) => UpdateWeightForSet(context.Index, setIndex, weight))
-            UpdateNotesForExercise=@((notes) => UpdateNotesForExercise(context.Index, notes))
-            OnEditExercise=@(() => BeginEditExercise(context.Index))
-            OnRemoveExercise=@(() => BeginRemoveExercise(context.Index))
-            OnOpenLink=@(() => Dispatcher.Dispatch(new OpenExternalUrlAction(context.Item.Blueprint.Link.Trim())))
-            IsReadonly=IsReadonly
-            ShowPreviousButton=@(SessionTarget == SessionTarget.WorkoutSession) />
+        @key=context.Index
+        RecordedExercise="context.Item"
+        ToStartNext=@(Session.NextExercise == context.Item)
+        CycleRepCountForSet=CycleRepCountForExerciseSet(context.Index)
+        ShowAdditionalActionsForSet=@(ShowAdditionalActionsForExerciseSet(context.Index))
+        UpdateWeightForExercise=UpdateWeightForExerciseWrapper(context.Index)
+        PreviousRecordedExercises=@(PreviouslyCompleted.GetValueOrDefault(context.Item.Blueprint, []))
+        ToggleExercisePerSetWeight=@(() => ToggleExercisePerSetWeight(context.Index))
+        UpdateWeightForSet=@((setIndex, weight) => UpdateWeightForSet(context.Index, setIndex, weight))
+        UpdateNotesForExercise=@((notes) => UpdateNotesForExercise(context.Index, notes))
+        OnEditExercise=@(() => BeginEditExercise(context.Index))
+        OnRemoveExercise=@(() => BeginRemoveExercise(context.Index))
+        OnOpenLink=@(() => Dispatcher.Dispatch(new OpenExternalUrlAction(context.Item.Blueprint.Link.Trim())))
+        IsReadonly=IsReadonly
+        ShowPreviousButton=@(SessionTarget == SessionTarget.WorkoutSession) />
     </ItemList>
 }
 @if (ShowBodyweight)
@@ -77,20 +77,20 @@ else
 @if(IsInActiveScreen && !IsReadonly)
 {
     <Microsoft.AspNetCore.Components.Sections.SectionContent SectionName="TrailingTitleButton">
-        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=SaveSession data-cy="save-session-button">
+        <AppButton class="text-lg" Type=AppButtonType.Text OnClick=BeginSaveSession data-cy="save-session-button">
             @(SessionTarget == SessionTarget.WorkoutSession ? UiStrings.Finish : UiStrings.Save)
         </AppButton>
     </Microsoft.AspNetCore.Components.Sections.SectionContent>
 }
 
 <FullScreenDialog
-    @ref=_editExerciseDialog
-    Title=@(_exerciseToEditIndex is null ? UiStrings.AddExercise : UiStrings.EditExercise)
-    Action="@(_exerciseToEditIndex is null ? UiStrings.Add : UiStrings.Update)"
-    OnAction="EditExerciseHandler"
-    OnClose="@(() => _exerciseToEditIndex = null)"
-    >
-        <ExerciseEditor Exercise="editingExerciseBlueprint" UpdateExercise="(ex) => {editingExerciseBlueprint = ex; StateHasChanged();}" />
+@ref=_editExerciseDialog
+Title=@(_exerciseToEditIndex is null ? UiStrings.AddExercise : UiStrings.EditExercise)
+Action="@(_exerciseToEditIndex is null ? UiStrings.Add : UiStrings.Update)"
+OnAction="EditExerciseHandler"
+OnClose="@(() => _exerciseToEditIndex = null)"
+>
+    <ExerciseEditor Exercise="editingExerciseBlueprint" UpdateExercise="(ex) => {editingExerciseBlueprint = ex; StateHasChanged();}" />
 </FullScreenDialog>
 
 <Dialog @ref="setAdditionalActionsDialog" PreventCancel=true>
@@ -100,7 +100,7 @@ else
         var set = exercise.PotentialSets[setAdditionalActions.Value.PotentialSetIndex];
         <span slot="headline" class="select-none">@UiStrings.SelectReps</span>
         <span slot="content" >
-        <PotentialSetAdditionalActions
+            <PotentialSetAdditionalActions
             Set="set"
             MaxReps=exercise.Blueprint.RepsPerSet
             OnSelectRepCount="@((reps)=>{
@@ -152,6 +152,13 @@ else
     </div>
 </Dialog>
 
+<ConfirmationDialog @ref="finishWorkoutDialogue" OkText="@UiStrings.Yes" OnOk="SaveSession">
+    <Headline>@UiStrings.Finish</Headline>
+    <TextContent>
+        <LimitedHtml Value=@(UiStrings.FinishWorkout) />
+    </TextContent>
+</ConfirmationDialog>
+
 @code {
 
     private ExerciseBlueprint editingExerciseBlueprint = ExerciseBlueprint.Default;
@@ -163,6 +170,7 @@ else
     private Dialog? _removeExerciseDialog;
     private Dialog? _updatePlanDialog;
     private Dialog? setAdditionalActionsDialog;
+    private ConfirmationDialog? finishWorkoutDialogue;
 
     private Session Session => SessionTarget switch {
         SessionTarget.WorkoutSession => CurrentSessionState.Value.WorkoutSession,
@@ -340,7 +348,8 @@ else
                         </span>
                     </span>
                 </span>
-            </SnackBar>;
+            </SnackBar>
+    ;
         }
 
         return null;
@@ -379,8 +388,23 @@ else
         }
     }
 
+    private void BeginSaveSession()
+    {
+        if (SessionTarget == SessionTarget.WorkoutSession)
+        {
+            // display confirmation message
+            finishWorkoutDialogue?.Open();
+        }
+        else
+        {
+            SaveSession();
+        }
+    }
+
     private void SaveSession()
     {
+        finishWorkoutDialogue?.Close();
+
         Dispatcher.Dispatch(new PersistCurrentSessionAction(SessionTarget));
         var id = CurrentSessionState.Value.WorkoutSession?.Id;
         if (Session is not null)

--- a/LiftLog.Ui/i18n/UiStrings.resx
+++ b/LiftLog.Ui/i18n/UiStrings.resx
@@ -1,5 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -922,5 +981,8 @@
   </data>
   <data name="NewPlanDefaultName" xml:space="preserve">
     <value>The default name given when a user creates a new plan</value>
+  </data>
+  <data name="FinishWorkout" xml:space="preserve">
+    <value>You are about to finish your workout. Are you sure?</value>
   </data>
 </root>


### PR DESCRIPTION
### What's Been Done:
- Added a confirmation dialog for the "Finish" button in the workout session flow.
- The dialog appears when the session target is WorkoutSession, allowing users to confirm before ending workout.
- If not a workout session, SaveSession is called directly without confirmation.

### Pending:
- **Language support**: The confirmation dialog text has been added to the resource file in English, but language translations are not yet included.
- **Testing**: The feature has not been fully tested yet, though it has been implemented with the same logic in other Razor pages.

### Related Issue: 
Add confirmation to “Finish” button #439