### PR TITLE
Fix RestBetween string showing wrong rest times with Spanish localization

### DIFF
--- a/LiftLog.Ui/i18n/UiStrings.es.resx
+++ b/LiftLog.Ui/i18n/UiStrings.es.resx
@@ -304,7 +304,7 @@
     <value>Descanse &lt;em&gt;{0}&lt;/em&gt;</value>
   </data>
   <data name="RestBetween{Time1}{Time2}" xml:space="preserve">
-    <value>Descanse entre &lt;em&gt;{0}&lt;/em&gt; y &lt;em&gt;{0}&lt;/em&gt;
+    <value>Descanse entre &lt;em&gt;{0}&lt;/em&gt; y &lt;em&gt;{1}&lt;/em&gt;
 </value>
   </data>
   <data name="ShareLinkToGetFollowers" xml:space="preserve">


### PR DESCRIPTION
While using the app, I noticed that the wrong time is shown for the max rest time in Spanish

![screenshot of app showing same min and max rest time](https://github.com/user-attachments/assets/0cad2339-19ff-4996-99eb-701d91646302)
