### PR TITLE
fix: Prevent crash in web due to missing I18nManager.swapLeftAndRightInRTL

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -19,7 +19,10 @@ LogBox.ignoreLogs([
   /.*Failed to fetch inbox.*/,
   /.*Failed to update profile*/,
 ]);
-I18nManager.swapLeftAndRightInRTL(true);
+
+if (Platform.OS !== 'web') {
+  I18nManager.swapLeftAndRightInRTL?.(true);
+}
 
 export default Sentry.wrap(function RootLayout() {
   const colorScheme = useColorScheme();


### PR DESCRIPTION
Hey. I wanted to run the app in the browser, but it crashed on startup with:
`I18nManager.swapLeftAndRightInRTL is not a function`

I found out that API exists on iOS/Android, but it seems that react-native-web doesn't implement it, so the web build blows up before anything renders.

This PR fixes it by only running that call on non-web platforms.