### PR TITLE
fix: Don't use dev url in prod

### DIFF
--- a/app/services/api-consts.ts
+++ b/app/services/api-consts.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-export const apiBaseUrl = !__DEV__
+export const apiBaseUrl = __DEV__
   ? Platform.OS === 'android'
     ? 'http://10.0.2.2:5264'
     : 'http://127.0.0.1:5264'


### PR DESCRIPTION
A commit accidentally swapped the url used for feed/sharing api between dev and prod.