### PR TITLE
fix535/fix aws upload

### DIFF
--- a/examples/remote-backup/reference-server-implementation/aws-lambda-s3-deployable/README.md
+++ b/examples/remote-backup/reference-server-implementation/aws-lambda-s3-deployable/README.md
@@ -121,5 +121,5 @@ If you want to verify the backup without restoring it, you can use the protoc co
 
 ```bash
 # from the root of this repo - change the filename accordingly:
-gunzip -c ~/Downloads/export.liftlogbackup.gz | protoc --decode=LiftLog.Ui.Models.ExportedDataDao.ExportedDataDaoV2 --proto_path=LiftLog.Ui Models/ExportedDataDao/ExportedDataDaoV2.proto
+gunzip -c ~/Downloads/export.liftlogbackup.gz | protoc --decode=LiftLog.Ui.Models.ExportedDataDao.ExportedDataDaoV2 --proto_path=proto ExportedDataDao/ExportedDataDaoV2.proto
 ```

--- a/examples/remote-backup/reference-server-implementation/aws-lambda-s3-deployable/terraform/.terraform.lock.hcl
+++ b/examples/remote-backup/reference-server-implementation/aws-lambda-s3-deployable/terraform/.terraform.lock.hcl
@@ -2,56 +2,43 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.14.0"
+  version     = "6.17.0"
   constraints = "~> 6.0"
   hashes = [
-    "h1:0l1/b+Uh3/+RrAhDfKcfAz9PKddUfQ1edIrl1YIN8/c=",
-    "h1:2QzX6gWl9rGQN1F+WnRtltQh6w8fRqERvLMXbirLSnE=",
-    "h1:6lPeVk70tyb+xZJjxFaMD2nFfzqQnWOCntUIOVN+ds8=",
-    "h1:M+RUprZE/MnT46C+21kdWW5/thGoBkVkU/JLLR6LCLs=",
-    "h1:MHSiHnXU6DcXC/suxG00SvfAtPRiNnvVKOkGUAZG39g=",
-    "h1:Pzqz+4gbXXAIW0jXcAxZ3imqnPGcgGKt2ykXUS5wvbc=",
-    "h1:QuZtvx4ZdmFqT1TxfzU1mWKOMemr4ur7ENyqJHHjaf8=",
-    "h1:V5xvcSuaUU19pGUgwxIwtXzGZs0lkQVXnc4iL4UKcRc=",
-    "h1:W53xCgvJL9vi+95nkNLyLHD/M8h16nupADOphgv4INQ=",
-    "h1:cz+tjvrVouV2n1ia94PAzXrOCVQoplDF8fTjCoL/cvw=",
-    "h1:gmcU8IV3schyCIC/aXfBgkEZ7Dm1394CW2mqbAGaDsU=",
-    "h1:j08+AhqbMSg7/I4mMJCLB/uNJAcd85dNKLTxJ3z8rHo=",
-    "h1:r3L2n2TpMRR+hS6cJE3vHw2OQMTNrvsiCrPYOYcliIo=",
-    "h1:wm0x2PXrphyC+dFsZ2NKeweMJoYr03kbwbPxtuxaCMc=",
-    "zh:35bd9514b397e96f40eaf5dea7de007e4105e804db3b246ee83edc31260f3251",
-    "zh:5662381971177f552b44b0f96e5aeb117b8c2e5c118845be41b19d44daed94d7",
-    "zh:58f574a0e83a2914c21995a159b155c0361c62690ebb8690cb28c1a5d9a40e6f",
-    "zh:798dc4a0bdd2da2e871a74f1c8fc64e30b5cd07e1d99255dc93c47dd202dc58b",
-    "zh:8972e3d0610e374f35f4e2f1ecd38ee6c4c0fa0d88bc88e0c138056646517751",
-    "zh:965711c26b0037842ab1a85a1ae38c11c446992b276131aea6fedd25995916bb",
+    "h1:V7rm9KGpo/dNJG2u8XfiB9nZIsfYTbAyUE0C0eA5lTc=",
+    "zh:157063d66cd4b5fc650f20f56127e19c9da5d135f4231f9ca0c19a1c0bf6e29d",
+    "zh:2050dc03304b42204e6c58bbb1a2afd4feeac7db55d7c06be77c6b1e2ab46a0f",
+    "zh:2a7f7751eef636ca064700cc4574b9b54a2596d9e2e86b91c45127410d9724c6",
+    "zh:335fd7bb44bebfc4dd1db1c013947e1dde2518c6f2d846aac13b7314414ce461",
+    "zh:545c248d2eb601a7b45a34313096cae0a5201ccf31e7fd99428357ef800051e0",
+    "zh:57d19883a6367c245e885856a1c5395c4c743c20feff631ea4ec7b5e16826281",
+    "zh:66d4f080b8c268d65e8c4758ed57234e5a19deff6073ffc3753b9a4cc177b54e",
+    "zh:6ad50de35970f15e1ed41d39742290c1be80600b7df3a9fbb4c02f353b9586cf",
+    "zh:7af42fa531e4dcb3ddb09f71ca988e90626abbf56a45981c2a6c01d0b364a51b",
+    "zh:9a6a535a879314a9137ec9d3e858b7c490a962050845cf62620ba2bf4ae916a8",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b3c41e233c90d70d465b1e371e7b741d0ce67b7bcedabb87c3467b43c56727c0",
-    "zh:b518daff3eaa800e741103f16a7e2d99958bc3a9dc6a50f71d19dcfe7bcdee71",
-    "zh:bd26f8aecdffdbaab5b4dbe1d996a6bd1d6e53c8e036177f4daabaef8aa5abc3",
-    "zh:c5bf06ee484c693b763c90d3022f93c00e4e16b34c9e7c0440053efbc60b2ece",
-    "zh:d3ea9da36625b322745ec66652131c3f61367b0a7a1862308149e42e4bdf3d90",
-    "zh:d6ba44950eceb4d2ac404ace4260a89880cd0a7524a69191369939a8b7efe74c",
-    "zh:e263e3a5b41e92af5b05840bed8c03de3f8339c7d8ef8fbb21d3c700b31ff7ad",
-    "zh:f847e5db9c6361d6fc9b24c36a3c254c123c393b149c836d8fec6428a59824dd",
+    "zh:ca213e0262c8f686fcd40e3fc84d67b8eea1596de988c13d4a8ecd4522ede669",
+    "zh:cc4132f682e9bf17c0649928ad92af4da07ffe7bccfe615d955225cdcf9e7f09",
+    "zh:dfe6de43496d2e2b6dff131fef6ada1e15f1fbba3d47235c751564d22003d05e",
+    "zh:e37d035fa02693a3d47fe636076cce50b6579b6adc0a36a7cf0456a2331c99ec",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version = "2.5.2"
+  version = "2.5.3"
   hashes = [
-    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
-    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
-    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
-    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
-    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
-    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
-    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
-    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
-    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
-    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
-    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
   ]
 }

--- a/examples/remote-backup/reference-server-implementation/aws-lambda-s3-deployable/terraform/outputs.tf
+++ b/examples/remote-backup/reference-server-implementation/aws-lambda-s3-deployable/terraform/outputs.tf
@@ -5,7 +5,7 @@ output "check_output_file" {
 
 resource "local_file" "output_file" {
   content = <<EOT
-API URL: ${aws_api_gateway_deployment.api_deployment.invoke_url}/backup
+API URL: ${aws_api_gateway_stage.prod_stage.invoke_url}/backup
 API Key: ${aws_api_gateway_api_key.liftlog_api_key.value}
 EOT
 


### PR DESCRIPTION
Housekeeping:

* Update way stages are deployed to match the latest version of the terraform aws provider
* Reference updated URI of deployed stage in output file
* Modify terraform so changes to stage config forces a re-deploy of stage (used to require a manual deletion)

Fix:

The previous upload code (probably related to the framework) used to post the entire binary in the body of a x-www-form-urlencoded form in base64 so we had to tell api-gateway to treat this type as binary and then decode it ourself before saving the file.

Looks like a change to this behaviour means we could just get the file as an octet-stream so I added this type to api-gateway to treat as binary and then we just save the raw buffer to S3.

I've updated the README to reflect the new protobuf modelse path and verified that a gz file downloaded from our S3 bucket does indeed decode correctly.