### PR TITLE
feat: Restyle exercise editor

### DIFF
--- a/app/app/(tabs)/feed/index.tsx
+++ b/app/app/(tabs)/feed/index.tsx
@@ -59,7 +59,7 @@ export default function FeedIndexPage() {
           </TabScreen>
           <TabScreen
             label={t('feed.followers.title')}
-            badge={followRequestBadgeCount!}
+            badge={followRequestBadgeCount}
           >
             <ScrollProvider
               isScrolled={!!tabScrolls[activeTabIndex]}

--- a/app/app/(tabs)/history/index.tsx
+++ b/app/app/(tabs)/history/index.tsx
@@ -53,11 +53,6 @@ export default function History() {
     selectCurrentSession,
     'workoutSession',
   );
-  const openWorkoutStats = (session: Session) => {
-    push(
-      `/history/post-workout?sessionId=${encodeURIComponent(session.id)}&source=history`,
-    );
-  };
   const onSelectSession = (session: Session) => {
     dispatch(setCurrentSession({ target: 'historySession', session }));
     push('/history/edit');

--- a/app/app/(tabs)/settings/backup-and-restore/plain-text-export.tsx
+++ b/app/app/(tabs)/settings/backup-and-restore/plain-text-export.tsx
@@ -1,5 +1,5 @@
 import FullHeightScrollView from '@/components/layout/full-height-scroll-view';
-import LabelledForm from '@/components/presentation/foundation/labelled-form';
+import Form from '@/components/presentation/foundation/form';
 import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
 import { SurfaceText } from '@/components/presentation/foundation/surface-text';
 import { spacing } from '@/hooks/useAppTheme';
@@ -47,7 +47,7 @@ export default function PlainTextExportPage() {
           </Button>
         </Card.Content>
       </Card>
-      <LabelledForm>
+      <Form>
         <LabelledFormRow
           label={t('backup.plaintext_export.format.label')}
           icon={'descriptionFill'}
@@ -62,7 +62,7 @@ export default function PlainTextExportPage() {
             onSelect={(s) => s && setFormat(s as PlaintextExportFormat)}
           ></Dropdown>
         </LabelledFormRow>
-      </LabelledForm>
+      </Form>
       <View
         style={{
           flexDirection: 'row',

--- a/app/app/(tabs)/settings/backup-and-restore/remote-backup.tsx
+++ b/app/app/(tabs)/settings/backup-and-restore/remote-backup.tsx
@@ -1,6 +1,6 @@
 import EmptyInfo from '@/components/presentation/foundation/empty-info';
 import FullHeightScrollView from '@/components/layout/full-height-scroll-view';
-import LabelledForm from '@/components/presentation/foundation/labelled-form';
+import Form from '@/components/presentation/foundation/form';
 import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
 import LimitedHtml from '@/components/presentation/foundation/limited-html';
 import ListSwitch from '@/components/presentation/foundation/list-switch';
@@ -98,7 +98,7 @@ export default function RemoteBackupPage() {
           </Button>
         </Card.Content>
       </Card>
-      <LabelledForm>
+      <Form>
         <LabelledFormRow label={t('backup.endpoint.label')} icon={'publicFill'}>
           <TextInput
             mode="outlined"
@@ -125,7 +125,7 @@ export default function RemoteBackupPage() {
           value={includeFeedAccountValue}
           onValueChange={setIncludeFeedAccount}
         />
-      </LabelledForm>
+      </Form>
       <View
         style={{
           flexDirection: 'row',

--- a/app/app/(tabs)/settings/manage-workouts/[programId]/manage-session/[sessionIndex]/index.tsx
+++ b/app/app/(tabs)/settings/manage-workouts/[programId]/manage-session/[sessionIndex]/index.tsx
@@ -4,7 +4,7 @@ import ExerciseBlueprintSummary from '@/components/presentation/workout-editor/e
 import FloatingBottomContainer from '@/components/presentation/foundation/floating-bottom-container';
 import FullHeightScrollView from '@/components/layout/full-height-scroll-view';
 import ItemList from '@/components/presentation/foundation/item-list';
-import LabelledForm from '@/components/presentation/foundation/labelled-form';
+import Form from '@/components/presentation/foundation/form';
 import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
 import LimitedHtml from '@/components/presentation/foundation/limited-html';
 import CopyExerciseDialog from '@/components/smart/copy-exercise-dialog';
@@ -143,7 +143,7 @@ function SessionEditor({
   return (
     <FullHeightScrollView floatingChildren={floatingBottomContainer}>
       <Stack.Screen options={{ title: session.name }} />
-      <LabelledForm>
+      <Form>
         <LabelledFormRow
           label={t('workout.name.label')}
           icon={'assignmentFill'}
@@ -198,7 +198,7 @@ function SessionEditor({
             )}
           />
         </LabelledFormRow>
-      </LabelledForm>
+      </Form>
       <ConfirmationDialog
         headline={t('exercise.remove.confirm.title')}
         onOk={() => {

--- a/app/components/presentation/foundation/app-bottom-sheet.tsx
+++ b/app/components/presentation/foundation/app-bottom-sheet.tsx
@@ -18,7 +18,7 @@ export default function AppBottomSheet({
     <Portal>
       <BottomSheet
         ref={sheetRef}
-        snapPoints={snapPoints ?? ['40%', '80%']}
+        snapPoints={snapPoints ?? ['80%']}
         backgroundStyle={[
           { backgroundColor: colors.surfaceContainerHighest },
           backgroundStyle,

--- a/app/components/presentation/foundation/editors/decimal-editor.tsx
+++ b/app/components/presentation/foundation/editors/decimal-editor.tsx
@@ -42,7 +42,7 @@ export function DecimalEditor(props: DecimalEditorProps) {
   }, [value, editorValue]);
   return (
     <TextInput
-      testID={props.testID!}
+      testID={props.testID}
       value={text}
       inputMode={'decimal'}
       keyboardType={'decimal-pad'}

--- a/app/components/presentation/foundation/editors/editable-incrementer.tsx
+++ b/app/components/presentation/foundation/editors/editable-incrementer.tsx
@@ -10,6 +10,7 @@ import { TextInput } from 'react-native-paper';
 interface EditableIncrementerProps {
   value: BigNumber;
   suffix?: string;
+  label?: string;
   onChange: (val: BigNumber) => void;
   disallowNegative?: boolean;
   testID?: string;
@@ -51,10 +52,11 @@ export default function EditableIncrementer(props: EditableIncrementerProps) {
       }}
     >
       <TextInput
-        testID={props.testID!}
+        testID={props.testID}
         mode="outlined"
         value={text}
         style={{ flex: 1 }}
+        label={props.label}
         inputMode={'decimal'}
         keyboardType={'decimal-pad'}
         onChangeText={handleTextChange}

--- a/app/components/presentation/foundation/editors/fixed-incrementer.tsx
+++ b/app/components/presentation/foundation/editors/fixed-incrementer.tsx
@@ -1,7 +1,10 @@
 import { IntegerEditor } from '@/components/presentation/foundation/editors/integer-editor';
 import IconButton from '@/components/presentation/foundation/gesture-wrappers/icon-button';
-import { useAppTheme, font } from '@/hooks/useAppTheme';
-import { Text, View } from 'react-native';
+import { AppIconSource } from '@/components/presentation/foundation/ms-icon-source';
+import { useAppTheme, font, spacing, rounding } from '@/hooks/useAppTheme';
+import { View } from 'react-native';
+import { Text } from 'react-native-paper';
+import { match } from 'ts-pattern';
 
 interface FixedIncrementerProps {
   value: number;
@@ -12,50 +15,122 @@ interface FixedIncrementerProps {
 
 export default function FixedIncrementer(props: FixedIncrementerProps) {
   const { colors } = useAppTheme();
+  const betweenRadius = rounding.segmentedBetweenRadius;
+  const capRadius = 10;
 
   return (
-    <View testID={props.testID}>
+    <View
+      testID={props.testID}
+      style={{
+        gap: spacing[0.5],
+        justifyContent: 'center',
+      }}
+    >
       <Text
+        variant="labelLarge"
         style={{
-          color: colors.onSurface,
-          ...font['text-lg'],
           textAlign: 'center',
         }}
       >
         {props.label}
       </Text>
 
-      <IntegerEditor
+      <View
         style={{
-          color: colors.primary,
-          ...font['text-2xl'],
-          fontWeight: 'bold',
-          textAlign: 'center',
-          flex: 1,
+          borderTopStartRadius: capRadius,
+          borderTopEndRadius: capRadius,
+          borderBottomStartRadius: betweenRadius,
+          borderBottomEndRadius: betweenRadius,
+          backgroundColor: colors.surfaceVariant,
+          overflow: 'hidden',
+          alignItems: 'center',
         }}
-        onChange={props.onValueChange}
-        value={props.value}
-        testID="fixed-value-input"
-      />
-
+      >
+        <IntegerEditor
+          style={{
+            color: colors.onSurfaceVariant,
+            ...font['text-xl'],
+            fontWeight: 'bold',
+            textAlign: 'center',
+            backgroundColor: colors.surfaceVariant,
+            flex: 1,
+          }}
+          noUnderline
+          onChange={props.onValueChange}
+          value={props.value}
+          testID="fixed-value-input"
+        />
+      </View>
       <View
         style={{
           flexDirection: 'row',
           justifyContent: 'space-between',
           alignItems: 'center',
+          gap: spacing[0.5],
         }}
       >
-        <IconButton
+        <ContainedSegmentIconButton
           icon={'remove'}
           onPress={() => props.onValueChange(props.value - 1)}
+          position="start"
           testID="fixed-decrement"
         />
-        <IconButton
+        <ContainedSegmentIconButton
           icon={'add'}
           onPress={() => props.onValueChange(props.value + 1)}
+          position="end"
           testID="fixed-increment"
         />
       </View>
     </View>
+  );
+}
+
+interface ContainedSegmentIconButtonProps {
+  position: 'start' | 'end' | 'middle';
+  icon: AppIconSource;
+  onPress: () => void;
+  testID?: string;
+}
+function ContainedSegmentIconButton(props: ContainedSegmentIconButtonProps) {
+  const { colors } = useAppTheme();
+  const betweenRadius = rounding.segmentedBetweenRadius;
+  const capRadius = 10;
+  const radius = match(props.position)
+    .with('start', () => ({
+      borderTopStartRadius: betweenRadius,
+      borderTopEndRadius: betweenRadius,
+      borderBottomStartRadius: capRadius,
+      borderBottomEndRadius: betweenRadius,
+    }))
+    .with('middle', () => ({
+      borderTopStartRadius: betweenRadius,
+      borderTopEndRadius: betweenRadius,
+      borderBottomStartRadius: betweenRadius,
+      borderBottomEndRadius: betweenRadius,
+    }))
+    .with('end', () => ({
+      borderTopStartRadius: betweenRadius,
+      borderTopEndRadius: betweenRadius,
+      borderBottomStartRadius: betweenRadius,
+      borderBottomEndRadius: capRadius,
+    }))
+    .exhaustive();
+  return (
+    <IconButton
+      testID={props.testID}
+      mode="contained-tonal"
+      icon={props.icon}
+      onPress={props.onPress}
+      iconColor={colors.onSurfaceVariant}
+      style={[
+        radius,
+        {
+          margin: 0,
+          backgroundColor: colors.surfaceVariant,
+          flex: 1,
+        },
+      ]}
+    />
   );
 }

--- a/app/components/presentation/foundation/editors/integer-editor.tsx
+++ b/app/components/presentation/foundation/editors/integer-editor.tsx
@@ -5,6 +5,7 @@ import { TextInput } from 'react-native-paper';
 interface IntegerEditorProps {
   value: number;
   onChange: (val: number) => void;
+  noUnderline?: boolean | undefined;
   style?: TextStyle;
   testID?: string;
 }
@@ -37,11 +38,12 @@ export function IntegerEditor(props: IntegerEditorProps) {
   }, [value, editorValue]);
   return (
     <TextInput
-      testID={props.testID!}
+      testID={props.testID}
       value={text}
       inputMode={'numeric'}
       keyboardType={'numeric'}
       onChangeText={handleTextChange}
+      underlineStyle={props.noUnderline ? { display: 'none' } : {}}
       selectTextOnFocus
       style={[props.style]}
       // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain

--- a/app/components/presentation/foundation/form-row.tsx
+++ b/app/components/presentation/foundation/form-row.tsx
@@ -1,0 +1,15 @@
+import { spacing } from '@/hooks/useAppTheme';
+import { ReactNode } from 'react';
+import { View } from 'react-native';
+
+export function FormRow(props: {
+  children: ReactNode;
+  undoFormPadding?: boolean | undefined;
+  noGap?: boolean | undefined;
+}) {
+  const margin = props.undoFormPadding
+    ? { marginHorizontal: -spacing.pageHorizontalMargin }
+    : {};
+  const gap = props.noGap ? {} : { gap: spacing[3] };
+  return <View style={[margin, gap]}>{props.children}</View>;
+}

--- a/app/components/presentation/foundation/form.tsx
+++ b/app/components/presentation/foundation/form.tsx
@@ -2,7 +2,7 @@ import { spacing } from '@/hooks/useAppTheme';
 import { ReactNode } from 'react';
 import { View } from 'react-native';
 
-export default function LabelledForm(props: { children: ReactNode }) {
+export default function Form(props: { children: ReactNode }) {
   return (
     <View
       style={{

--- a/app/components/presentation/foundation/full-screen-dialog.tsx
+++ b/app/components/presentation/foundation/full-screen-dialog.tsx
@@ -55,8 +55,8 @@ export default function FullScreenDialog(props: FullScreenDialogProps) {
           >
             <Header
               onClose={onClose}
-              action={action!}
-              onAction={onAction!}
+              action={action}
+              onAction={onAction}
               title={title}
             />
             {props.noScroll ? (
@@ -72,7 +72,7 @@ export default function FullScreenDialog(props: FullScreenDialogProps) {
               </View>
             ) : (
               <FullHeightScrollView
-                avoidKeyboard={props.avoidKeyboard!}
+                avoidKeyboard={props.avoidKeyboard}
                 scrollStyle={{
                   padding: spacing.pageHorizontalMargin,
                 }}

--- a/app/components/presentation/foundation/gesture-wrappers/button.tsx
+++ b/app/components/presentation/foundation/gesture-wrappers/button.tsx
@@ -31,7 +31,7 @@ export default function Button({
   return (
     <GestureDetector gesture={gesture}>
       <NativeButton
-        disabled={disabled!}
+        disabled={disabled}
         onPress={onPress ? () => {} : undefined!}
         onLongPress={onLongPress || onPress ? () => {} : undefined!}
         {...rest}

--- a/app/components/presentation/foundation/gesture-wrappers/icon-button.tsx
+++ b/app/components/presentation/foundation/gesture-wrappers/icon-button.tsx
@@ -35,7 +35,7 @@ export default function IconButton({
   return (
     <GestureDetector gesture={gesture}>
       <NativeIconButton
-        disabled={disabled!}
+        disabled={disabled}
         onPress={onPress ? () => {} : undefined!}
         onLongPress={onLongPress || onPress ? () => {} : undefined!}
         style={[

--- a/app/components/presentation/foundation/gesture-wrappers/touchable-ripple.tsx
+++ b/app/components/presentation/foundation/gesture-wrappers/touchable-ripple.tsx
@@ -27,7 +27,7 @@ export default function TouchableRipple({
   return (
     <GestureDetector gesture={gesture}>
       <NativeTouchableRipple
-        disabled={disabled!}
+        disabled={disabled}
         onPress={onPress ? () => {} : undefined!}
         // Disable long press since we should be using Holdable for this
         onLongPress={onLongPress || onPress ? () => {} : undefined!}

--- a/app/components/presentation/foundation/labelled-form-row.tsx
+++ b/app/components/presentation/foundation/labelled-form-row.tsx
@@ -1,3 +1,4 @@
+import { FormRow } from '@/components/presentation/foundation/form-row';
 import { AppIconSource } from '@/components/presentation/foundation/ms-icon-source';
 import { SurfaceText } from '@/components/presentation/foundation/surface-text';
 import { spacing, useAppTheme } from '@/hooks/useAppTheme';
@@ -13,18 +14,23 @@ export default function LabelledFormRow(props: {
   noGap?: boolean;
 }) {
   const { colors } = useAppTheme();
-  const margin = props.undoFormPadding
-    ? { marginHorizontal: -spacing.pageHorizontalMargin }
+  const labelPadding = props.undoFormPadding
+    ? {
+        paddingHorizontal: spacing.pageHorizontalMargin,
+      }
     : {};
   return (
-    <View style={{ gap: props.noGap ? undefined! : spacing[3] }}>
+    <FormRow noGap={props.noGap} undoFormPadding={props.undoFormPadding}>
       <View
-        style={{ flexDirection: 'row', alignItems: 'center', gap: spacing[2] }}
+        style={[
+          { flexDirection: 'row', alignItems: 'center', gap: spacing[2] },
+          labelPadding,
+        ]}
       >
         <Icon source={props.icon as string} size={20} color={colors.primary} />
         <SurfaceText font="text-xl">{props.label}</SurfaceText>
       </View>
-      <View style={margin}>{props.children}</View>
-    </View>
+      <View>{props.children}</View>
+    </FormRow>
   );
 }

--- a/app/components/presentation/foundation/list-switch.android.tsx
+++ b/app/components/presentation/foundation/list-switch.android.tsx
@@ -29,20 +29,20 @@ export default function ListSwitch(props: ListSwitchProps) {
 
   return (
     <List.Item
-      testID={props.testID!}
+      testID={props.testID}
       title={props.headline}
       description={props.supportingText}
       onPress={() => props.onValueChange(!props.value)}
       style={{
         backgroundColor: props.focus ? colors.tertiary + '33' : undefined!,
       }}
-      disabled={props.disabled!}
-      left={props.left!}
+      disabled={props.disabled}
+      left={props.left}
       right={() =>
         delayRender && (
           <Switch
             value={props.value}
-            disabled={props.disabled!}
+            disabled={props.disabled}
             onValueChange={props.onValueChange}
           />
         )

--- a/app/components/presentation/foundation/list-switch.tsx
+++ b/app/components/presentation/foundation/list-switch.tsx
@@ -17,19 +17,19 @@ export default function ListSwitch(props: ListSwitchProps) {
   const { colors } = useAppTheme();
   return (
     <List.Item
-      testID={props.testID!}
+      testID={props.testID}
       title={props.headline}
       style={{
         backgroundColor: props.focus ? colors.tertiary + '33' : undefined!,
       }}
       description={props.supportingText}
       onPress={() => props.onValueChange(!props.value)}
-      disabled={props.disabled!}
-      left={props.left!}
+      disabled={props.disabled}
+      left={props.left}
       right={() => (
         <Switch
           value={props.value}
-          disabled={props.disabled!}
+          disabled={props.disabled}
           onValueChange={props.onValueChange}
         />
       )}

--- a/app/components/presentation/foundation/ms-icon-source.tsx
+++ b/app/components/presentation/foundation/ms-icon-source.tsx
@@ -109,6 +109,10 @@ import { msAvgTime } from '@material-symbols-react-native/outlined-400/msAvgTime
 import { msAnchor } from '@material-symbols-react-native/outlined-400/msAnchor';
 import { msFunction } from '@material-symbols-react-native/outlined-400/msFunction';
 import { msHeartCheck } from '@material-symbols-react-native/outlined-400/msHeartCheck';
+import { msContentPasteSearch } from '@material-symbols-react-native/outlined-400/msContentPasteSearch';
+import { msLink } from '@material-symbols-react-native/outlined-400/msLink';
+import { msSteps } from '@material-symbols-react-native/outlined-400/msSteps';
+import { msElevation } from '@material-symbols-react-native/outlined-400/msElevation';
 
 // Importing these icons using the below methods causes android app to crash
 // import { msAdd, msArrowDownward } from '@material-symbols-react-native/outlined-400';
@@ -154,7 +158,11 @@ const MaterialSymbols = {
   promptSuggestion: msPromptSuggestion,
   send: msSend,
   bolt: msBolt,
+  link: msLink,
+  steps: msSteps,
+  elevation: msElevation,
   remove: msRemove,
+  contentPasteSearch: msContentPasteSearch,
   doNotDisturbOn: msDoNotDisturbOn,
   save: msSave,
   forum: msForum,

--- a/app/components/presentation/foundation/segmented-list-switch.tsx
+++ b/app/components/presentation/foundation/segmented-list-switch.tsx
@@ -1,0 +1,30 @@
+import { AppIconSource } from '@/components/presentation/foundation/ms-icon-source';
+import { SegmentListFormElement } from '@/components/presentation/foundation/segmented-list';
+import { Switch } from 'react-native-paper';
+
+interface ListSwitchProps {
+  label: string;
+  icon: AppIconSource;
+  value: boolean;
+  onValueChange: (value: boolean) => void;
+  testID?: string;
+  disabled?: boolean;
+}
+
+export function SegmentedListSwitch(props: ListSwitchProps) {
+  return (
+    <SegmentListFormElement
+      label={props.label}
+      icon={props.icon}
+      // onPress={() => props.onValueChange(!props.value)}
+      right={
+        <Switch
+          value={props.value}
+          disabled={props.disabled}
+          testID={props.testID}
+          onValueChange={props.onValueChange}
+        />
+      }
+    />
+  );
+}

--- a/app/components/presentation/foundation/segmented-list.tsx
+++ b/app/components/presentation/foundation/segmented-list.tsx
@@ -1,15 +1,17 @@
-import { spacing, useAppTheme } from '@/hooks/useAppTheme';
+import Icon from '@/components/presentation/foundation/gesture-wrappers/icon';
+import { AppIconSource } from '@/components/presentation/foundation/ms-icon-source';
+import { rounding, spacing, useAppTheme } from '@/hooks/useAppTheme';
 import { useBottomSheetScrollableCreator } from '@gorhom/bottom-sheet';
 import { LegendList } from '@legendapp/list';
 import { ReactNode } from 'react';
 import { StyleSheet, View, ViewStyle } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { Card } from 'react-native-paper';
+import { Card, Text } from 'react-native-paper';
 import { match } from 'ts-pattern';
 
 export function SegmentedList<T>(props: {
   renderItem: (item: T, index: number) => ReactNode;
-  onItemPress?: (item: T) => void;
+  onItemPress?: (item: T, index: number) => void;
   itemKey?: (item: T, index: number) => string;
   items: T[];
   scrollable?: boolean;
@@ -28,7 +30,7 @@ export function SegmentedList<T>(props: {
             key={itemKey(item, index)}
             isFirst={index === 0}
             isLast={index === props.items.length - 1}
-            onPress={onItemPress ? () => onItemPress(item) : undefined}
+            onPress={onItemPress ? () => onItemPress(item, index) : undefined}
           >
             {props.renderItem(item, index)}
           </SegmentedListItem>
@@ -52,12 +54,40 @@ export function SegmentedList<T>(props: {
           key={itemKey(item, index)}
           isFirst={index === 0}
           isLast={index === props.items.length - 1}
-          onPress={onItemPress ? () => onItemPress(item) : undefined}
+          onPress={onItemPress ? () => onItemPress(item, index) : undefined}
         >
           {props.renderItem(item, index)}
         </SegmentedListItem>
       )}
     />
+  );
+}
+
+export function SegmentListFormElement(props: {
+  label: string;
+  icon: AppIconSource;
+  right?: ReactNode | string;
+}) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}
+    >
+      <View
+        style={{ flexDirection: 'row', gap: spacing[2], alignItems: 'center' }}
+      >
+        <Icon size={20} source={props.icon} />
+        <Text variant="labelLarge">{props.label}</Text>
+      </View>
+      {typeof props.right === 'string' ? (
+        <Text variant="labelLarge">{props.right}</Text>
+      ) : (
+        props.right
+      )}
+    </View>
   );
 }
 
@@ -95,17 +125,17 @@ function SegmentedListItem(props: {
 const styles = StyleSheet.create({
   onlyItem: {},
   firstItem: {
-    borderBottomLeftRadius: 2,
-    borderBottomRightRadius: 2,
+    borderBottomLeftRadius: rounding.segmentedBetweenRadius,
+    borderBottomRightRadius: rounding.segmentedBetweenRadius,
   },
   middleItem: {
-    borderTopLeftRadius: 2,
-    borderTopRightRadius: 2,
-    borderBottomLeftRadius: 2,
-    borderBottomRightRadius: 2,
+    borderTopLeftRadius: rounding.segmentedBetweenRadius,
+    borderTopRightRadius: rounding.segmentedBetweenRadius,
+    borderBottomLeftRadius: rounding.segmentedBetweenRadius,
+    borderBottomRightRadius: rounding.segmentedBetweenRadius,
   },
   lastItem: {
-    borderTopLeftRadius: 2,
-    borderTopRightRadius: 2,
+    borderTopLeftRadius: rounding.segmentedBetweenRadius,
+    borderTopRightRadius: rounding.segmentedBetweenRadius,
   },
 });

--- a/app/components/presentation/foundation/select-button.tsx
+++ b/app/components/presentation/foundation/select-button.tsx
@@ -46,7 +46,7 @@ export default function SelectButton<
       }}
       anchor={
         <Button
-          testID={testID!}
+          testID={testID}
           icon={open ? 'arrowDropUp' : 'arrowDropDown'}
           onPress={() => {
             setOpen(true);

--- a/app/components/presentation/summary/session-diff-view.tsx
+++ b/app/components/presentation/summary/session-diff-view.tsx
@@ -191,14 +191,14 @@ function DiffChangeRow({
 
   return (
     <List.Item
-      disabled={disabled!}
+      disabled={disabled}
       onPress={onToggle}
       title={t(label.key, label.params)}
       titleStyle={variantColor ? { color: variantColor } : undefined}
       description={t(description.key, description.params)}
       left={() => (
         <Checkbox
-          disabled={disabled!}
+          disabled={disabled}
           status={selected ? 'checked' : 'unchecked'}
         />
       )}

--- a/app/components/presentation/workout-editor/exercise-editor.tsx
+++ b/app/components/presentation/workout-editor/exercise-editor.tsx
@@ -4,10 +4,8 @@ import EditableIncrementer from '@/components/presentation/foundation/editors/ed
 import ExerciseFilterer from '@/components/presentation/workout-editor/exercise-filterer';
 import FixedIncrementer from '@/components/presentation/foundation/editors/fixed-incrementer';
 import Button from '@/components/presentation/foundation/gesture-wrappers/button';
-import LabelledForm from '@/components/presentation/foundation/labelled-form';
-import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
-import ListSwitch from '@/components/presentation/foundation/list-switch';
-import RestEditorGroup from '@/components/presentation/workout-editor/rest-editor-group';
+import Form from '@/components/presentation/foundation/form';
+import { RestEditorDialog } from '@/components/presentation/workout-editor/rest-editor-dialog';
 import SelectButton from '@/components/presentation/foundation/select-button';
 import { spacing, useAppTheme } from '@/hooks/useAppTheme';
 import {
@@ -36,20 +34,22 @@ import BottomSheet, {
 import { Duration } from '@js-joda/core';
 import { T, useTranslate } from '@tolgee/react';
 import BigNumber from 'bignumber.js';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Keyboard, View } from 'react-native';
-import {
-  Card,
-  Divider,
-  List,
-  SegmentedButtons,
-  TextInput,
-} from 'react-native-paper';
+import { Divider, List, SegmentedButtons, TextInput } from 'react-native-paper';
 import { match, P } from 'ts-pattern';
 import { LegendList } from '@legendapp/list';
 import { ExerciseDescriptor } from '@/models/exercise-models';
 import { useDispatch } from 'react-redux';
 import { uuid } from '@/utils/uuid';
+import { FormRow } from '@/components/presentation/foundation/form-row';
+import {
+  SegmentedList,
+  SegmentListFormElement,
+} from '@/components/presentation/foundation/segmented-list';
+import { SegmentedListSwitch } from '@/components/presentation/foundation/segmented-list-switch';
+import RestFormat from '@/components/presentation/foundation/rest-format';
+import { KeysOfType } from '@/utils/types';
 
 interface ExerciseEditorProps {
   exercise: ExerciseBlueprint;
@@ -79,7 +79,6 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
     () => ['filter', suggestedNewExercise, ...filteredExerciseIds] as const,
     [filteredExerciseIds, suggestedNewExercise],
   );
-  const { t } = useTranslate();
   const { exercise: propsExercise, updateExercise: updatePropsExercise } =
     props;
   const [exercise, setExercise] = useState(propsExercise);
@@ -127,12 +126,22 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
     .exhaustive();
 
   return (
-    <View style={{ gap: spacing[4] }}>
-      <LabelledForm>
-        <LabelledFormRow
-          label={t('exercise.type.label')}
-          icon={'fitnessCenterFill'}
-        >
+    <View style={{ paddingVertical: spacing.pageHorizontalMargin }}>
+      <Form>
+        <FormRow>
+          <Button
+            icon={'contentPasteSearch'}
+            mode="contained"
+            onPress={() => {
+              setBottomSheetShown(true);
+              Keyboard.dismiss();
+              bottomSheetRef.current?.expand();
+            }}
+          >
+            {exercise.name}
+          </Button>
+        </FormRow>
+        <FormRow>
           <SegmentedButtons
             value={
               exercise instanceof WeightedExerciseBlueprint
@@ -155,22 +164,9 @@ export function ExerciseEditor(props: ExerciseEditorProps) {
             ]}
             onValueChange={handleTypeChange}
           />
-        </LabelledFormRow>
-        <LabelledFormRow label={t('exercise.exercise.label')} icon="infoFill">
-          <Button
-            mode="outlined"
-            icon={'search'}
-            onPress={() => {
-              setBottomSheetShown(true);
-              Keyboard.dismiss();
-              bottomSheetRef.current?.expand();
-            }}
-          >
-            {exercise.name}
-          </Button>
-        </LabelledFormRow>
+        </FormRow>
         {exerciseEditor}
-      </LabelledForm>
+      </Form>
       <AppBottomSheet
         index={-1}
         sheetRef={bottomSheetRef}
@@ -321,56 +317,82 @@ function CardioSetEditor(props: {
 }) {
   const { t } = useTranslate();
   const { set, updateSet } = props;
+  const toggleSetItem =
+    (item: KeysOfType<CardioExerciseSetBlueprint, boolean>) => () =>
+      updateSet(set.with({ [item]: !set[item] }));
   return (
     <>
       <CardioTargetEditor
         target={set.target}
         onValueChange={(target) => updateSet(set.with({ target }))}
       />
-      <List.Section>
-        <ListSwitch
-          value={set.trackDuration || set.target.type === 'time'}
-          testID="track-time-switch"
-          onValueChange={(trackDuration) =>
-            updateSet(set.with({ trackDuration }))
-          }
-          headline={t('exercise.track_time.label')}
-          disabled={set.target.type === 'time'}
-        />
-        <ListSwitch
-          value={set.trackDistance || set.target.type === 'distance'}
-          testID="track-distance-switch"
-          onValueChange={(trackDistance) =>
-            updateSet(set.with({ trackDistance }))
-          }
-          headline={t('exercise.track_distance.label')}
-          disabled={set.target.type === 'distance'}
-        />
-        <ListSwitch
-          value={set.trackResistance}
-          onValueChange={(trackResistance) =>
-            updateSet(set.with({ trackResistance }))
-          }
-          headline={t('exercise.track_resistance.label')}
-        />
-        <ListSwitch
-          value={set.trackIncline}
-          onValueChange={(trackIncline) =>
-            updateSet(set.with({ trackIncline }))
-          }
-          headline={t('exercise.track_incline.label')}
-        />
-        <ListSwitch
-          value={set.trackWeight}
-          onValueChange={(trackWeight) => updateSet(set.with({ trackWeight }))}
-          headline={t('exercise.track_weight.label')}
-        />
-        <ListSwitch
-          value={set.trackSteps}
-          onValueChange={(trackSteps) => updateSet(set.with({ trackSteps }))}
-          headline={t('exercise.track_steps.label')}
-        />
-      </List.Section>
+      <SegmentedList
+        renderItem={(i) => i[0]}
+        onItemPress={([_, toggle]) => toggle()}
+        items={
+          [
+            [
+              <SegmentedListSwitch
+                value={set.trackDuration || set.target.type === 'time'}
+                testID="track-time-switch"
+                icon={'timer'}
+                onValueChange={toggleSetItem('trackDuration')}
+                label={t('exercise.track_time.label')}
+                disabled={set.target.type === 'time'}
+              />,
+              toggleSetItem('trackDuration'),
+            ],
+            [
+              <SegmentedListSwitch
+                value={set.trackDistance || set.target.type === 'distance'}
+                icon={'trailLength'}
+                testID="track-distance-switch"
+                onValueChange={toggleSetItem('trackDistance')}
+                label={t('exercise.track_distance.label')}
+                disabled={set.target.type === 'distance'}
+              />,
+              toggleSetItem('trackDistance'),
+            ],
+            [
+              <SegmentedListSwitch
+                icon={'speed'}
+                value={set.trackResistance}
+                onValueChange={toggleSetItem('trackResistance')}
+                label={t('exercise.track_resistance.label')}
+              />,
+              toggleSetItem('trackResistance'),
+            ],
+            [
+              <SegmentedListSwitch
+                value={set.trackIncline}
+                icon={'elevation'}
+                onValueChange={toggleSetItem('trackIncline')}
+                label={t('exercise.track_incline.label')}
+              />,
+              toggleSetItem('trackIncline'),
+            ],
+            [
+              <SegmentedListSwitch
+                value={set.trackWeight}
+                icon={'weight'}
+                onValueChange={toggleSetItem('trackWeight')}
+                label={t('exercise.track_weight.label')}
+              />,
+              toggleSetItem('trackWeight'),
+            ],
+            [
+              <SegmentedListSwitch
+                value={set.trackSteps}
+                icon={'steps'}
+                onValueChange={toggleSetItem('trackSteps')}
+                label={t('exercise.track_steps.label')}
+              />,
+              toggleSetItem('trackSteps'),
+            ],
+          ] as const
+        }
+      />
+
       <Divider />
     </>
   );
@@ -388,29 +410,28 @@ function SharedFieldsEditor({
   const { t } = useTranslate();
   return (
     <>
-      <LabelledFormRow label={t('plan.notes.label')} icon="notesFill">
+      <FormRow>
         <TextInput
           mode="outlined"
+          label={t('plan.notes.label')}
           testID="exercise-notes"
           style={{ marginBottom: spacing[2] }}
           value={exercise.notes}
           onChangeText={(notes) => updateExercise({ notes })}
           multiline
         />
-      </LabelledFormRow>
-      <LabelledFormRow
-        label={t('generic.external_link.label')}
-        icon="publicFill"
-      >
+      </FormRow>
+      <FormRow>
         <TextInput
           mode="outlined"
           testID="exercise-link"
+          label={t('generic.external_link.label')}
           style={{ marginBottom: spacing[2] }}
           placeholder="https://"
           value={exercise.link}
           onChangeText={(link) => updateExercise({ link })}
         />
-      </LabelledFormRow>
+      </FormRow>
     </>
   );
 }
@@ -449,10 +470,7 @@ function CardioTargetEditor(props: {
   };
   return (
     <>
-      <LabelledFormRow
-        label={t('exercise.cardio_target.label')}
-        icon={'targetFill'}
-      >
+      <FormRow>
         <SegmentedButtons
           value={target.type}
           onValueChange={handleTypeChange}
@@ -471,7 +489,7 @@ function CardioTargetEditor(props: {
             },
           ]}
         />
-      </LabelledFormRow>
+      </FormRow>
 
       {matchCardioTarget(target, {
         distance: (t) => (
@@ -542,6 +560,8 @@ function WeightedExerciseEditor({
   updateExercise: (ex: Partial<ExerciseBlueprint>) => void;
 }) {
   const { t } = useTranslate();
+  const { colors } = useAppTheme();
+  const [restDialogOpen, setRestDialogOpen] = useState(false);
 
   const setSets = (value: number) =>
     updateExercise({ sets: Math.max(value, 1) });
@@ -563,55 +583,78 @@ function WeightedExerciseEditor({
           marginBlockEnd: spacing[2],
         }}
       >
-        <Card style={{ flex: 1 }} mode="contained">
-          <Card.Content>
-            <FixedIncrementer
-              label={t('exercise.sets.label')}
-              onValueChange={setSets}
-              value={exercise.sets}
-              testID="exercise-sets"
-            />
-          </Card.Content>
-        </Card>
-        <Card style={{ flex: 1 }} mode="contained">
-          <Card.Content>
-            <FixedIncrementer
-              label={t('exercise.reps.label')}
-              onValueChange={setReps}
-              value={exercise.repsPerSet}
-              testID="exercise-reps"
-            />
-          </Card.Content>
-        </Card>
+        <View style={{ flex: 1 }}>
+          <FixedIncrementer
+            label={t('exercise.sets.label')}
+            onValueChange={setSets}
+            value={exercise.sets}
+            testID="exercise-sets"
+          />
+        </View>
+        <View style={{ flex: 1 }}>
+          <FixedIncrementer
+            label={t('exercise.reps.label')}
+            onValueChange={setReps}
+            value={exercise.repsPerSet}
+            testID="exercise-reps"
+          />
+        </View>
       </View>
 
       <SharedFieldsEditor exercise={exercise} updateExercise={updateExercise} />
 
-      <LabelledFormRow
-        label={t('exercise.progressive_overload.label')}
-        icon="speedFill"
-      >
+      <FormRow>
         <EditableIncrementer
+          label={t('exercise.progressive_overload.label')}
           testID="exercise-auto-increase"
           value={exercise.weightIncreaseOnSuccess}
           onChange={setExerciseWeightIncrease}
         />
-      </LabelledFormRow>
+      </FormRow>
 
-      <RestEditorGroup
-        rest={exercise.restBetweenSets}
+      <RestEditorDialog
         onRestUpdated={(restBetweenSets) => updateExercise({ restBetweenSets })}
+        rest={exercise.restBetweenSets}
+        dialogOpen={restDialogOpen}
+        setDialogOpen={setRestDialogOpen}
       />
+      <FormRow>
+        <SegmentedList
+          items={[
+            <SegmentListFormElement
+              label={t('rest.rest.label')}
+              icon={'airlineSeatReclineExtraFill'}
+              right={
+                <RestFormat
+                  style={{ color: colors.onSurface }}
+                  rest={exercise.restBetweenSets}
+                />
+              }
+            />,
 
-      <ListSwitch
-        headline={t('workout.superset_next_exercise.button')}
-        value={exercise.supersetWithNext}
-        supportingText=""
-        testID="exercise-superset"
-        onValueChange={(supersetWithNext) =>
-          updateExercise({ supersetWithNext })
-        }
-      />
+            <SegmentedListSwitch
+              label={t('workout.superset_next_exercise.button')}
+              icon={'link'}
+              value={exercise.supersetWithNext}
+              testID="exercise-superset"
+              onValueChange={(supersetWithNext) =>
+                updateExercise({ supersetWithNext })
+              }
+            />,
+          ]}
+          renderItem={(i) => i}
+          onItemPress={(_, i) => {
+            match(i)
+              .with(0, () => setRestDialogOpen(true))
+              .with(1, () =>
+                updateExercise({
+                  supersetWithNext: !exercise.supersetWithNext,
+                }),
+              )
+              .run();
+          }}
+        />
+      </FormRow>
     </View>
   );
 }

--- a/app/components/presentation/workout-editor/rest-editor-dialog.tsx
+++ b/app/components/presentation/workout-editor/rest-editor-dialog.tsx
@@ -6,19 +6,23 @@ import { Duration } from '@js-joda/core';
 import { useTranslate } from '@tolgee/react';
 import { useState } from 'react';
 import { View } from 'react-native';
-import { SegmentedButtons } from 'react-native-paper';
 import { match } from 'ts-pattern';
-import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
+import { Dialog, SegmentedButtons } from 'react-native-paper';
+import { Portal } from 'react-native-paper';
+import Button from '@/components/presentation/foundation/gesture-wrappers/button';
 
 type ButtonValues = 'short' | 'medium' | 'long' | 'custom';
 
 interface RestEditorGroupProps {
   rest: Rest;
   onRestUpdated: (rest: Rest) => void;
+  dialogOpen: boolean;
+  setDialogOpen: (open: boolean) => void;
 }
-export default function RestEditorGroup(props: RestEditorGroupProps) {
+export function RestEditorDialog(props: RestEditorGroupProps) {
   const { colors } = useAppTheme();
   const { t } = useTranslate();
+
   const { onRestUpdated, rest } = props;
   const [buttonValue, setButtonValue] = useState(
     match(rest)
@@ -70,36 +74,45 @@ export default function RestEditorGroup(props: RestEditorGroupProps) {
       </View>
     );
   return (
-    <LabelledFormRow
-      label={t('rest.rest.label')}
-      icon="airlineSeatReclineExtraFill"
-    >
-      <View style={{ width: '100%' }}>
-        <SegmentedButtons
-          style={{ width: '100%' }}
-          value={buttonValue}
-          onValueChange={(s) => handleValueChange(s as ButtonValues)}
-          buttons={[
-            {
-              value: 'short',
-              label: t('rest.short.label'),
-            },
-            {
-              value: 'medium',
-              label: t('rest.medium.label'),
-            },
-            {
-              value: 'long',
-              label: t('rest.long.label'),
-            },
-            {
-              value: 'custom',
-              label: t('generic.custom.label'),
-            },
-          ]}
-        />
-      </View>
-      {customView}
-    </LabelledFormRow>
+    <Portal>
+      <Dialog
+        visible={props.dialogOpen}
+        onDismiss={() => props.setDialogOpen(false)}
+      >
+        <Dialog.Content>
+          <View style={{ width: '100%' }}>
+            <SegmentedButtons
+              style={{ width: '100%' }}
+              value={buttonValue}
+              onValueChange={(s) => handleValueChange(s as ButtonValues)}
+              buttons={[
+                {
+                  value: 'short',
+                  label: t('rest.short.label'),
+                },
+                {
+                  value: 'medium',
+                  label: t('rest.medium.label'),
+                },
+                {
+                  value: 'long',
+                  label: t('rest.long.label'),
+                },
+                {
+                  value: 'custom',
+                  label: t('generic.custom.label'),
+                },
+              ]}
+            />
+          </View>
+          {customView}
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button onPress={() => props.setDialogOpen(false)}>
+            {t('generic.close.button')}
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
   );
 }

--- a/app/components/smart/feed.tsx
+++ b/app/components/smart/feed.tsx
@@ -2,7 +2,7 @@ import CardActions from '@/components/presentation/foundation/card-actions';
 import ConfirmationDialog from '@/components/presentation/foundation/confirmation-dialog';
 import EmptyInfo from '@/components/presentation/foundation/empty-info';
 import FullScreenDialog from '@/components/presentation/foundation/full-screen-dialog';
-import LabelledForm from '@/components/presentation/foundation/labelled-form';
+import Form from '@/components/presentation/foundation/form';
 import LabelledFormRow from '@/components/presentation/foundation/labelled-form-row';
 import ListSwitch from '@/components/presentation/foundation/list-switch';
 import { Remote } from '@/components/presentation/foundation/remote';
@@ -200,7 +200,7 @@ function FeedProfileEditor({
           marginHorizontal: -spacing.pageHorizontalMargin,
         }}
       >
-        <LabelledForm>
+        <Form>
           <LabelledFormRow
             icon={'personFill'}
             label={t('feed.your_name.label')}
@@ -213,7 +213,7 @@ function FeedProfileEditor({
               onChangeText={(name) => updateProfile({ name })}
             />
           </LabelledFormRow>
-        </LabelledForm>
+        </Form>
         <List.Section>
           <ListSwitch
             testID="feed-publish-workouts-switch"

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable */
 const { defineConfig, globalIgnores } = require('eslint/config');
 
-const prettier = require('eslint-plugin-prettier');
 const reactCompiler = require('eslint-plugin-react-compiler');
 const unusedImports = require('eslint-plugin-unused-imports');
 const typescriptEslint = require('@typescript-eslint/eslint-plugin');
@@ -38,7 +37,6 @@ module.exports = defineConfig([
   {
     extends: compat.extends(
       'expo',
-      'prettier',
       'plugin:@typescript-eslint/recommended-type-checked',
     ),
     ignores: [
@@ -54,14 +52,12 @@ module.exports = defineConfig([
       'types/dom.slim.d.ts',
     ],
     plugins: {
-      prettier,
       'react-compiler': reactCompiler,
       'unused-imports': unusedImports,
       '@typescript-eslint': typescriptEslint,
     },
 
     rules: {
-      'prettier/prettier': 'error',
       'import/no-unresolved': 'off',
       'react-compiler/react-compiler': 'error',
       'unused-imports/no-unused-imports': 'error',

--- a/app/hooks/useAppTheme.tsx
+++ b/app/hooks/useAppTheme.tsx
@@ -23,6 +23,7 @@ import {
 export const rounding = {
   roundedRectangleRadius: 10,
   roundedRectangleFocusRingRadius: 15,
+  segmentedBetweenRadius: 2,
 };
 
 export const spacing = {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -12,7 +12,7 @@
       "@/*": ["./*"]
     },
     "types": ["vitest"],
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": false
   },
   "include": [
     "**/*.ts",

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -1,0 +1,3 @@
+export type KeysOfType<T, TKeyType> = {
+  [K in keyof T]: T[K] extends TKeyType ? K : never;
+}[keyof T];


### PR DESCRIPTION
This change restyles the exercise editor a bit to update it to material expressive 3.

It uses segmented list for the form elements and drops the labelled form. It's not perfect, definitely could use some tweaking, but it is a more efficient use of space

## Before

<img width="361" height="763" alt="image" src="https://github.com/user-attachments/assets/6708579a-1ba8-489a-aa6a-34b8b8dac62b" />
<img width="358" height="759" alt="image" src="https://github.com/user-attachments/assets/436f8b64-ff11-4058-aefd-2f20508ec3d6" />
<img width="367" height="764" alt="image" src="https://github.com/user-attachments/assets/e81f8518-91dc-4bcc-8c3c-2e3da8f1bbc1" />


## After

<img width="364" height="755" alt="image" src="https://github.com/user-attachments/assets/9d78f39d-4760-4f55-b0d5-378bfe74e671" />

<img width="362" height="757" alt="image" src="https://github.com/user-attachments/assets/6cf44e17-391f-40ff-9b45-d8e3c9054747" />
