### PR TITLE
fix: Stop potential set growing when in readonly mode

### DIFF
--- a/app/app/(tabs)/(session)/index.tsx
+++ b/app/app/(tabs)/(session)/index.tsx
@@ -15,7 +15,7 @@ import {
   selectCurrentSession,
   setCurrentSession,
 } from '@/store/current-session';
-import { publishUnpublishedSessions } from '@/store/feed';
+import { encryptAndShare, publishUnpublishedSessions } from '@/store/feed';
 import { fetchUpcomingSessions, selectActiveProgram } from '@/store/program';
 import { setEditingSession } from '@/store/session-editor';
 import { executeRemoteBackup } from '@/store/settings';
@@ -31,6 +31,7 @@ import { useDebouncedCallback } from 'use-debounce';
 import { MigrateToWeightUnitsWizard } from '@/components/smart/migrate-to-weight-units';
 import { WelcomeWizard } from '@/components/smart/welcome-wizard';
 import { SessionDiffSaveDialog } from '@/components/smart/session-diff-save-dialog';
+import { SharedSession } from '@/models/feed-models';
 
 function PlanManager() {
   const { push } = useRouter();
@@ -150,8 +151,16 @@ function ListUpcomingWorkouts({
               { withAnchor: true },
             );
           };
+          const handleSharePress = () => {
+            dispatch(encryptAndShare(new SharedSession(session)));
+          };
           return (
             <CardActions style={{ marginTop: spacing[2] }}>
+              <IconButton
+                icon={'share'}
+                mode="contained"
+                onPress={handleSharePress}
+              />
               {sessionPlanIndex !== -1 ? (
                 <IconButton
                   icon={'edit'}

--- a/app/components/presentation/foundation/holdable.tsx
+++ b/app/components/presentation/foundation/holdable.tsx
@@ -17,6 +17,7 @@ export type HoldableProps = {
   children: ReactNode;
   onLongPress: () => void;
   duration?: number;
+  disabled?: boolean;
   style?: ViewStyle;
 } & Pick<AnimatedProps<Animated.View>, 'layout' | 'entering' | 'exiting'>;
 export default function Holdable({
@@ -25,6 +26,7 @@ export default function Holdable({
   duration = 500,
   style,
   layout,
+  disabled,
   entering,
   exiting,
 }: HoldableProps) {
@@ -51,12 +53,14 @@ export default function Holdable({
     });
     if (!triggered) cancelHaptic();
   };
-  const gesture = Gesture.LongPress()
-    .minDuration(duration)
-    .runOnJS(true)
-    .onBegin(enterHold)
-    .onFinalize((_, triggered) => exitHold(triggered))
-    .onStart(handleLongPress);
+  const gesture = disabled
+    ? Gesture.Manual()
+    : Gesture.LongPress()
+        .minDuration(duration)
+        .runOnJS(true)
+        .onBegin(enterHold)
+        .onFinalize((_, triggered) => exitHold(triggered))
+        .onStart(handleLongPress);
 
   const scaleStyle = useAnimatedStyle(() => ({
     transform: [{ scale: holdingScale.value }],

--- a/app/components/presentation/foundation/ms-icon-source.tsx
+++ b/app/components/presentation/foundation/ms-icon-source.tsx
@@ -81,7 +81,6 @@ import { msPersonFill } from '@material-symbols-react-native/outlined-400/msPers
 import { MsIcon } from 'material-symbols-react-native';
 import { IconProps } from 'react-native-paper/lib/typescript/components/MaterialCommunityIcon';
 import { Platform } from 'react-native';
-import { match } from 'ts-pattern';
 import { msReplay } from '@material-symbols-react-native/outlined-400/msReplay';
 import { msAssignmentAdd } from '@material-symbols-react-native/outlined-400/msAssignmentAdd';
 import { msCopyAll } from '@material-symbols-react-native/outlined-400/msCopyAll';
@@ -174,13 +173,14 @@ const MaterialSymbols = {
   stop: msStop,
   replay: msReplay,
   vpnKeyFill: msVpnKeyFill,
-  share: match(Platform.OS)
-    .with('ios', () => msIosShare)
-    .with('macos', () => msIosShare)
-    .with('android', () => msShare)
-    .with('web', () => msShare)
-    .with('windows', () => msShareWindows)
-    .exhaustive(),
+  share: Platform.select({
+    ios: msIosShare,
+    android: msShare,
+    web: msShare,
+    macos: msIosShare,
+    native: msShare,
+    windows: msShareWindows,
+  }),
   text: msTextAd,
   reload: msRefresh,
   check: msCheck,

--- a/app/components/presentation/workout/weighted/potential-set-counter.tsx
+++ b/app/components/presentation/workout/weighted/potential-set-counter.tsx
@@ -36,7 +36,10 @@ export default function PotentialSetCounter(props: PotentialSetCounterProps) {
   const [applyTo, setApplyTo] = useState<WeightAppliesTo>('uncompletedSets');
 
   return (
-    <Holdable onLongPress={() => setIsRepsDialogOpen(true)}>
+    <Holdable
+      disabled={props.isReadonly}
+      onLongPress={() => setIsRepsDialogOpen(true)}
+    >
       <FocusRing
         isSelected={props.toStartNext}
         radius={rounding.roundedRectangleFocusRingRadius}

--- a/app/gen/proto.d.ts
+++ b/app/gen/proto.d.ts
@@ -3371,6 +3371,9 @@ export namespace LiftLog {
 
                 /** SharedItemPayload sharedProgramBlueprint */
                 sharedProgramBlueprint?: (LiftLog.Ui.Models.ISharedProgramBlueprintPayload|null);
+
+                /** SharedItemPayload sharedSession */
+                sharedSession?: (LiftLog.Ui.Models.ISharedSessionPayload|null);
             }
 
             /** Represents a SharedItemPayload. */
@@ -3385,8 +3388,11 @@ export namespace LiftLog {
                 /** SharedItemPayload sharedProgramBlueprint. */
                 public sharedProgramBlueprint?: (LiftLog.Ui.Models.ISharedProgramBlueprintPayload|null);
 
+                /** SharedItemPayload sharedSession. */
+                public sharedSession?: (LiftLog.Ui.Models.ISharedSessionPayload|null);
+
                 /** SharedItemPayload payload. */
-                public payload?: "sharedProgramBlueprint";
+                public payload?: ("sharedProgramBlueprint"|"sharedSession");
 
                 /**
                  * Creates a new SharedItemPayload instance using the specified properties.
@@ -3557,6 +3563,103 @@ export namespace LiftLog {
 
                 /**
                  * Gets the default type url for SharedProgramBlueprintPayload
+                 * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns The default type url
+                 */
+                public static getTypeUrl(typeUrlPrefix?: string): string;
+            }
+
+            /** Properties of a SharedSessionPayload. */
+            interface ISharedSessionPayload {
+
+                /** SharedSessionPayload session */
+                session?: (LiftLog.Ui.Models.SessionHistoryDao.ISessionDaoV2|null);
+            }
+
+            /** Represents a SharedSessionPayload. */
+            class SharedSessionPayload implements ISharedSessionPayload {
+
+                /**
+                 * Constructs a new SharedSessionPayload.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: LiftLog.Ui.Models.ISharedSessionPayload);
+
+                /** SharedSessionPayload session. */
+                public session?: (LiftLog.Ui.Models.SessionHistoryDao.ISessionDaoV2|null);
+
+                /**
+                 * Creates a new SharedSessionPayload instance using the specified properties.
+                 * @param [properties] Properties to set
+                 * @returns SharedSessionPayload instance
+                 */
+                public static create(properties?: LiftLog.Ui.Models.ISharedSessionPayload): LiftLog.Ui.Models.SharedSessionPayload;
+
+                /**
+                 * Encodes the specified SharedSessionPayload message. Does not implicitly {@link LiftLog.Ui.Models.SharedSessionPayload.verify|verify} messages.
+                 * @param message SharedSessionPayload message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encode(message: LiftLog.Ui.Models.ISharedSessionPayload, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Encodes the specified SharedSessionPayload message, length delimited. Does not implicitly {@link LiftLog.Ui.Models.SharedSessionPayload.verify|verify} messages.
+                 * @param message SharedSessionPayload message or plain object to encode
+                 * @param [writer] Writer to encode to
+                 * @returns Writer
+                 */
+                public static encodeDelimited(message: LiftLog.Ui.Models.ISharedSessionPayload, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                /**
+                 * Decodes a SharedSessionPayload message from the specified reader or buffer.
+                 * @param reader Reader or buffer to decode from
+                 * @param [length] Message length if known beforehand
+                 * @returns SharedSessionPayload
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): LiftLog.Ui.Models.SharedSessionPayload;
+
+                /**
+                 * Decodes a SharedSessionPayload message from the specified reader or buffer, length delimited.
+                 * @param reader Reader or buffer to decode from
+                 * @returns SharedSessionPayload
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): LiftLog.Ui.Models.SharedSessionPayload;
+
+                /**
+                 * Verifies a SharedSessionPayload message.
+                 * @param message Plain object to verify
+                 * @returns `null` if valid, otherwise the reason why it is not
+                 */
+                public static verify(message: { [k: string]: any }): (string|null);
+
+                /**
+                 * Creates a SharedSessionPayload message from a plain object. Also converts values to their respective internal types.
+                 * @param object Plain object
+                 * @returns SharedSessionPayload
+                 */
+                public static fromObject(object: { [k: string]: any }): LiftLog.Ui.Models.SharedSessionPayload;
+
+                /**
+                 * Creates a plain object from a SharedSessionPayload message. Also converts values to other types if specified.
+                 * @param message SharedSessionPayload
+                 * @param [options] Conversion options
+                 * @returns Plain object
+                 */
+                public static toObject(message: LiftLog.Ui.Models.SharedSessionPayload, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                /**
+                 * Converts this SharedSessionPayload to JSON.
+                 * @returns JSON object
+                 */
+                public toJSON(): { [k: string]: any };
+
+                /**
+                 * Gets the default type url for SharedSessionPayload
                  * @param [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
                  * @returns The default type url
                  */

--- a/app/gen/proto.js
+++ b/app/gen/proto.js
@@ -8803,6 +8803,7 @@ export const LiftLog = $root.LiftLog = (() => {
                  * @memberof LiftLog.Ui.Models
                  * @interface ISharedItemPayload
                  * @property {LiftLog.Ui.Models.ISharedProgramBlueprintPayload|null} [sharedProgramBlueprint] SharedItemPayload sharedProgramBlueprint
+                 * @property {LiftLog.Ui.Models.ISharedSessionPayload|null} [sharedSession] SharedItemPayload sharedSession
                  */
 
                 /**
@@ -8828,17 +8829,25 @@ export const LiftLog = $root.LiftLog = (() => {
                  */
                 SharedItemPayload.prototype.sharedProgramBlueprint = null;
 
+                /**
+                 * SharedItemPayload sharedSession.
+                 * @member {LiftLog.Ui.Models.ISharedSessionPayload|null|undefined} sharedSession
+                 * @memberof LiftLog.Ui.Models.SharedItemPayload
+                 * @instance
+                 */
+                SharedItemPayload.prototype.sharedSession = null;
+
                 // OneOf field names bound to virtual getters and setters
                 let $oneOfFields;
 
                 /**
                  * SharedItemPayload payload.
-                 * @member {"sharedProgramBlueprint"|undefined} payload
+                 * @member {"sharedProgramBlueprint"|"sharedSession"|undefined} payload
                  * @memberof LiftLog.Ui.Models.SharedItemPayload
                  * @instance
                  */
                 Object.defineProperty(SharedItemPayload.prototype, "payload", {
-                    get: $util.oneOfGetter($oneOfFields = ["sharedProgramBlueprint"]),
+                    get: $util.oneOfGetter($oneOfFields = ["sharedProgramBlueprint", "sharedSession"]),
                     set: $util.oneOfSetter($oneOfFields)
                 });
 
@@ -8868,6 +8877,8 @@ export const LiftLog = $root.LiftLog = (() => {
                         writer = $Writer.create();
                     if (message.sharedProgramBlueprint != null && Object.hasOwnProperty.call(message, "sharedProgramBlueprint"))
                         $root.LiftLog.Ui.Models.SharedProgramBlueprintPayload.encode(message.sharedProgramBlueprint, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    if (message.sharedSession != null && Object.hasOwnProperty.call(message, "sharedSession"))
+                        $root.LiftLog.Ui.Models.SharedSessionPayload.encode(message.sharedSession, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
                     return writer;
                 };
 
@@ -8906,6 +8917,10 @@ export const LiftLog = $root.LiftLog = (() => {
                         switch (tag >>> 3) {
                         case 1: {
                                 message.sharedProgramBlueprint = $root.LiftLog.Ui.Models.SharedProgramBlueprintPayload.decode(reader, reader.uint32());
+                                break;
+                            }
+                        case 2: {
+                                message.sharedSession = $root.LiftLog.Ui.Models.SharedSessionPayload.decode(reader, reader.uint32());
                                 break;
                             }
                         default:
@@ -8952,6 +8967,16 @@ export const LiftLog = $root.LiftLog = (() => {
                                 return "sharedProgramBlueprint." + error;
                         }
                     }
+                    if (message.sharedSession != null && message.hasOwnProperty("sharedSession")) {
+                        if (properties.payload === 1)
+                            return "payload: multiple values";
+                        properties.payload = 1;
+                        {
+                            let error = $root.LiftLog.Ui.Models.SharedSessionPayload.verify(message.sharedSession);
+                            if (error)
+                                return "sharedSession." + error;
+                        }
+                    }
                     return null;
                 };
 
@@ -8971,6 +8996,11 @@ export const LiftLog = $root.LiftLog = (() => {
                         if (typeof object.sharedProgramBlueprint !== "object")
                             throw TypeError(".LiftLog.Ui.Models.SharedItemPayload.sharedProgramBlueprint: object expected");
                         message.sharedProgramBlueprint = $root.LiftLog.Ui.Models.SharedProgramBlueprintPayload.fromObject(object.sharedProgramBlueprint);
+                    }
+                    if (object.sharedSession != null) {
+                        if (typeof object.sharedSession !== "object")
+                            throw TypeError(".LiftLog.Ui.Models.SharedItemPayload.sharedSession: object expected");
+                        message.sharedSession = $root.LiftLog.Ui.Models.SharedSessionPayload.fromObject(object.sharedSession);
                     }
                     return message;
                 };
@@ -8992,6 +9022,11 @@ export const LiftLog = $root.LiftLog = (() => {
                         object.sharedProgramBlueprint = $root.LiftLog.Ui.Models.SharedProgramBlueprintPayload.toObject(message.sharedProgramBlueprint, options);
                         if (options.oneofs)
                             object.payload = "sharedProgramBlueprint";
+                    }
+                    if (message.sharedSession != null && message.hasOwnProperty("sharedSession")) {
+                        object.sharedSession = $root.LiftLog.Ui.Models.SharedSessionPayload.toObject(message.sharedSession, options);
+                        if (options.oneofs)
+                            object.payload = "sharedSession";
                     }
                     return object;
                 };
@@ -9233,6 +9268,216 @@ export const LiftLog = $root.LiftLog = (() => {
                 };
 
                 return SharedProgramBlueprintPayload;
+            })();
+
+            Models.SharedSessionPayload = (function() {
+
+                /**
+                 * Properties of a SharedSessionPayload.
+                 * @memberof LiftLog.Ui.Models
+                 * @interface ISharedSessionPayload
+                 * @property {LiftLog.Ui.Models.SessionHistoryDao.ISessionDaoV2|null} [session] SharedSessionPayload session
+                 */
+
+                /**
+                 * Constructs a new SharedSessionPayload.
+                 * @memberof LiftLog.Ui.Models
+                 * @classdesc Represents a SharedSessionPayload.
+                 * @implements ISharedSessionPayload
+                 * @constructor
+                 * @param {LiftLog.Ui.Models.ISharedSessionPayload=} [properties] Properties to set
+                 */
+                function SharedSessionPayload(properties) {
+                    if (properties)
+                        for (let keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+
+                /**
+                 * SharedSessionPayload session.
+                 * @member {LiftLog.Ui.Models.SessionHistoryDao.ISessionDaoV2|null|undefined} session
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @instance
+                 */
+                SharedSessionPayload.prototype.session = null;
+
+                /**
+                 * Creates a new SharedSessionPayload instance using the specified properties.
+                 * @function create
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {LiftLog.Ui.Models.ISharedSessionPayload=} [properties] Properties to set
+                 * @returns {LiftLog.Ui.Models.SharedSessionPayload} SharedSessionPayload instance
+                 */
+                SharedSessionPayload.create = function create(properties) {
+                    return new SharedSessionPayload(properties);
+                };
+
+                /**
+                 * Encodes the specified SharedSessionPayload message. Does not implicitly {@link LiftLog.Ui.Models.SharedSessionPayload.verify|verify} messages.
+                 * @function encode
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {LiftLog.Ui.Models.ISharedSessionPayload} message SharedSessionPayload message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                SharedSessionPayload.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.session != null && Object.hasOwnProperty.call(message, "session"))
+                        $root.LiftLog.Ui.Models.SessionHistoryDao.SessionDaoV2.encode(message.session, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                    return writer;
+                };
+
+                /**
+                 * Encodes the specified SharedSessionPayload message, length delimited. Does not implicitly {@link LiftLog.Ui.Models.SharedSessionPayload.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {LiftLog.Ui.Models.ISharedSessionPayload} message SharedSessionPayload message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                SharedSessionPayload.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+
+                /**
+                 * Decodes a SharedSessionPayload message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {LiftLog.Ui.Models.SharedSessionPayload} SharedSessionPayload
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                SharedSessionPayload.decode = function decode(reader, length, error) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    let end = length === undefined ? reader.len : reader.pos + length, message = new $root.LiftLog.Ui.Models.SharedSessionPayload();
+                    while (reader.pos < end) {
+                        let tag = reader.uint32();
+                        if (tag === error)
+                            break;
+                        switch (tag >>> 3) {
+                        case 1: {
+                                message.session = $root.LiftLog.Ui.Models.SessionHistoryDao.SessionDaoV2.decode(reader, reader.uint32());
+                                break;
+                            }
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+
+                /**
+                 * Decodes a SharedSessionPayload message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {LiftLog.Ui.Models.SharedSessionPayload} SharedSessionPayload
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                SharedSessionPayload.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+
+                /**
+                 * Verifies a SharedSessionPayload message.
+                 * @function verify
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                SharedSessionPayload.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.session != null && message.hasOwnProperty("session")) {
+                        let error = $root.LiftLog.Ui.Models.SessionHistoryDao.SessionDaoV2.verify(message.session);
+                        if (error)
+                            return "session." + error;
+                    }
+                    return null;
+                };
+
+                /**
+                 * Creates a SharedSessionPayload message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {LiftLog.Ui.Models.SharedSessionPayload} SharedSessionPayload
+                 */
+                SharedSessionPayload.fromObject = function fromObject(object) {
+                    if (object instanceof $root.LiftLog.Ui.Models.SharedSessionPayload)
+                        return object;
+                    let message = new $root.LiftLog.Ui.Models.SharedSessionPayload();
+                    if (object.session != null) {
+                        if (typeof object.session !== "object")
+                            throw TypeError(".LiftLog.Ui.Models.SharedSessionPayload.session: object expected");
+                        message.session = $root.LiftLog.Ui.Models.SessionHistoryDao.SessionDaoV2.fromObject(object.session);
+                    }
+                    return message;
+                };
+
+                /**
+                 * Creates a plain object from a SharedSessionPayload message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {LiftLog.Ui.Models.SharedSessionPayload} message SharedSessionPayload
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                SharedSessionPayload.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    let object = {};
+                    if (options.defaults)
+                        object.session = null;
+                    if (message.session != null && message.hasOwnProperty("session"))
+                        object.session = $root.LiftLog.Ui.Models.SessionHistoryDao.SessionDaoV2.toObject(message.session, options);
+                    return object;
+                };
+
+                /**
+                 * Converts this SharedSessionPayload to JSON.
+                 * @function toJSON
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                SharedSessionPayload.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+
+                /**
+                 * Gets the default type url for SharedSessionPayload
+                 * @function getTypeUrl
+                 * @memberof LiftLog.Ui.Models.SharedSessionPayload
+                 * @static
+                 * @param {string} [typeUrlPrefix] your custom typeUrlPrefix(default "type.googleapis.com")
+                 * @returns {string} The default type url
+                 */
+                SharedSessionPayload.getTypeUrl = function getTypeUrl(typeUrlPrefix) {
+                    if (typeUrlPrefix === undefined) {
+                        typeUrlPrefix = "type.googleapis.com";
+                    }
+                    return typeUrlPrefix + "/LiftLog.Ui.Models.SharedSessionPayload";
+                };
+
+                return SharedSessionPayload;
             })();
 
             Models.ProgramBlueprintDao = (function() {

--- a/app/models/feed-models.ts
+++ b/app/models/feed-models.ts
@@ -7,6 +7,12 @@ import {
 } from './blueprint-models';
 import { RsaPublicKey, AesKey, RsaKeyPair } from '@/models/encryption-models';
 import { Session, SessionPOJO } from '@/models/session-models';
+import { assertUnreachable } from '@/utils/assert-unreachable';
+import { LiftLog } from '@/gen/proto';
+import {
+  toProgramBlueprintDao,
+  toSessionDao,
+} from '@/models/storage/conversions.to-dao';
 
 export interface FeedUserPOJO {
   type: 'FeedUser';
@@ -456,7 +462,7 @@ export class FollowResponse {
   }
 }
 
-export type SharedItemPOJO = SharedProgramBlueprintPOJO;
+export type SharedItemPOJO = SharedProgramBlueprintPOJO | SharedSessionPOJO;
 
 export abstract class SharedItem {
   abstract toPOJO(): SharedItemPOJO;
@@ -467,8 +473,13 @@ export abstract class SharedItem {
         ProgramBlueprint.fromPOJO(pojo.programBlueprint),
       );
     }
-    throw new Error('Unknown type');
+    if (pojo.type === 'SHARED_Session') {
+      return new SharedSession(Session.fromPOJO(pojo.session));
+    }
+    assertUnreachable(pojo);
   }
+
+  abstract toDao(): LiftLog.Ui.Models.SharedItemPayload;
 }
 
 export interface SharedProgramBlueprintPOJO {
@@ -501,5 +512,45 @@ export class SharedProgramBlueprint extends SharedItem {
     return new SharedProgramBlueprint(
       other.programBlueprint ?? this.programBlueprint,
     );
+  }
+
+  toDao(): LiftLog.Ui.Models.SharedItemPayload {
+    return new LiftLog.Ui.Models.SharedItemPayload({
+      sharedProgramBlueprint: {
+        programBlueprint: toProgramBlueprintDao(this.programBlueprint),
+      },
+    });
+  }
+}
+
+export interface SharedSessionPOJO {
+  type: 'SHARED_Session';
+  session: SessionPOJO;
+}
+export class SharedSession extends SharedItem {
+  readonly session: Session;
+
+  constructor(session: Session) {
+    super();
+    this.session = session!;
+  }
+
+  toPOJO(): SharedSessionPOJO {
+    return {
+      type: 'SHARED_Session',
+      session: this.session.toPOJO(),
+    };
+  }
+
+  with(other: Partial<{ session: Session }>): SharedSession {
+    return new SharedSession(other.session ?? this.session);
+  }
+
+  toDao(): LiftLog.Ui.Models.SharedItemPayload {
+    return new LiftLog.Ui.Models.SharedItemPayload({
+      sharedSession: {
+        session: toSessionDao(this.session),
+      },
+    });
   }
 }

--- a/app/models/storage/conversions.from-dao.ts
+++ b/app/models/storage/conversions.from-dao.ts
@@ -31,6 +31,7 @@ import {
   SessionFeedItem,
   SharedItem,
   SharedProgramBlueprint,
+  SharedSession,
 } from '@/models/feed-models';
 import {
   Duration,
@@ -548,12 +549,22 @@ export function fromCurrentSessionDao(
 export function fromSharedItemDao(
   dao: LiftLog.Ui.Models.SharedItemPayload,
 ): SharedItem | null {
-  if (dao.sharedProgramBlueprint?.programBlueprint) {
-    return new SharedProgramBlueprint(
-      fromProgramBlueprintDao(dao.sharedProgramBlueprint.programBlueprint),
-    );
+  console.log(dao);
+  switch (dao.payload) {
+    case 'sharedProgramBlueprint':
+      return new SharedProgramBlueprint(
+        fromProgramBlueprintDao(dao.sharedProgramBlueprint!.programBlueprint!),
+      );
+    case 'sharedSession':
+      return new SharedSession(fromSessionDao(dao.sharedSession?.session));
+    case undefined:
+      return null;
+    default: {
+      // We don't want it throwing for older clients
+      expectNever(dao.payload);
+      return null;
+    }
   }
-  return null;
 }
 function fromFollowRequestDao(
   value: LiftLog.Ui.Models.IInboxMessageDao,
@@ -569,4 +580,8 @@ export function fromWeightDao(value: LiftLog.Ui.Models.IWeight): Weight {
     fromDecimalDao(value.value!),
     fromWeightUnitDao(value.unit),
   );
+}
+
+function expectNever(never: never) {
+  // Do nothing, this is a compile time check
 }

--- a/app/models/storage/conversions.to-dao.ts
+++ b/app/models/storage/conversions.to-dao.ts
@@ -23,8 +23,6 @@ import {
   FeedUser,
   FollowRequest,
   SessionFeedItem,
-  SharedItem,
-  SharedProgramBlueprint,
 } from '@/models/feed-models';
 import {
   SessionPOJO,
@@ -406,20 +404,6 @@ export function toFeedStateDao(
       .unwrapOr(null),
     unpublishedSessionIds: state.unpublishedSessionIds.map(toUuidDao),
     revokedFollowSecrets: state.revokedFollowSecrets,
-  });
-}
-
-export function toSharedItemDao(
-  item: SharedItem,
-): LiftLog.Ui.Models.SharedItemPayload {
-  const sharedProgramBlueprint =
-    item instanceof SharedProgramBlueprint
-      ? new LiftLog.Ui.Models.SharedProgramBlueprintPayload({
-          programBlueprint: toProgramBlueprintDao(item.programBlueprint),
-        })
-      : null;
-  return new LiftLog.Ui.Models.SharedItemPayload({
-    sharedProgramBlueprint,
   });
 }
 

--- a/app/services/api-consts.ts
+++ b/app/services/api-consts.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-export const apiBaseUrl = __DEV__
+export const apiBaseUrl = !__DEV__
   ? Platform.OS === 'android'
     ? 'http://10.0.2.2:5264'
     : 'http://127.0.0.1:5264'

--- a/app/store/feed/shared-item-effects.ts
+++ b/app/store/feed/shared-item-effects.ts
@@ -2,7 +2,6 @@ import { LiftLog } from '@/gen/proto';
 import { AesKey } from '@/models/encryption-models';
 import { RemoteData } from '@/models/remote';
 import { fromSharedItemDao } from '@/models/storage/conversions.from-dao';
-import { toSharedItemDao } from '@/models/storage/conversions.to-dao';
 import { ApiErrorType } from '@/services/api-error';
 import {
   encryptAndShare,
@@ -47,7 +46,7 @@ export function addSharedItemEffects() {
       }
 
       const aesKey = await encryptionService.generateAesKey();
-      const payload = toSharedItemDao(action.payload);
+      const payload = action.payload.toDao();
       const payloadBytes =
         LiftLog.Ui.Models.SharedItemPayload.encode(payload).finish();
 

--- a/proto/SharedItem.proto
+++ b/proto/SharedItem.proto
@@ -3,15 +3,22 @@ syntax = "proto3";
 package LiftLog.Ui.Models;
 
 import "proto/ProgramBlueprintDao/ProgramBlueprintDaoV1.proto";
+import "proto/SessionHistoryDao/SessionHistoryDaoV2.proto";
 
 message SharedItemPayload {
   // Note that messages shouldn't just be raw data, but should be a wrapper around the data
   // so we can add additional fields in the future if needed
   oneof payload {
     SharedProgramBlueprintPayload shared_program_blueprint = 1;
+    SharedSessionPayload shared_session = 2;
   }
 }
 
 message SharedProgramBlueprintPayload {
   LiftLog.Ui.Models.ProgramBlueprintDao.ProgramBlueprintDaoV1 program_blueprint = 1;
+}
+
+
+message SharedSessionPayload {
+  LiftLog.Ui.Models.SessionHistoryDao.SessionDaoV2 session = 1;
 }


### PR DESCRIPTION
The set counter component (the Holdable) did not respect the isReadonly/disabled state, and therefore would grow and open the selector when tapping.
This change fixes this by respecting a disabled flag.
