### PR TITLE
fix: NPE in session select on stats page

### DIFF
--- a/LiftLog.Ui/Pages/StatsPage.razor
+++ b/LiftLog.Ui/Pages/StatsPage.razor
@@ -13,7 +13,7 @@
         Options="SessionSelectOptions"
         Value="StatsState.Value.OverallViewSessionName"
         ValueChanged="HandleSessionSelectChanged"
-        EqualsComparer="(a,b)=>a.Equals(b)" />
+        EqualsComparer="(a,b)=>a?.Equals(b) ?? (a is null && b is null)" />
     <Select
         data-cy="stats-time-selector"
         T="TimeSpan"


### PR DESCRIPTION
For some reason NRE is not working on this razor page - so the possible null pointer was not caught at compile time.

Fixes: #445