### PR TITLE
Order same-day history sessions by completionDateTime

### DIFF
--- a/app/services/progress-repository.ts
+++ b/app/services/progress-repository.ts
@@ -3,7 +3,7 @@ import { TemporalComparer } from '@/models/comparers';
 import { Session } from '@/models/session-models';
 import Enumerable from 'linq';
 import { RootState } from '@/store';
-import { ZoneId } from '@js-joda/core';
+import { getSessionReferenceTime } from '@/store/stored-sessions';
 
 export class ProgressRepository {
   constructor(private getState: () => RootState) {}
@@ -20,15 +20,6 @@ export class ProgressRepository {
 
     return Enumerable.from(sessions)
       .select((x) => Session.fromPOJO(x.value))
-      .orderByDescending((x) => x.date, TemporalComparer)
-      .thenByDescending(
-        (x) =>
-          x.lastExercise?.latestTime ??
-          x.date
-            .atStartOfDay()
-            .atZone(ZoneId.systemDefault())
-            .toOffsetDateTime(),
-        TemporalComparer,
-      );
+      .orderByDescending((x) => getSessionReferenceTime(x), TemporalComparer);
   }
 }

--- a/app/store/stored-sessions/index.spec.ts
+++ b/app/store/stored-sessions/index.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { LocalDate, OffsetDateTime, ZoneOffset, YearMonth } from '@js-joda/core';
+import BigNumber from 'bignumber.js';
+import { v4 as uuid } from 'uuid';
+import { selectSessionsInMonth } from '@/store/stored-sessions';
+import {
+  Rest,
+  SessionBlueprint,
+  WeightedExerciseBlueprint,
+} from '@/models/blueprint-models';
+import {
+  PotentialSet,
+  RecordedSet,
+  RecordedWeightedExercise,
+  Session,
+} from '@/models/session-models';
+import { Weight } from '@/models/weight';
+
+function createSessionWithCompletionTime(
+  sessionDate: LocalDate,
+  completionTime: OffsetDateTime,
+  name: string,
+) {
+  const blueprint = new SessionBlueprint(
+    name,
+    [
+      new WeightedExerciseBlueprint(
+        `${name} Exercise`,
+        1,
+        5,
+        new BigNumber(0),
+        Rest.medium,
+        false,
+        '',
+        '',
+      ),
+    ],
+    '',
+  );
+  const exerciseBlueprint = blueprint.exercises[0] as WeightedExerciseBlueprint;
+  const recordedExercise = new RecordedWeightedExercise(
+    exerciseBlueprint,
+    [
+      new PotentialSet(
+        new RecordedSet(exerciseBlueprint.repsPerSet, completionTime),
+        new Weight(100, 'kilograms'),
+      ),
+    ],
+    undefined,
+  );
+
+  return new Session(uuid(), blueprint, [recordedExercise], sessionDate, undefined);
+}
+
+describe('stored sessions sorting', () => {
+  it('sorts sessions in a month by the actual completion time, not only the date', () => {
+    const sameDay = LocalDate.of(2026, 4, 10);
+    const earlier = createSessionWithCompletionTime(
+      sameDay,
+      OffsetDateTime.of(2026, 4, 10, 8, 30, 0, 0, ZoneOffset.UTC),
+      'Morning',
+    );
+    const later = createSessionWithCompletionTime(
+      sameDay,
+      OffsetDateTime.of(2026, 4, 10, 18, 15, 0, 0, ZoneOffset.UTC),
+      'Evening',
+    );
+
+    const state = {
+      storedSessions: {
+        sessions: {
+          [earlier.id]: earlier.toPOJO(),
+          [later.id]: later.toPOJO(),
+        },
+      },
+    };
+
+    const ordered = selectSessionsInMonth(
+      state as never,
+      YearMonth.of(2026, 4),
+    );
+
+    expect(ordered.map((session) => session.blueprint.name)).toEqual([
+      'Evening',
+      'Morning',
+    ]);
+  });
+});

--- a/app/store/stored-sessions/index.ts
+++ b/app/store/stored-sessions/index.ts
@@ -363,16 +363,7 @@ export const selectSessionsInMonth = createSelector(
       .where(
         (x) => x.date.year() === ym.year() && x.date.month().equals(ym.month()),
       )
-      .orderByDescending((x) => x.date, TemporalComparer)
-      .thenByDescending(
-        (x) =>
-          x.lastExercise?.latestTime ??
-          x.date
-            .atStartOfDay()
-            .atZone(ZoneId.systemDefault())
-            .toOffsetDateTime(),
-        TemporalComparer,
-      )
+      .orderByDescending((x) => getSessionReferenceTime(x), TemporalComparer)
       .toArray(),
 );
 
@@ -391,7 +382,7 @@ export const selectExerciseIds = createSelector(
 
 export const storedSessionsReducer = storedSessionsSlice.reducer;
 
-function getSessionReferenceTime(session: Session): OffsetDateTime {
+export function getSessionReferenceTime(session: Session): OffsetDateTime {
   return (
     session.lastExercise?.latestTime ??
     session.date


### PR DESCRIPTION
Currently, when addind 2 sessions on the same day, they appear in a random order in the history as the current ordering is made using date only.

This uses completionDateTime to order the sessions.