### PR TITLE
feat: allow typing sets/reps values directly via numeric input

### DIFF
--- a/app/components/presentation/foundation/editors/fixed-incrementer.tsx
+++ b/app/components/presentation/foundation/editors/fixed-incrementer.tsx
@@ -6,9 +6,7 @@ import { Pressable, Text, TextInput, View } from 'react-native';
 interface FixedIncrementerProps<T> {
   value: T;
   label: string;
-  increment: () => void;
-  decrement: () => void;
-  onValueChange?: (value: number) => void;
+  onValueChange: (value: number) => void;
   testID?: string;
 }
 
@@ -21,7 +19,6 @@ export default function FixedIncrementer<T extends { toString(): string }>(
   const inputRef = useRef<TextInput>(null);
 
   const handlePress = () => {
-    if (!props.onValueChange) return;
     setEditText(props.value?.toString() ?? '');
     setIsEditing(true);
     setTimeout(() => inputRef.current?.focus(), 50);
@@ -30,7 +27,7 @@ export default function FixedIncrementer<T extends { toString(): string }>(
   const handleSubmit = () => {
     setIsEditing(false);
     const parsed = parseInt(editText, 10);
-    if (!isNaN(parsed) && parsed >= 0 && props.onValueChange) {
+    if (!isNaN(parsed)) {
       props.onValueChange(parsed);
     }
   };
@@ -60,7 +57,7 @@ export default function FixedIncrementer<T extends { toString(): string }>(
         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
           <IconButton
             icon={'remove'}
-            onPress={props.decrement}
+            onPress={() => props.onValueChange(Number(props.value) - 1)}
             testID="fixed-decrement"
           />
           {isEditing ? (
@@ -102,7 +99,7 @@ export default function FixedIncrementer<T extends { toString(): string }>(
           )}
           <IconButton
             icon={'add'}
-            onPress={props.increment}
+            onPress={() => props.onValueChange(Number(props.value) + 1)}
             testID="fixed-increment"
           />
         </View>

--- a/app/components/presentation/foundation/editors/fixed-incrementer.tsx
+++ b/app/components/presentation/foundation/editors/fixed-incrementer.tsx
@@ -1,12 +1,14 @@
 import IconButton from '@/components/presentation/foundation/gesture-wrappers/icon-button';
 import { useAppTheme, spacing, font } from '@/hooks/useAppTheme';
-import { Text, View } from 'react-native';
+import { useRef, useState } from 'react';
+import { Pressable, Text, TextInput, View } from 'react-native';
 
 interface FixedIncrementerProps<T> {
   value: T;
   label: string;
   increment: () => void;
   decrement: () => void;
+  onValueChange?: (value: number) => void;
   testID?: string;
 }
 
@@ -14,6 +16,25 @@ export default function FixedIncrementer<T extends { toString(): string }>(
   props: FixedIncrementerProps<T>,
 ) {
   const { colors } = useAppTheme();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editText, setEditText] = useState('');
+  const inputRef = useRef<TextInput>(null);
+
+  const handlePress = () => {
+    if (!props.onValueChange) return;
+    setEditText(props.value?.toString() ?? '');
+    setIsEditing(true);
+    setTimeout(() => inputRef.current?.focus(), 50);
+  };
+
+  const handleSubmit = () => {
+    setIsEditing(false);
+    const parsed = parseInt(editText, 10);
+    if (!isNaN(parsed) && parsed >= 0 && props.onValueChange) {
+      props.onValueChange(parsed);
+    }
+  };
+
   return (
     <View
       style={{
@@ -42,16 +63,43 @@ export default function FixedIncrementer<T extends { toString(): string }>(
             onPress={props.decrement}
             testID="fixed-decrement"
           />
-          <Text
-            style={{
-              color: colors.primary,
-              ...font['text-3xl'],
-              marginHorizontal: spacing[2],
-              fontWeight: 'bold',
-            }}
-          >
-            {props.value?.toString()}
-          </Text>
+          {isEditing ? (
+            <TextInput
+              ref={inputRef}
+              style={{
+                color: colors.primary,
+                ...font['text-3xl'],
+                marginHorizontal: spacing[2],
+                fontWeight: 'bold',
+                textAlign: 'center',
+                minWidth: 40,
+                padding: 0,
+              }}
+              value={editText}
+              onChangeText={setEditText}
+              keyboardType="number-pad"
+              selectTextOnFocus
+              onBlur={handleSubmit}
+              onSubmitEditing={handleSubmit}
+              testID="fixed-value-input"
+            />
+          ) : (
+            <Pressable
+              onPress={handlePress}
+              testID="fixed-value-display"
+            >
+              <Text
+                style={{
+                  color: colors.primary,
+                  ...font['text-3xl'],
+                  marginHorizontal: spacing[2],
+                  fontWeight: 'bold',
+                }}
+              >
+                {props.value?.toString()}
+              </Text>
+            </Pressable>
+          )}
           <IconButton
             icon={'add'}
             onPress={props.increment}

--- a/app/components/presentation/foundation/editors/fixed-incrementer.tsx
+++ b/app/components/presentation/foundation/editors/fixed-incrementer.tsx
@@ -1,108 +1,58 @@
+import { IntegerEditor } from '@/components/presentation/foundation/editors/integer-editor';
 import IconButton from '@/components/presentation/foundation/gesture-wrappers/icon-button';
-import { useAppTheme, spacing, font } from '@/hooks/useAppTheme';
-import { useRef, useState } from 'react';
-import { Pressable, Text, TextInput, View } from 'react-native';
+import { useAppTheme, font } from '@/hooks/useAppTheme';
+import { Text, View } from 'react-native';
 
-interface FixedIncrementerProps<T> {
-  value: T;
+interface FixedIncrementerProps {
+  value: number;
   label: string;
   onValueChange: (value: number) => void;
   testID?: string;
 }
 
-export default function FixedIncrementer<T extends { toString(): string }>(
-  props: FixedIncrementerProps<T>,
-) {
+export default function FixedIncrementer(props: FixedIncrementerProps) {
   const { colors } = useAppTheme();
-  const [isEditing, setIsEditing] = useState(false);
-  const [editText, setEditText] = useState('');
-  const inputRef = useRef<TextInput>(null);
-
-  const handlePress = () => {
-    setEditText(props.value?.toString() ?? '');
-    setIsEditing(true);
-    setTimeout(() => inputRef.current?.focus(), 50);
-  };
-
-  const handleSubmit = () => {
-    setIsEditing(false);
-    const parsed = parseInt(editText, 10);
-    if (!isNaN(parsed)) {
-      props.onValueChange(parsed);
-    }
-  };
 
   return (
-    <View
-      style={{
-        justifyContent: 'center',
-        flexDirection: 'row',
-      }}
-      testID={props.testID}
-    >
-      <View
+    <View>
+      <Text
         style={{
-          gap: spacing[2],
+          color: colors.onSurface,
+          ...font['text-lg'],
+          textAlign: 'center',
         }}
       >
-        <Text
+        {props.label}
+      </Text>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          alignSelf: 'center',
+        }}
+      >
+        <IconButton
+          icon={'remove'}
+          onPress={() => props.onValueChange(Number(props.value) - 1)}
+          testID="fixed-decrement"
+        />
+        <IntegerEditor
           style={{
-            color: colors.onSurface,
-            ...font['text-lg'],
+            color: colors.primary,
+            ...font['text-3xl'],
+            fontWeight: 'bold',
             textAlign: 'center',
+            minWidth: 40,
           }}
-        >
-          {props.label}
-        </Text>
-        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-          <IconButton
-            icon={'remove'}
-            onPress={() => props.onValueChange(Number(props.value) - 1)}
-            testID="fixed-decrement"
-          />
-          {isEditing ? (
-            <TextInput
-              ref={inputRef}
-              style={{
-                color: colors.primary,
-                ...font['text-3xl'],
-                marginHorizontal: spacing[2],
-                fontWeight: 'bold',
-                textAlign: 'center',
-                minWidth: 40,
-                padding: 0,
-              }}
-              value={editText}
-              onChangeText={setEditText}
-              keyboardType="number-pad"
-              selectTextOnFocus
-              onBlur={handleSubmit}
-              onSubmitEditing={handleSubmit}
-              testID="fixed-value-input"
-            />
-          ) : (
-            <Pressable
-              onPress={handlePress}
-              testID="fixed-value-display"
-            >
-              <Text
-                style={{
-                  color: colors.primary,
-                  ...font['text-3xl'],
-                  marginHorizontal: spacing[2],
-                  fontWeight: 'bold',
-                }}
-              >
-                {props.value?.toString()}
-              </Text>
-            </Pressable>
-          )}
-          <IconButton
-            icon={'add'}
-            onPress={() => props.onValueChange(Number(props.value) + 1)}
-            testID="fixed-increment"
-          />
-        </View>
+          onChange={props.onValueChange}
+          value={props.value}
+          testID="fixed-value-input"
+        />
+        <IconButton
+          icon={'add'}
+          onPress={() => props.onValueChange(Number(props.value) + 1)}
+          testID="fixed-increment"
+        />
       </View>
     </View>
   );

--- a/app/components/presentation/foundation/editors/integer-editor.tsx
+++ b/app/components/presentation/foundation/editors/integer-editor.tsx
@@ -44,6 +44,8 @@ export function IntegerEditor(props: IntegerEditorProps) {
       onChangeText={handleTextChange}
       selectTextOnFocus
       style={[props.style]}
+      // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+      textColor={props.style?.color! as string}
       onBlur={() => {
         if (text === '') {
           setText('0');

--- a/app/components/presentation/workout-editor/exercise-editor.tsx
+++ b/app/components/presentation/workout-editor/exercise-editor.tsx
@@ -504,20 +504,11 @@ function WeightedExerciseEditor({
 }) {
   const { t } = useTranslate();
 
-  const incrementSets = () => updateExercise({ sets: exercise.sets + 1 });
+  const setSets = (value: number) =>
+    updateExercise({ sets: Math.max(value, 1) });
 
-  const decrementSets = () =>
-    updateExercise({ sets: Math.max(exercise.sets - 1, 0) });
-
-  const setSets = (value: number) => updateExercise({ sets: value });
-
-  const incrementReps = () =>
-    updateExercise({ repsPerSet: exercise.repsPerSet + 1 });
-
-  const decrementReps = () =>
-    updateExercise({ repsPerSet: Math.max(exercise.repsPerSet - 1, 0) });
-
-  const setReps = (value: number) => updateExercise({ repsPerSet: value });
+  const setReps = (value: number) =>
+    updateExercise({ repsPerSet: Math.max(value, 1) });
 
   const setExerciseWeightIncrease = (weightIncreaseOnSuccess: BigNumber) =>
     updateExercise({ weightIncreaseOnSuccess });
@@ -544,8 +535,6 @@ function WeightedExerciseEditor({
           <Card.Content>
             <FixedIncrementer
               label={t('exercise.sets.label')}
-              increment={incrementSets}
-              decrement={decrementSets}
               onValueChange={setSets}
               value={exercise.sets}
               testID="exercise-sets"
@@ -564,8 +553,6 @@ function WeightedExerciseEditor({
           <Card.Content>
             <FixedIncrementer
               label={t('exercise.reps.label')}
-              increment={incrementReps}
-              decrement={decrementReps}
               onValueChange={setReps}
               value={exercise.repsPerSet}
               testID="exercise-reps"

--- a/app/components/presentation/workout-editor/exercise-editor.tsx
+++ b/app/components/presentation/workout-editor/exercise-editor.tsx
@@ -509,11 +509,15 @@ function WeightedExerciseEditor({
   const decrementSets = () =>
     updateExercise({ sets: Math.max(exercise.sets - 1, 0) });
 
+  const setSets = (value: number) => updateExercise({ sets: value });
+
   const incrementReps = () =>
     updateExercise({ repsPerSet: exercise.repsPerSet + 1 });
 
   const decrementReps = () =>
     updateExercise({ repsPerSet: Math.max(exercise.repsPerSet - 1, 0) });
+
+  const setReps = (value: number) => updateExercise({ repsPerSet: value });
 
   const setExerciseWeightIncrease = (weightIncreaseOnSuccess: BigNumber) =>
     updateExercise({ weightIncreaseOnSuccess });
@@ -542,6 +546,7 @@ function WeightedExerciseEditor({
               label={t('exercise.sets.label')}
               increment={incrementSets}
               decrement={decrementSets}
+              onValueChange={setSets}
               value={exercise.sets}
               testID="exercise-sets"
             />
@@ -561,6 +566,7 @@ function WeightedExerciseEditor({
               label={t('exercise.reps.label')}
               increment={incrementReps}
               decrement={decrementReps}
+              onValueChange={setReps}
               value={exercise.repsPerSet}
               testID="exercise-reps"
             />

--- a/app/components/presentation/workout-editor/exercise-editor.tsx
+++ b/app/components/presentation/workout-editor/exercise-editor.tsx
@@ -521,13 +521,14 @@ function WeightedExerciseEditor({
           alignItems: 'center',
           width: '100%',
           gap: spacing[4],
+          marginBlockEnd: spacing[2],
         }}
       >
         <Card
           style={{
             flexGrow: 1,
             flex: 1,
-            paddingVertical: spacing[5],
+            paddingVertical: spacing[2],
             justifyContent: 'center',
           }}
           mode="contained"
@@ -545,7 +546,7 @@ function WeightedExerciseEditor({
           style={{
             flexGrow: 1,
             flex: 1,
-            paddingVertical: spacing[5],
+            paddingVertical: spacing[2],
             justifyContent: 'center',
           }}
           mode="contained"


### PR DESCRIPTION
## Summary

When adding or editing an exercise, users can now tap the sets or reps value to type a number directly using a numeric keypad.

The +/- buttons continue to function as before.

This significantly improves usability when entering large values (e.g., 3 sets of 100 jumping jacks), reducing repetitive tapping.

---

## Changes

### fixed-incrementer.tsx
- Added optional `onValueChange` prop
- Tapping the value toggles an inline `TextInput`
- Uses `number-pad` keyboard
- On blur/submit, the parsed value is applied
- Invalid or empty input reverts to the previous value
- Fully backwards compatible (existing usages unaffected)

### exercise-editor.tsx
- Added `setSets` and `setReps` callbacks
- Passed `onValueChange` to both `FixedIncrementer` instances

---

## Test Plan

### Automated
- [x] All 167 existing tests pass (`npm test`)
- [x] TypeScript compiles with zero errors (`tsc --noEmit`)

### Manual
- [ ] Tap sets/reps value → numeric keypad opens pre-filled
- [ ] Enter a new number → value updates on blur/submit
- [ ] Empty/invalid input → reverts to previous value
- [ ] +/- buttons still increment/decrement correctly
- [ ] Verified on iOS
- [ ] Verified on Android

---





Closes #400
