### PR TITLE
feat: Tie exercise selection to the main exercise list 

### DIFF
--- a/app/app/(tabs)/settings/manage-workouts/[programId]/manage-session/[sessionIndex]/exercise.tsx
+++ b/app/app/(tabs)/settings/manage-workouts/[programId]/manage-session/[sessionIndex]/exercise.tsx
@@ -1,0 +1,64 @@
+import FullHeightScrollView from '@/components/layout/full-height-scroll-view';
+import { ExerciseEditor } from '@/components/presentation/workout-editor/exercise-editor';
+import { ExerciseBlueprint } from '@/models/blueprint-models';
+import { useAppSelector } from '@/store';
+import {
+  addExercise,
+  selectEditingExercise,
+  setEditingExerciseIndex,
+  updateSessionExercise,
+} from '@/store/session-editor';
+import { useTranslate } from '@tolgee/react';
+import { Stack, useRouter } from 'expo-router';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+export default function ExercisePage() {
+  const { t } = useTranslate();
+  const exercise = useAppSelector(selectEditingExercise);
+  const dispatch = useDispatch();
+  const { dismiss } = useRouter();
+  const exerciseIndex = useAppSelector(
+    (x) => x.sessionEditor.editingExerciseIndex,
+  );
+  const exerciseCount = useAppSelector(
+    (x) => x.sessionEditor.sessionBlueprint?.exercises?.length ?? 0,
+  );
+  const saveExercise = (exerciseToSave: ExerciseBlueprint) => {
+    if (!exerciseToSave) {
+      return;
+    }
+    if (exerciseIndex !== undefined) {
+      dispatch(
+        updateSessionExercise({
+          index: exerciseIndex,
+          exercise: exerciseToSave,
+        }),
+      );
+    } else {
+      dispatch(addExercise(exerciseToSave));
+      dispatch(setEditingExerciseIndex(exerciseCount));
+    }
+  };
+  const hasExercise = !!exercise;
+  useEffect(() => {
+    if (!hasExercise) {
+      dismiss();
+    }
+  }, [hasExercise, dismiss]);
+  if (!exercise) {
+    return;
+  }
+
+  return (
+    <FullHeightScrollView avoidKeyboard>
+      <ExerciseEditor
+        exercise={exercise}
+        updateExercise={(ex) => {
+          saveExercise(ex);
+        }}
+      />
+      <Stack.Screen options={{ title: t('exercise.edit.title') }} />
+    </FullHeightScrollView>
+  );
+}

--- a/app/app/(tabs)/settings/manage-workouts/[programId]/manage-session/[sessionIndex]/index.tsx
+++ b/app/app/(tabs)/settings/manage-workouts/[programId]/manage-session/[sessionIndex]/index.tsx
@@ -1,10 +1,8 @@
 import ConfirmationDialog from '@/components/presentation/foundation/confirmation-dialog';
 import EmptyInfo from '@/components/presentation/foundation/empty-info';
 import ExerciseBlueprintSummary from '@/components/presentation/workout-editor/exercise-blueprint-summary';
-import { ExerciseEditor } from '@/components/presentation/workout-editor/exercise-editor';
 import FloatingBottomContainer from '@/components/presentation/foundation/floating-bottom-container';
 import FullHeightScrollView from '@/components/layout/full-height-scroll-view';
-import FullScreenDialog from '@/components/presentation/foundation/full-screen-dialog';
 import ItemList from '@/components/presentation/foundation/item-list';
 import LabelledForm from '@/components/presentation/foundation/labelled-form';
 import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
@@ -25,13 +23,19 @@ import {
   moveExerciseUp,
   removeExercise,
   selectCurrentlyEditingSession,
+  setEditingExerciseIndex,
   setEditingSessionName,
   setEditingSessionNotes,
-  updateSessionExercise,
 } from '@/store/session-editor';
 import { T, useTranslate } from '@tolgee/react';
 import BigNumber from 'bignumber.js';
-import { Redirect, Stack, useLocalSearchParams } from 'expo-router';
+import {
+  Redirect,
+  Stack,
+  useFocusEffect,
+  useLocalSearchParams,
+  useRouter,
+} from 'expo-router';
 import { useState } from 'react';
 import { Card, FAB, TextInput } from 'react-native-paper';
 import { useDispatch, useStore } from 'react-redux';
@@ -69,11 +73,18 @@ function SessionEditor({
   const [selectedExercise, setSelectedExercise] = useState<
     ExerciseBlueprint | undefined
   >(undefined);
-  const [selectedExerciseIndex, setSelectedExerciseIndex] = useState<
-    number | undefined
-  >(undefined);
   const [isRemoveOpen, setIsRemoveOpen] = useState(false);
-  const [isEditOpen, setIsEditOpen] = useState(false);
+  const exerciseCount = useAppSelector(
+    (x) => x.sessionEditor.sessionBlueprint?.exercises?.length ?? 0,
+  );
+  const { push } = useRouter();
+  const openExerciseEditor = (exerciseIndex: number | undefined) => {
+    dispatch(setEditingExerciseIndex(exerciseIndex));
+
+    push(
+      `/settings/manage-workouts/${programId}/manage-session/${sessionIndex}/exercise`,
+    );
+  };
   const { t } = useTranslate();
   const saveSession = () => {
     // We need to get it again, as we likely dispatched, but the 'session' var will not have updated yet
@@ -87,21 +98,25 @@ function SessionEditor({
       }),
     );
   };
+  useFocusEffect(() => {
+    saveSession();
+  });
   const beginAddExercise = () => {
-    setSelectedExerciseIndex(undefined);
-    setSelectedExercise(
-      WeightedExerciseBlueprint.fromPOJO({
-        name: `Exercise ${session.exercises.length + 1}`,
-        repsPerSet: 10,
-        sets: 3,
-        weightIncreaseOnSuccess: BigNumber('2.5'),
-        link: '',
-        notes: '',
-        restBetweenSets: Rest.medium,
-        supersetWithNext: false,
-      }),
+    dispatch(
+      addExercise(
+        WeightedExerciseBlueprint.fromPOJO({
+          name: `Exercise ${session.exercises.length + 1}`,
+          repsPerSet: 10,
+          sets: 3,
+          weightIncreaseOnSuccess: BigNumber('2.5'),
+          link: '',
+          notes: '',
+          restBetweenSets: Rest.medium,
+          supersetWithNext: false,
+        }),
+      ),
     );
-    setIsEditOpen(true);
+    openExerciseEditor(exerciseCount);
   };
   const setName = (name: string) => {
     dispatch(setEditingSessionName(name));
@@ -110,23 +125,6 @@ function SessionEditor({
   const setNotes = (notes: string) => {
     dispatch(setEditingSessionNotes(notes));
     saveSession();
-  };
-  const saveExercise = () => {
-    if (!selectedExercise) {
-      return;
-    }
-    if (selectedExerciseIndex !== undefined) {
-      dispatch(
-        updateSessionExercise({
-          index: selectedExerciseIndex,
-          exercise: selectedExercise,
-        }),
-      );
-    } else {
-      dispatch(addExercise(selectedExercise));
-    }
-    saveSession();
-    setIsEditOpen(false);
   };
 
   const floatingBottomContainer = (
@@ -189,14 +187,11 @@ function SessionEditor({
                 sessionIndex={sessionIndex}
                 programId={programId}
                 beginEdit={() => {
-                  setSelectedExerciseIndex(index);
-                  setSelectedExercise(blueprint);
-                  setIsEditOpen(true);
+                  openExerciseEditor(index);
                 }}
                 beginRemove={() => {
                   setSelectedExercise(blueprint);
                   setIsRemoveOpen(true);
-                  setSelectedExerciseIndex(index);
                 }}
                 saveSession={saveSession}
               />
@@ -204,25 +199,6 @@ function SessionEditor({
           />
         </LabelledFormRow>
       </LabelledForm>
-      <FullScreenDialog
-        avoidKeyboard
-        open={!!selectedExercise && isEditOpen}
-        onClose={() => setIsEditOpen(false)}
-        title={
-          selectedExerciseIndex === undefined
-            ? t('exercise.add.title')
-            : t('exercise.edit.title')
-        }
-        action={t('generic.save.button')}
-        onAction={saveExercise}
-      >
-        {selectedExercise && (
-          <ExerciseEditor
-            exercise={selectedExercise}
-            updateExercise={setSelectedExercise}
-          />
-        )}
-      </FullScreenDialog>
       <ConfirmationDialog
         headline={t('exercise.remove.confirm.title')}
         onOk={() => {

--- a/app/components/layout/material-bottom-tabs.tsx
+++ b/app/components/layout/material-bottom-tabs.tsx
@@ -70,8 +70,6 @@ export function MaterialBottomTabs({
                 dismissTo(('/' + route.name) as '/');
               } else {
                 // Not focused: navigate normally
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-expect-error
                 navigation.dispatch({
                   ...CommonActions.navigate(route.name, route.params),
                   target: state.key, // target the tab navigator

--- a/app/components/presentation/workout-editor/exercise-editor.tsx
+++ b/app/components/presentation/workout-editor/exercise-editor.tsx
@@ -24,7 +24,11 @@ import {
   WeightedExerciseBlueprintPOJO,
 } from '@/models/blueprint-models';
 import { useAppSelector, useAppSelectorWithArg } from '@/store';
-import { selectExerciseById, selectExerciseIds } from '@/store/stored-sessions';
+import {
+  selectExerciseById,
+  selectExerciseIds,
+  updateExercise,
+} from '@/store/stored-sessions';
 import { assertUnreachable } from '@/utils/assert-unreachable';
 import BottomSheet, {
   useBottomSheetScrollableCreator,
@@ -44,6 +48,8 @@ import {
 import { match, P } from 'ts-pattern';
 import { LegendList } from '@legendapp/list';
 import { ExerciseDescriptor } from '@/models/exercise-models';
+import { useDispatch } from 'react-redux';
+import { uuid } from '@/utils/uuid';
 
 interface ExerciseEditorProps {
   exercise: ExerciseBlueprint;
@@ -58,15 +64,20 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
   const bottomSheetRef = useRef<BottomSheet>(null);
   const BottomSheetScrollView = useBottomSheetScrollableCreator();
   const selectExerciseFromSearch = (ex: ExerciseDescriptor) => {
-    updateExercise({ name: ex.name, notes: ex.instructions });
+    updateExercise({ name: ex.name });
+    setFilteredExerciseIds(exerciseIds);
+    setSuggestedNewExercise('NONE');
     bottomSheetRef.current?.close();
   };
 
   const [bottomSheetShown, setBottomSheetShown] = useState(false);
   const [filteredExerciseIds, setFilteredExerciseIds] = useState(exerciseIds);
+  const [suggestedNewExercise, setSuggestedNewExercise] = useState<
+    ExerciseDescriptor | 'NONE'
+  >('NONE');
   const exerciseListItems = useMemo(
-    () => ['filter', ...filteredExerciseIds],
-    [filteredExerciseIds],
+    () => ['filter', suggestedNewExercise, ...filteredExerciseIds] as const,
+    [filteredExerciseIds, suggestedNewExercise],
   );
   const { t } = useTranslate();
   const { exercise: propsExercise, updateExercise: updatePropsExercise } =
@@ -145,25 +156,18 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
             onValueChange={handleTypeChange}
           />
         </LabelledFormRow>
-        <LabelledFormRow label={t('exercise.name.label')} icon="infoFill">
-          <TextInput
-            testID="exercise-name"
+        <LabelledFormRow label={t('exercise.exercise.label')} icon="infoFill">
+          <Button
             mode="outlined"
-            style={{ marginBottom: spacing[2] }}
-            value={exercise.name}
-            onChangeText={(name) => updateExercise({ name })}
-            selectTextOnFocus={true}
-            right={
-              <TextInput.Icon
-                icon="search"
-                onPress={() => {
-                  setBottomSheetShown(true);
-                  Keyboard.dismiss();
-                  bottomSheetRef.current?.expand();
-                }}
-              />
-            }
-          />
+            icon={'search'}
+            onPress={() => {
+              setBottomSheetShown(true);
+              Keyboard.dismiss();
+              bottomSheetRef.current?.expand();
+            }}
+          >
+            {exercise.name}
+          </Button>
         </LabelledFormRow>
         {exerciseEditor}
       </LabelledForm>
@@ -177,19 +181,36 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
           <LegendList
             data={exerciseListItems}
             renderScrollComponent={BottomSheetScrollView}
-            getItemType={(_, index) => (index === 0 ? 'filters' : 'exercise')}
-            keyExtractor={(item, index) => (index === 0 ? 'filters' : item)}
+            getItemType={(_, index) =>
+              index === 0 ? 'filters' : index === 1 ? 'suggest' : 'exercise'
+            }
+            keyExtractor={(item, index) =>
+              index === 0
+                ? 'filters'
+                : index === 1
+                  ? 'suggest'
+                  : (item as string)
+            }
             renderItem={(i) => {
               if (i.index === 0) {
                 return (
                   <ExerciseFilterer
+                    onSuggestedNewExercise={setSuggestedNewExercise}
                     onFilteredExerciseIdsChange={setFilteredExerciseIds}
                   />
                 );
               }
+              if (i.index === 1) {
+                return i.item !== 'NONE' ? (
+                  <SuggestedExerciseSearchListItem
+                    exercise={i.item as ExerciseDescriptor}
+                    onPress={selectExerciseFromSearch}
+                  />
+                ) : undefined;
+              }
               return (
-                <ExerciseSearchListItem
-                  exerciseId={i.item}
+                <ExerciseIdSearchListItem
+                  exerciseId={i.item as string}
                   onPress={selectExerciseFromSearch}
                 />
               );
@@ -201,13 +222,34 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
   );
 }
 
-function ExerciseSearchListItem(props: {
+function ExerciseIdSearchListItem(props: {
   exerciseId: string;
   onPress: (exercise: ExerciseDescriptor) => void;
 }) {
   const exercise = useAppSelectorWithArg(selectExerciseById, props.exerciseId);
   return (
     <List.Item title={exercise.name} onPress={() => props.onPress(exercise)} />
+  );
+}
+
+function SuggestedExerciseSearchListItem(props: {
+  exercise: ExerciseDescriptor;
+  onPress: (exercise: ExerciseDescriptor) => void;
+}) {
+  const dispatch = useDispatch();
+  return (
+    <View style={{ padding: spacing.pageHorizontalMargin }}>
+      <Button
+        icon={'plus'}
+        mode="outlined"
+        onPress={() => {
+          dispatch(updateExercise({ id: uuid(), exercise: props.exercise }));
+          props.onPress(props.exercise);
+        }}
+      >
+        Add {props.exercise.name}
+      </Button>
+    </View>
   );
 }
 

--- a/app/components/presentation/workout-editor/exercise-filterer.tsx
+++ b/app/components/presentation/workout-editor/exercise-filterer.tsx
@@ -1,4 +1,5 @@
 import ExerciseSearchAndFilters from '@/components/presentation/workout-editor/exercise-search-and-filters';
+import { ExerciseDescriptor } from '@/models/exercise-models';
 import { useAppSelector } from '@/store';
 import { selectExercises } from '@/store/stored-sessions';
 import Enumerable from 'linq';
@@ -7,15 +8,22 @@ import { useDebouncedCallback } from 'use-debounce';
 
 export default function ExerciseFilterer(props: {
   onFilteredExerciseIdsChange: (ids: string[]) => void;
+  onSuggestedNewExercise: (
+    exerciseDescriptor: ExerciseDescriptor | 'NONE',
+  ) => void;
 }) {
   const exercises = useAppSelector(selectExercises);
-  const { onFilteredExerciseIdsChange } = props;
+  const { onFilteredExerciseIdsChange, onSuggestedNewExercise } = props;
   const [muscleFilters, setMuscleFilters] = useState([] as string[]);
   const [searchText, setSearchText] = useState('');
 
   const search = useDebouncedCallback(() => {
-    const searchRegex = new RegExp(escapeRegExp(searchText), 'i');
-    const matchRegex = new RegExp('^' + escapeRegExp(searchText) + '$', 'i');
+    const trimmed = searchText.trim();
+    const escaped = escapeRegExp(trimmed);
+    const searchRegex = new RegExp(escaped, 'i');
+    const startsWithRegex = new RegExp('^' + escaped, 'i');
+    const fullMatchRegex = new RegExp('^' + escaped + '$', 'i');
+    let hasExactMatch = false;
     const newFilteredExercises = Enumerable.from(Object.entries(exercises))
       .where(
         (x) =>
@@ -23,12 +31,36 @@ export default function ExerciseFilterer(props: {
             x[1].muscles.some((exerciseMuscle) =>
               muscleFilters.includes(exerciseMuscle),
             )) &&
-          (!searchText || searchRegex.test(x[1].name)),
+          (!trimmed || searchRegex.test(x[1].name)),
       )
-      .orderByDescending((x) => matchRegex.test(x[1].name))
+      .doAction((x) => {
+        if (!hasExactMatch && trimmed && fullMatchRegex.test(x[1].name)) {
+          hasExactMatch = true;
+        }
+      })
+      // If the exercise starts with the search term, then it is a good match and should be brought to the top
+      .orderByDescending(
+        (x) =>
+          (startsWithRegex.test(x[1].name) ? 1 : 0) +
+          (fullMatchRegex.test(x[1].name) ? 1 : 0),
+      )
       .select((x) => x[0])
       .toArray();
     onFilteredExerciseIdsChange(newFilteredExercises);
+    if (!hasExactMatch && searchText) {
+      onSuggestedNewExercise({
+        name: trimmed,
+        category: '',
+        equipment: null,
+        force: null,
+        instructions: '',
+        level: '',
+        mechanic: '',
+        muscles: muscleFilters,
+      });
+    } else {
+      onSuggestedNewExercise('NONE');
+    }
   }, 100);
 
   return (

--- a/app/components/presentation/workout-editor/exercise-search-and-filters.tsx
+++ b/app/components/presentation/workout-editor/exercise-search-and-filters.tsx
@@ -29,6 +29,7 @@ export default function ExerciseSearchAndFilters({
         placeholder={t('generic.search.button')}
         value={searchText}
         onChangeText={setSearchText}
+        autoCapitalize={'words'}
         autoCorrect={false}
         style={{ marginHorizontal: spacing.pageHorizontalMargin }}
         testID="exercise-search-input"

--- a/app/components/smart/exercise-manager.tsx
+++ b/app/components/smart/exercise-manager.tsx
@@ -197,6 +197,7 @@ export default function ExerciseManager() {
             return (
               <ExerciseFilterer
                 onFilteredExerciseIdsChange={setFilteredExerciseIds}
+                onSuggestedNewExercise={() => {}}
               />
             );
           }

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -249,6 +249,8 @@ PODS:
     - ExpoModulesCore
   - ExpoSplashScreen (55.0.12):
     - ExpoModulesCore
+  - ExpoSQLite (55.0.14):
+    - ExpoModulesCore
   - ExpoSymbols (55.0.5):
     - ExpoModulesCore
   - EXUpdatesInterface (55.1.3):
@@ -2628,6 +2630,7 @@ DEPENDENCIES:
   - ExpoRouter (from `../node_modules/expo-router/ios`)
   - ExpoSharing (from `../node_modules/expo-sharing/ios`)
   - ExpoSplashScreen (from `../node_modules/expo-splash-screen/ios`)
+  - ExpoSQLite (from `../node_modules/expo-sqlite/ios`)
   - ExpoSymbols (from `../node_modules/expo-symbols/ios`)
   - EXUpdatesInterface (from `../node_modules/expo-updates-interface/ios`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
@@ -2796,6 +2799,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-sharing/ios"
   ExpoSplashScreen:
     :path: "../node_modules/expo-splash-screen/ios"
+  ExpoSQLite:
+    :path: "../node_modules/expo-sqlite/ios"
   ExpoSymbols:
     :path: "../node_modules/expo-symbols/ios"
   EXUpdatesInterface:
@@ -3011,6 +3016,7 @@ SPEC CHECKSUMS:
   ExpoRouter: 2bef44d037beb8ba5a325ec9e9ab870bc7dd96a9
   ExpoSharing: a706da94ade9646338a63bbaa4320d4f1db02c45
   ExpoSplashScreen: 755302759fbcf4af56b8ad5fb76e535dcf812f91
+  ExpoSQLite: 2e093a6c9ca7b43736211a6ba1e3c38baa612b44
   ExpoSymbols: 3d67a96643245a5d933ce7fbf535f95eb541f617
   EXUpdatesInterface: d48f288b92900bd95a27c6cf92a7b9aff826d49a
   FBLazyVector: 32e9ed0301d0fcbc1b2b341dd7fcbf291f51eb83

--- a/app/models/session-models.ts
+++ b/app/models/session-models.ts
@@ -427,7 +427,7 @@ export function fromRecordedExercisePOJO(
     .exhaustive();
 }
 
-function fromRecordedExerciseJSON(
+export function fromRecordedExerciseJSON(
   pojo: RecordedExerciseJSON,
 ): RecordedExercise {
   return match(pojo)

--- a/app/models/session-models.ts
+++ b/app/models/session-models.ts
@@ -191,12 +191,12 @@ export class Session {
 
   with(other: Partial<Session>) {
     return new Session(
-      'id' in other ? other.id : this.id,
-      'blueprint' in other ? other.blueprint : this.blueprint,
+      'id' in other ? other.id! : this.id,
+      'blueprint' in other ? other.blueprint! : this.blueprint,
       'recordedExercises' in other
-        ? other.recordedExercises
+        ? other.recordedExercises!
         : this.recordedExercises,
-      'date' in other ? other.date : this.date,
+      'date' in other ? other.date! : this.date,
       'bodyweight' in other ? other.bodyweight! : this.bodyweight,
     );
   }
@@ -875,10 +875,10 @@ export class RecordedWeightedExercise {
   with(other: Partial<RecordedWeightedExercisePOJO>) {
     return new RecordedWeightedExercise(
       'blueprint' in other
-        ? WeightedExerciseBlueprint.fromPOJO(other.blueprint)
+        ? WeightedExerciseBlueprint.fromPOJO(other.blueprint!)
         : this.blueprint,
       'potentialSets' in other
-        ? other.potentialSets.map((x) => PotentialSet.fromPOJO(x))
+        ? other.potentialSets!.map((x) => PotentialSet.fromPOJO(x))
         : this.potentialSets,
       'notes' in other ? other.notes : this.notes,
     );
@@ -1035,9 +1035,9 @@ export class RecordedSet {
 
   with(other: Partial<RecordedSet>): RecordedSet {
     return new RecordedSet(
-      'repsCompleted' in other ? other.repsCompleted : this.repsCompleted,
+      'repsCompleted' in other ? other.repsCompleted! : this.repsCompleted,
       'completionDateTime' in other
-        ? other.completionDateTime
+        ? other.completionDateTime!
         : this.completionDateTime,
     );
   }
@@ -1115,7 +1115,7 @@ export class PotentialSet {
   with(other: Partial<PotentialSet>): PotentialSet {
     return new PotentialSet(
       'set' in other ? other.set : this.set,
-      'weight' in other ? other.weight : this.weight,
+      'weight' in other ? other.weight! : this.weight,
     );
   }
 

--- a/app/services/data-migrations/import-exercises-from-workouts.ts
+++ b/app/services/data-migrations/import-exercises-from-workouts.ts
@@ -1,0 +1,80 @@
+import { ExpoSQLiteDatabase } from 'drizzle-orm/expo-sqlite';
+import {
+  dataMigrationsSchema,
+  exercisesSchema,
+  sessionsSchema,
+} from '@/db/schema';
+import { MigratorVAnyToLatest } from '@/models/storage/versions/migrator';
+import Enumerable from 'linq';
+import { NormalizedName } from '@/models/blueprint-models';
+import { fromRecordedExerciseJSON } from '@/models/session-models';
+import {
+  ExerciseDescriptorJSON,
+  LatestVersion,
+} from '@/models/storage/versions/latest';
+import { uuid } from '@/utils/uuid';
+
+export const importExercisesFromWorkoutsDataMigration =
+  'IMPORT_EXERCISES_FROM_WORKOUTS';
+
+export async function importExercisesFromWorkouts(db: ExpoSQLiteDatabase) {
+  await db.transaction(async (tx) => {
+    const workouts = (await tx.select().from(sessionsSchema)).map((row) =>
+      MigratorVAnyToLatest.migrateSession(row.modelVersion, row.payload),
+    );
+    const existingExerciseNames = new Set(
+      (await tx.select().from(exercisesSchema))
+        .map((row) =>
+          MigratorVAnyToLatest.migrateExerciseDescriptor(
+            row.modelVersion,
+            row.payload,
+          ),
+        )
+        .map((x) => new NormalizedName(x.name).toString()),
+    );
+    const uniqueExercisesNotInList = Enumerable.from(workouts)
+      .selectMany((x) => x.recordedExercises)
+      .select(fromRecordedExerciseJSON)
+      .where(
+        (x) =>
+          !existingExerciseNames.has(
+            NormalizedName.fromExerciseBlueprint(x.blueprint).toString(),
+          ),
+      )
+      .distinct((x) =>
+        NormalizedName.fromExerciseBlueprint(x.blueprint).toString(),
+      );
+
+    const newExercises = uniqueExercisesNotInList
+      .select(
+        (ex) =>
+          ({
+            name: ex.blueprint.name,
+            category: 'Unknown',
+            equipment: null,
+            force: null,
+            instructions: '',
+            level: '',
+            mechanic: '',
+            muscles: [],
+          }) satisfies ExerciseDescriptorJSON,
+      )
+      .select(
+        (payload) =>
+          ({
+            id: uuid(),
+            modelVersion: LatestVersion,
+            payload,
+          }) satisfies typeof exercisesSchema.$inferInsert,
+      )
+      .toArray();
+
+    if (newExercises.length) {
+      await tx.insert(exercisesSchema).values(newExercises);
+    }
+
+    await tx
+      .insert(dataMigrationsSchema)
+      .values({ id: importExercisesFromWorkoutsDataMigration });
+  });
+}

--- a/app/services/database-migration-service.ts
+++ b/app/services/database-migration-service.ts
@@ -21,6 +21,10 @@ import {
   importExercises,
   importExercisesDataMigration,
 } from './data-migrations/import-exercises';
+import {
+  importExercisesFromWorkouts,
+  importExercisesFromWorkoutsDataMigration,
+} from '@/services/data-migrations/import-exercises-from-workouts';
 
 export class DatabaseMigrationService {
   // DO NOT Add a dependency to getState here, it gets messy quick
@@ -45,6 +49,9 @@ export class DatabaseMigrationService {
     }
     if (!dataMigrationsRun.includes(importExercisesDataMigration)) {
       await importExercises(this.db, this.keyValueStore);
+    }
+    if (!dataMigrationsRun.includes(importExercisesFromWorkoutsDataMigration)) {
+      await importExercisesFromWorkouts(this.db);
     }
 
     // We always want to update all entities to the latest version

--- a/app/store/session-editor/index.ts
+++ b/app/store/session-editor/index.ts
@@ -1,6 +1,7 @@
 import {
   ExerciseBlueprint,
   ExerciseBlueprintPOJO,
+  fromExerciseBlueprintPOJO,
   SessionBlueprint,
   SessionBlueprintPOJO,
 } from '@/models/blueprint-models';
@@ -8,10 +9,12 @@ import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 const initialState: SessionEditorState = {
   sessionBlueprint: undefined,
+  editingExerciseIndex: undefined,
 };
 
 export type SessionEditorState = {
   sessionBlueprint: SessionBlueprintPOJO | undefined;
+  editingExerciseIndex: number | undefined;
 };
 
 const sessionEditorSlice = createSlice({
@@ -38,6 +41,9 @@ const sessionEditorSlice = createSlice({
       if (state.sessionBlueprint) {
         state.sessionBlueprint.exercises.push(action.payload.toPOJO());
       }
+    },
+    setEditingExerciseIndex(state, action: PayloadAction<number | undefined>) {
+      state.editingExerciseIndex = action.payload;
     },
     removeExercise(state, action: PayloadAction<ExerciseBlueprint>) {
       if (state.sessionBlueprint) {
@@ -103,6 +109,13 @@ const sessionEditorSlice = createSlice({
       (state: SessionEditorState) => state.sessionBlueprint,
       (x) => (x ? SessionBlueprint.fromPOJO(x) : undefined),
     ),
+    selectEditingExercise: createSelector(
+      (state: SessionEditorState) =>
+        state.editingExerciseIndex !== undefined &&
+        state.sessionBlueprint?.exercises[state.editingExerciseIndex],
+      (exercise) =>
+        exercise ? fromExerciseBlueprintPOJO(exercise) : undefined,
+    ),
   },
 });
 
@@ -111,12 +124,14 @@ export const {
   moveExerciseDown,
   moveExerciseUp,
   removeExercise,
+  setEditingExerciseIndex,
   setEditingSession,
   setEditingSessionName,
   setEditingSessionNotes,
   updateSessionExercise,
 } = sessionEditorSlice.actions;
 
-export const { selectCurrentlyEditingSession } = sessionEditorSlice.selectors;
+export const { selectCurrentlyEditingSession, selectEditingExercise } =
+  sessionEditorSlice.selectors;
 
 export const sessionEditorReducer = sessionEditorSlice.reducer;


### PR DESCRIPTION
Rather than letting users type in arbitrary exercise names, when editing exercises they will now need to select from the exercise list. They can search for their exercise in the list. If it is not there, a button appears allowing them to add it to the list in one tap.

This should help users type consistent names for their exercises for tracking purposes.

This is a WIP in terms of UI/UX. It still feels a little clunky, I think we should probably try drop the bottom sheet.

Ignore the duplicate entries when searching, there was a bug in the migration to add previously completed exercises to the list.

https://github.com/user-attachments/assets/707349ea-da49-4921-b630-6d1d13577e96


Still TODO:
- [ ] Migrate exercises from programs into the exercise list
- [x] Trim exercise names
- [ ] Ensure uniqueness on names for exercises in the exercise list
- [x] Figure out UI

