### PR TITLE
feat: Add ability to set negative numbers

### DIFF
--- a/app/assets/math-plus-minus.svg
+++ b/app/assets/math-plus-minus.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+	<!-- Plus (vertical + horizontal) -->
+	<line x1="20" y1="5" x2="20" y2="25" stroke-width="3" />
+	<line x1="10" y1="15" x2="30" y2="15" stroke-width="3" />
+
+	<!-- Minus -->
+	<line x1="10" y1="32" x2="30" y2="32" stroke-width="3" />
+</svg>

--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -4,6 +4,12 @@ module.exports = function (api) {
     presets: ['babel-preset-expo'],
     plugins: [
       '@babel/plugin-proposal-export-namespace-from',
+      [
+        "babel-plugin-inline-import",
+        {
+          "extensions": [".svg"]
+        }
+      ],
       'react-native-reanimated/plugin',
     ],
   };

--- a/app/components/presentation/editable-incrementer.tsx
+++ b/app/components/presentation/editable-incrementer.tsx
@@ -2,13 +2,13 @@ import {
   localeFormatBigNumber,
   localeParseBigNumber,
 } from '@/utils/locale-bignumber';
+import { useTranslate } from '@tolgee/react';
 import BigNumber from 'bignumber.js';
 import { useEffect, useState } from 'react';
 import { View } from 'react-native';
-import { IconButton, List, TextInput } from 'react-native-paper';
+import { IconButton, List, TextInput, Tooltip } from 'react-native-paper';
 
 interface EditableIncrementerProps {
-  increment: BigNumber;
   label: string;
   value: BigNumber;
   suffix: string;
@@ -17,7 +17,8 @@ interface EditableIncrementerProps {
 }
 
 export default function EditableIncrementer(props: EditableIncrementerProps) {
-  const { increment, label, value, onChange } = props;
+  const { label, value, onChange } = props;
+  const { t } = useTranslate();
   const [text, setText] = useState(localeFormatBigNumber(props.value));
   const [editorValue, setEditorValue] = useState<BigNumber>(value);
 
@@ -45,35 +46,31 @@ export default function EditableIncrementer(props: EditableIncrementerProps) {
       title={label}
       titleNumberOfLines={2}
       right={() => (
-        <>
-          <View
-            style={{
-              alignItems: 'center',
-              flexDirection: 'row',
-              justifyContent: 'center',
-            }}
-          >
+        <View
+          style={{
+            alignItems: 'center',
+            flexDirection: 'row',
+            justifyContent: 'center',
+          }}
+        >
+          <Tooltip title={t('Toggle negative')}>
             <IconButton
-              icon={'remove'}
+              icon={'plusMinus'}
               onPress={() => {
-                onChange(editorValue.minus(increment));
+                onChange(editorValue.multipliedBy(-1));
               }}
             />
-            <TextInput
-              testID="editable-field"
-              value={text}
-              inputMode="decimal"
-              onChangeText={handleTextChange}
-              selectTextOnFocus
-              onBlur={() => onChange(editorValue)}
-              right={<TextInput.Affix text={props.suffix} />}
-            />
-            <IconButton
-              icon={'add'}
-              onPress={() => onChange(editorValue.plus(increment))}
-            />
-          </View>
-        </>
+          </Tooltip>
+          <TextInput
+            testID="editable-field"
+            value={text}
+            inputMode="decimal"
+            keyboardType="decimal-pad"
+            onChangeText={handleTextChange}
+            onBlur={() => onChange(editorValue)}
+            right={<TextInput.Affix text={props.suffix} />}
+          />
+        </View>
       )}
     ></List.Item>
   );

--- a/app/components/presentation/exercise-editor.tsx
+++ b/app/components/presentation/exercise-editor.tsx
@@ -165,7 +165,6 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
 
       <View style={{ gap: spacing[2] }}>
         <EditableIncrementer
-          increment={new BigNumber('0.1')}
           label={t('ProgressiveOverload')}
           testID="exercise-auto-increase"
           suffix={weightSuffix}

--- a/app/components/presentation/ms-icon-source.tsx
+++ b/app/components/presentation/ms-icon-source.tsx
@@ -93,10 +93,16 @@ import { msDirectionsRun } from '@material-symbols-react-native/outlined-400/msD
 import { msLanguage } from '@material-symbols-react-native/outlined-400/msLanguage';
 import { msUnfoldLess } from '@material-symbols-react-native/outlined-400/msUnfoldLess';
 import { msUnfoldMore } from '@material-symbols-react-native/outlined-400/msUnfoldMore';
+import plusMinus from '../../assets/math-plus-minus.svg';
+import { SvgXml } from 'react-native-svg';
 
 // Importing these icons using the below methods causes android app to crash
 // import { msAdd, msArrowDownward } from '@material-symbols-react-native/outlined-400';
 // import * as AllIcons from '@material-symbols-react-native/outlined-400';
+
+const CustomIcons = {
+  plusMinus: plusMinus,
+};
 
 const MaterialSymbols = {
   add: msAdd,
@@ -206,6 +212,18 @@ const MaterialSymbols = {
 };
 
 export function MsIconSrc({ name, ...rest }: IconProps) {
+  if ((name as keyof typeof CustomIcons) in CustomIcons) {
+    return (
+      <SvgXml
+        width={rest.size}
+        stroke={rest.color ?? 'white'}
+        height={rest.size}
+        fill={rest.color ?? 'white'}
+        xml={CustomIcons[name as keyof typeof CustomIcons]}
+        {...rest}
+      />
+    );
+  }
   const icon = MaterialSymbols[name as keyof typeof MaterialSymbols];
   if (!icon) {
     return <MsIcon icon={MaterialSymbols['info']} {...rest} />;

--- a/app/components/presentation/weight-dialog.tsx
+++ b/app/components/presentation/weight-dialog.tsx
@@ -4,7 +4,7 @@ import {
   localeFormatBigNumber,
   localeParseBigNumber,
 } from '@/utils/locale-bignumber';
-import { T } from '@tolgee/react';
+import { T, useTranslate } from '@tolgee/react';
 import BigNumber from 'bignumber.js';
 import { ReactNode, useEffect, useState } from 'react';
 import { View } from 'react-native';
@@ -15,6 +15,7 @@ import {
   IconButton,
   Portal,
   TextInput,
+  Tooltip,
   useTheme,
 } from 'react-native-paper';
 
@@ -39,6 +40,7 @@ type WeightDialogProps = {
 
 export default function WeightDialog(props: WeightDialogProps) {
   const theme = useTheme();
+  const { t } = useTranslate();
   const [text, setText] = useState(localeFormatBigNumber(props.weight));
   const [editorWeight, setEditorWeight] = useState<BigNumber | undefined>(
     props.weight,
@@ -109,12 +111,6 @@ export default function WeightDialog(props: WeightDialogProps) {
                   alignItems: 'center',
                 }}
               >
-                <IconButton
-                  icon={'minus'}
-                  mode="outlined"
-                  testID="decrement-weight"
-                  onPress={decrementWeight}
-                />
                 <TextInput
                   testID="weight-input"
                   right={<TextInput.Affix text={weightSuffix} />}
@@ -129,6 +125,26 @@ export default function WeightDialog(props: WeightDialogProps) {
                     backgroundColor: theme.colors.elevation.level3,
                     flex: 1,
                   }}
+                />
+                <Tooltip title={t('Toggle negative')}>
+                  <IconButton
+                    mode="outlined"
+                    icon={'plusMinus'}
+                    onPress={() => {
+                      setEditorWeight(
+                        editorWeight?.multipliedBy(-1) as BigNumber,
+                      );
+                      setText(
+                        localeFormatBigNumber(editorWeight?.multipliedBy(-1)),
+                      );
+                    }}
+                  />
+                </Tooltip>
+                <IconButton
+                  icon={'minus'}
+                  mode="outlined"
+                  testID="decrement-weight"
+                  onPress={decrementWeight}
                 />
                 <IconButton
                   icon={'plus'}

--- a/app/hooks/useAppTheme.tsx
+++ b/app/hooks/useAppTheme.tsx
@@ -222,7 +222,12 @@ export const AppThemeProvider: React.FC<AppThemeProviderProps> = ({
       <PaperProvider
         theme={paperTheme}
         settings={{
-          icon: (props) => <MsIconSrc {...props} />,
+          icon: (props) => (
+            <MsIconSrc
+              {...props}
+              color={props.color ?? appTheme.colors.onSurface}
+            />
+          ),
         }}
       >
         <NavigationThemeProvider value={navigationTheme}>

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -29,6 +29,7 @@
   "This set": "This set",
   "Uncompleted sets": "Uncompleted sets",
   "Max weight lifted in a workout": "Max weight lifted in a workout",
+  "Toggle negative": "Toggle negative",
   "Arms": "Arms",
   "AutomaticRemoteBackup": "Automatic remote backup",
   "AutomaticRemoteBackupSubtitle": "Send backups to a remote server. Advanced users only",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -79,6 +79,7 @@
         "@babel/core": "^7.20.0",
         "@react-native-community/cli": "^18.0.0",
         "@types/react": "~19.0.14",
+        "babel-plugin-inline-import": "^3.0.0",
         "eslint": "^8.57.0",
         "eslint-config-expo": "~9.2.0",
         "eslint-config-prettier": "^10.0.2",
@@ -7181,6 +7182,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-inline-import": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-import/-/babel-plugin-inline-import-3.0.0.tgz",
+      "integrity": "sha512-thnykl4FMb8QjMjVCuZoUmAM7r2mnTn5qJwrryCvDv6rugbJlTHZMctdjDtEgD0WBAXJOLJSGXN3loooEwx7UQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-resolve": "0.0.2"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -15039,6 +15050,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-extra": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/path-extra/-/path-extra-1.0.3.tgz",
+      "integrity": "sha512-vYm3+GCkjUlT1rDvZnDVhNLXIRvwFPaN8ebHAFcuMJM/H0RBOPD7JrcldiNLd9AS3dhAyUHLa4Hny5wp1A+Ffw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -16484,6 +16502,16 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "devOptional": true,
       "license": "ISC"
+    },
+    "node_modules/require-resolve": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/require-resolve/-/require-resolve-0.0.2.tgz",
+      "integrity": "sha512-eafQVaxdQsWUB8HybwognkdcIdKdQdQBwTxH48FuE6WI0owZGKp63QYr1MRp73PoX0AcyB7MDapZThYUY8FD0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "x-path": "^0.0.2"
+      }
     },
     "node_modules/requireg": {
       "version": "0.2.2",
@@ -19404,6 +19432,16 @@
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/x-path": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/x-path/-/x-path-0.0.2.tgz",
+      "integrity": "sha512-zQ4WFI0XfJN1uEkkrB19Y4TuXOlHqKSxUJo0Yt+axPjRm8tCG6SJ6+Wo3/+Kjg4c2c8IvBXuJ0uYoshxNn4qMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-extra": "^1.0.2"
       }
     },
     "node_modules/xcode": {

--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
     "expo-intent-launcher": "~12.1.4",
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.7",
+    "expo-localization": "~16.1.6",
     "expo-notifications": "~0.31.4",
     "expo-router": "~5.1.4",
     "expo-sharing": "~13.1.5",
@@ -86,13 +87,13 @@
     "react-redux": "^9.2.0",
     "ts-pattern": "^5.6.2",
     "use-debounce": "^10.0.4",
-    "uuid": "^11.1.0",
-    "expo-localization": "~16.1.6"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@react-native-community/cli": "^18.0.0",
     "@types/react": "~19.0.14",
+    "babel-plugin-inline-import": "^3.0.0",
     "eslint": "^8.57.0",
     "eslint-config-expo": "~9.2.0",
     "eslint-config-prettier": "^10.0.2",

--- a/app/types/svg.d.ts
+++ b/app/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}

--- a/tests/cypress-tests/cypress/e2e/completing-a-session.cy.js
+++ b/tests/cypress-tests/cypress/e2e/completing-a-session.cy.js
@@ -102,6 +102,7 @@ describe('Completing a session', () => {
 
       it('can complete a workout while switching to per set weights with it progressing properly', () => {
         cy.contains('Start workout').click()
+
         updateWeight(0, 20)
         cy.getByTestId('repcount').first().click().should('contain.text', '5/5')
         cy.getByTestId('rest-timer').should('be.visible')
@@ -112,6 +113,7 @@ describe('Completing a session', () => {
         // Update the weight of the second set to be lower than the top level weight
         // Applying to uncompleted sets
         cy.getByTestId('repcount-weight').eq(1).click()
+        cy.dialog().findByTestId('repcount-apply-weight-to-uncompleted-sets').click()
         cy.dialog().findByTestId('decrement-weight').click()
         cy.dialog().findByTestId('save').click()
         cy.getByTestId('modal').should('not.exist')
@@ -123,8 +125,7 @@ describe('Completing a session', () => {
         // Apply to this set
         cy.getByTestId('repcount-weight').eq(2).click()
         cy.dialog().findByTestId('decrement-weight').click()
-        cy.dialog().findByTestId('repcount-apply-weight-to').click()
-        cy.contains('Apply to this set').click({ force: true })
+        cy.dialog().findByTestId('repcount-apply-weight-to-this-set').click()
         cy.dialog().findByTestId('save').click()
         cy.getByTestId('modal').should('not.exist')
 
@@ -136,8 +137,7 @@ describe('Completing a session', () => {
         // Apply to all sets
         cy.getByTestId('repcount-weight').eq(2).click()
         cy.dialog().findByTestId('decrement-weight').click()
-        cy.dialog().findByTestId('repcount-apply-weight-to').click()
-        cy.contains('Apply to all sets').click({ force: true })
+        cy.dialog().findByTestId('repcount-apply-weight-to-all-sets').click()
         cy.dialog().findByTestId('save').click()
         cy.getByTestId('modal').should('not.exist')
 
@@ -235,5 +235,6 @@ function updateWeight(index, amount) {
   cy.getByTestId('repcount-weight').eq(index).click()
 
   cy.dialog().find('[data-testid=weight-input]:visible').click().type(amount.toString())
+  cy.dialog().findByTestId('repcount-apply-weight-to-uncompleted-sets').click()
   cy.dialog().findByTestId("save").click()
 }


### PR DESCRIPTION
The iOS keyboard does not allow for BOTH negative and decimal numbers. Who would need that right?

Fixes: #527 

Anyway this commit adds a +- button next to any weight inputs
<img width="830" height="1724" alt="CleanShot 2025-08-27 at 11 17 51@2x" src="https://github.com/user-attachments/assets/b878a420-3d3c-4450-8f68-5fb24bec314f" />
<img width="864" height="1772" alt="CleanShot 2025-08-27 at 11 18 00@2x" src="https://github.com/user-attachments/assets/bdb78bb3-a16a-4e87-a5eb-b3ccdcbb4f9d" />
