### PR TITLE
Add button to get to exercise stat from workout page

### DIFF
--- a/app/app/(tabs)/stats/expanded-weighted-exercise.tsx
+++ b/app/app/(tabs)/stats/expanded-weighted-exercise.tsx
@@ -10,12 +10,13 @@ import { WeightLineChart } from '@/components/presentation/stats/weight-line-cha
 import { spacing, useAppTheme } from '@/hooks/useAppTheme';
 import { useAppSelector, useAppSelectorWithArg } from '@/store';
 import {
+  fetchOverallStats,
   selectExerciseView,
   setOverallViewTime,
   WeightedExerciseStatistics,
 } from '@/store/stats';
 import { T, useTranslate } from '@tolgee/react';
-import { Stack } from 'expo-router';
+import { Stack, useFocusEffect } from 'expo-router';
 import { useLocalSearchParams, useRouter } from 'expo-router/build/hooks';
 import { ReactNode, useEffect } from 'react';
 import { View } from 'react-native';
@@ -27,6 +28,9 @@ export default function ExpandedExercisePage() {
   const timePeriod = useAppSelector((x) => x.stats.overallViewTime);
   const { exerciseName } = useLocalSearchParams<{ exerciseName: string }>();
   const { dismissTo } = useRouter();
+  useFocusEffect(() => {
+    dispatch(fetchOverallStats());
+  });
   useEffect(() => {
     if (!exerciseName) {
       dismissTo('/stats');

--- a/app/components/presentation/workout/exercise-section.tsx
+++ b/app/components/presentation/workout/exercise-section.tsx
@@ -1,6 +1,9 @@
 import ItemTitle from '@/components/presentation/foundation/item-title';
 import { spacing } from '@/hooks/useAppTheme';
-import { RecordedExercise } from '@/models/session-models';
+import {
+  RecordedExercise,
+  RecordedWeightedExercise,
+} from '@/models/session-models';
 import { ReactNode, useState } from 'react';
 import { View } from 'react-native';
 import { Menu, Tooltip } from 'react-native-paper';
@@ -10,6 +13,7 @@ import ConfirmationDialog from '@/components/presentation/foundation/confirmatio
 import ExerciseNotesDisplay from '@/components/presentation/workout/exercise-notes-display';
 import RecordedExerciseNotesEditor from '@/components/presentation/workout/recorded-exercise-notes-editor';
 import IconButton from '@/components/presentation/foundation/gesture-wrappers/icon-button';
+import { useRouter } from 'expo-router';
 
 interface ExerciseSectionProps {
   recordedExercise: RecordedExercise;
@@ -29,12 +33,14 @@ interface ExerciseSectionProps {
 export default function ExerciseSection(props: ExerciseSectionProps) {
   const { updateNotesForExercise, onRemoveExercise } = props;
   const { t } = useTranslate();
+  const { push } = useRouter();
   const { recordedExercise } = props;
   const [menuVisible, setMenuVisible] = useState(false);
   const [notesDialogOpen, setNotesDialogOpen] = useState(false);
   const [previousDialogOpen, setPreviousDialogOpen] = useState(false);
   const [removeExerciseDialogOpen, setRemoveExerciseDialogOpen] =
     useState(false);
+  const showStats = recordedExercise instanceof RecordedWeightedExercise;
   const showPrevious = () => {
     setPreviousDialogOpen(true);
   };
@@ -96,6 +102,19 @@ export default function ExerciseSection(props: ExerciseSectionProps) {
             setMenuVisible(false);
           }}
         />
+        {showStats ? (
+          <Menu.Item
+            onPress={() => {
+              push(
+                `/(tabs)/stats/expanded-weighted-exercise?exerciseName=${encodeURIComponent(recordedExercise.blueprint.name)}`,
+              );
+              setMenuVisible(false);
+            }}
+            testID="exercise-stats-menu-button"
+            leadingIcon={'analytics'}
+            title={t('stats.stats.title')}
+          />
+        ) : null}
         <Menu.Item
           onPress={() => {
             setRemoveExerciseDialogOpen(true);

--- a/app/components/presentation/workout/exercise-section.tsx
+++ b/app/components/presentation/workout/exercise-section.tsx
@@ -107,6 +107,7 @@ export default function ExerciseSection(props: ExerciseSectionProps) {
             onPress={() => {
               push(
                 `/(tabs)/stats/expanded-weighted-exercise?exerciseName=${encodeURIComponent(recordedExercise.blueprint.name)}`,
+                { withAnchor: true },
               );
               setMenuVisible(false);
             }}


### PR DESCRIPTION
Most of time, I ask myself how my e1RM has evolved recently for the current exercise.
However, getting to that page during the workout takes at least 5 or 6 clicks including searching for the exercise name. Imputing long names during a workout does not really work.

This adds a button to the dropdown menu during a workout that get the user to the full stat page of the exercise.

<img width="223" height="260" alt="image" src="https://github.com/user-attachments/assets/18313c2e-134d-4405-a095-d33083190a02" />

I used a generic "Stats" title for the button but we can rename it.