### PR TITLE
Add in-app rest timer stop button

### DIFF
--- a/app/src/components/presentation/workout/rest-timer.tsx
+++ b/app/src/components/presentation/workout/rest-timer.tsx
@@ -7,6 +7,9 @@ import { Animated, Easing, View, ViewStyle } from 'react-native';
 import { SurfaceText } from '@/components/presentation/foundation/surface-text';
 import { impactAsync, ImpactFeedbackStyle } from 'expo-haptics';
 import Holdable from '@/components/presentation/foundation/holdable';
+import IconButton from '@/components/presentation/foundation/gesture-wrappers/icon-button';
+import { Tooltip } from 'react-native-paper';
+import { useTranslate } from '@tolgee/react';
 
 interface RestTimerProps {
   rest: Rest;
@@ -14,6 +17,8 @@ interface RestTimerProps {
   failed: boolean;
   style?: ViewStyle;
   resetTimer: () => void;
+  stopTimer: () => void;
+  allowStopTimer?: boolean;
 }
 
 export default function RestTimer({
@@ -22,8 +27,11 @@ export default function RestTimer({
   failed,
   style,
   resetTimer,
+  stopTimer,
+  allowStopTimer = true,
 }: RestTimerProps) {
   const { colors } = useAppTheme();
+  const { t } = useTranslate();
   const isSameMinMaxRest = rest.minRest.equals(rest.maxRest);
   const [jiggled, setJiggled] = useState([] as string[]);
 
@@ -36,15 +44,14 @@ export default function RestTimer({
     const diffMs = Duration.between(startTime, now);
     const timeSinceStart = formatTimeSpan(diffMs);
     const firstProgressBarProgress = failed
-      ? Math.min(diffMs.toMillis() / rest.failureRest.toMillis(), 1)
-      : Math.min(diffMs.toMillis() / rest.minRest.toMillis(), 1);
+      ? clampProgress(diffMs.toMillis() / rest.failureRest.toMillis())
+      : clampProgress(diffMs.toMillis() / rest.minRest.toMillis());
     const secondProgressBarProgress =
       failed || isSameMinMaxRest
         ? -1
-        : Math.min(
+        : clampProgress(
             (diffMs.toMillis() - rest.minRest.toMillis()) /
               (rest.maxRest.toMillis() - rest.minRest.toMillis()),
-            1,
           );
     const [textColor, backgroundColor]: [ColorChoice, ColorChoice] =
       firstProgressBarProgress < 1
@@ -125,6 +132,7 @@ export default function RestTimer({
 
   const pillHeight = spacing[14];
   const pillWidth = pillHeight * 2.2;
+  const stopButtonSize = spacing[10];
   const radius = (pillHeight - 6) / 2;
   const straightLength = pillWidth - pillHeight;
   const pillPerimeter = 2 * straightLength + 2 * Math.PI * radius;
@@ -144,74 +152,109 @@ export default function RestTimer({
     outputRange: [`${-amplitude}rad`, `${amplitude}rad`],
     extrapolate: 'clamp',
   });
+  const showStopButton =
+    allowStopTimer && timerState.firstProgressBarProgress >= 1;
+  const showSecondProgressBar =
+    !failed && !isSameMinMaxRest && timerState.secondProgressBarProgress > 0;
 
   return (
-    <Holdable
-      onLongPress={() => {
-        resetTimer();
-        triggerJiggle('reset');
-      }}
+    <View
+      style={[
+        {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: spacing[2],
+        },
+        style,
+      ]}
     >
-      <Animated.View
-        testID="rest-timer"
-        style={[
-          {
-            width: pillWidth,
-            height: pillHeight,
-            pointerEvents: 'none',
-            overflow: 'hidden',
-            borderRadius: pillHeight,
-            backgroundColor: colors[timerState.backgroundColor],
-            alignItems: 'center',
-            justifyContent: 'center',
-          },
-          style,
-          { transform: [{ rotateZ }] },
-        ]}
+      {allowStopTimer ? (
+        showStopButton ? (
+          <Tooltip title={t('rest.timer.stop.action')}>
+            <IconButton
+              testID="rest-timer-stop-button"
+              icon="stop"
+              accessibilityLabel={t('rest.timer.stop.action')}
+              iconColor={colors.onPrimary}
+              containerColor={colors.primary}
+              mode="contained"
+              size={20}
+              style={{
+                width: stopButtonSize,
+                height: stopButtonSize,
+                margin: 0,
+                borderRadius: stopButtonSize / 2,
+              }}
+              onPress={stopTimer}
+            />
+          </Tooltip>
+        ) : (
+          <View style={{ width: stopButtonSize, height: stopButtonSize }} />
+        )
+      ) : null}
+      <Holdable
+        onLongPress={() => {
+          resetTimer();
+          triggerJiggle('reset');
+        }}
       >
-        <View
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: '100%',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+        <Animated.View
+          testID="rest-timer"
+          style={[
+            {
+              width: pillWidth,
+              height: pillHeight,
+              pointerEvents: 'none',
+              overflow: 'hidden',
+              borderRadius: pillHeight,
+              backgroundColor: colors[timerState.backgroundColor],
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+            { transform: [{ rotateZ }] },
+          ]}
         >
-          <Svg width={pillWidth} height={pillHeight}>
-            <PillProgressBar
-              color={colors.primary}
-              progress={timerState.firstProgressBarProgress}
-              pillWidth={pillWidth}
-              pillHeight={pillHeight}
-              pillPerimeter={pillPerimeter}
-            />
-            <PillProgressBar
-              color={colors.orange}
-              progress={timerState.secondProgressBarProgress}
-              pillWidth={pillWidth}
-              pillHeight={pillHeight}
-              pillPerimeter={pillPerimeter}
-              visible={
-                !failed &&
-                !isSameMinMaxRest &&
-                timerState.secondProgressBarProgress > 0
-              }
-            />
-          </Svg>
-        </View>
-        <SurfaceText
-          style={{ fontVariant: ['tabular-nums'] }}
-          font="text-2xl"
-          weight="bold"
-          color={timerState.textColor}
-        >
-          {timerState.timeSinceStart}
-        </SurfaceText>
-      </Animated.View>
-    </Holdable>
+          <View
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Svg width={pillWidth} height={pillHeight}>
+              <PillProgressBar
+                color={colors.primary}
+                progress={timerState.firstProgressBarProgress}
+                pillWidth={pillWidth}
+                pillHeight={pillHeight}
+                pillPerimeter={pillPerimeter}
+              />
+              <PillProgressBar
+                color={colors.orange}
+                progress={timerState.secondProgressBarProgress}
+                pillWidth={pillWidth}
+                pillHeight={pillHeight}
+                pillPerimeter={pillPerimeter}
+                visible={showSecondProgressBar}
+              />
+            </Svg>
+          </View>
+          <SurfaceText
+            style={{ fontVariant: ['tabular-nums'] }}
+            font="text-2xl"
+            weight="bold"
+            color={timerState.textColor}
+          >
+            {timerState.timeSinceStart}
+          </SurfaceText>
+        </Animated.View>
+      </Holdable>
+    </View>
   );
 }
 
@@ -220,6 +263,10 @@ function formatTimeSpan(ms: Duration): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function clampProgress(value: number): number {
+  return Math.min(Math.max(value, 0), 1);
 }
 
 const AnimatedPath = Animated.createAnimatedComponent(Path);

--- a/app/src/components/smart/session-component.tsx
+++ b/app/src/components/smart/session-component.tsx
@@ -9,6 +9,7 @@ import {
   setCompletionTimeForCardioExercise,
   setExerciseReps,
   setWorkoutSessionLastSetTime,
+  stopRestTimer,
   updateBodyweight,
   updateCurrentBlockStartTimeForCardioExercise,
   updateDistanceForCardioExercise,
@@ -53,6 +54,7 @@ import { DelayRender } from '../presentation/foundation/delay-render';
 import { Loader } from '../presentation/foundation/loader';
 import WeightFormat from '../presentation/foundation/weight-format';
 import { formatDuration } from '@/utils/format-date';
+import { getRestTimerExercise } from '@/store/current-session/helpers';
 
 export default function SessionComponent(props: {
   target: SessionTarget;
@@ -385,10 +387,10 @@ export default function SessionComponent(props: {
     </Card>
   ) : null;
 
-  const lastExercise = session.lastExercise;
+  const restTimerExercise = getRestTimerExercise(session, lastSetTime);
   const lastRecordedSet =
-    lastExercise instanceof RecordedWeightedExercise
-      ? lastExercise?.lastRecordedSet
+    restTimerExercise instanceof RecordedWeightedExercise
+      ? restTimerExercise?.lastRecordedSet
       : undefined;
   const nextExercise = session.nextExercise;
   // We only want to show the rest timer - which is primarily for weights
@@ -397,38 +399,33 @@ export default function SessionComponent(props: {
     props.target === 'workoutSession' &&
     nextExercise &&
     nextExercise instanceof RecordedWeightedExercise &&
-    lastExercise &&
-    lastExercise instanceof RecordedWeightedExercise &&
+    restTimerExercise &&
     lastSetTime;
   const lastSetFailed =
     lastRecordedSet?.set &&
-    lastExercise &&
-    lastExercise instanceof RecordedWeightedExercise &&
-    lastRecordedSet.set.repsCompleted < lastExercise.blueprint.repsPerSet;
+    restTimerExercise &&
+    lastRecordedSet.set.repsCompleted < restTimerExercise.blueprint.repsPerSet;
   const restTimer = showRestTimer ? (
-    <View style={{ flex: 1 }}>
-      <RestTimer
-        rest={lastExercise.blueprint.restBetweenSets}
-        startTime={lastSetTime}
-        failed={!!lastSetFailed}
-        resetTimer={resetTimer}
-      />
-    </View>
+    <RestTimer
+      rest={restTimerExercise.blueprint.restBetweenSets}
+      startTime={lastSetTime}
+      failed={!!lastSetFailed}
+      resetTimer={resetTimer}
+      stopTimer={() => storeDispatch(stopRestTimer())}
+    />
   ) : undefined;
   const saveButton = props.saveAndClose && (
-    <View style={{ flex: 1, flexDirection: 'row', justifyContent: 'flex-end' }}>
-      <FAB
-        onPress={props.saveAndClose}
-        variant="surface"
-        icon={'inventory'}
-        testID="save-session-button"
-        label={
-          props.target === 'workoutSession'
-            ? t('generic.finish.button')
-            : t('generic.save.button')
-        }
-      ></FAB>
-    </View>
+    <FAB
+      onPress={props.saveAndClose}
+      variant="surface"
+      icon={'inventory'}
+      testID="save-session-button"
+      label={
+        props.target === 'workoutSession'
+          ? t('generic.finish.button')
+          : t('generic.save.button')
+      }
+    ></FAB>
   );
 
   const floatingBottomContainer = isReadonly ? null : (
@@ -438,10 +435,12 @@ export default function SessionComponent(props: {
           style={{
             flexDirection: 'row',
             alignItems: 'center',
+            gap: spacing[4],
           }}
         >
-          <View style={{ flex: 1 }}></View>
-          {restTimer}
+          <View style={{ flex: 1, alignItems: 'center', minWidth: 0 }}>
+            {restTimer}
+          </View>
           {saveButton}
         </View>
       }

--- a/app/src/i18n/ar.json
+++ b/app/src/i18n/ar.json
@@ -255,6 +255,7 @@
   "rest.rest.label": "قصير",
   "rest.short.label": "قصير",
   "rest.singular.label": "راحة <em>{time}</em>",
+  "rest.timer.stop.action": "إيقاف المؤقت",
   "settings.app_configuration.subtitle": "ضبط المظهر وإعدادات أخرى متنوعة",
   "settings.app_configuration.title": "إعدادات التطبيق",
   "settings.app_info.subtitle": "عرض معلومات التطبيق",

--- a/app/src/i18n/cs.json
+++ b/app/src/i18n/cs.json
@@ -204,6 +204,7 @@
   "rest.notifications.title": "Notifikace odpočinku",
   "rest.short.label": "Krátký",
   "rest.singular.label": "Odpočívejte <em>{time}</em>",
+  "rest.timer.stop.action": "Zastavit časovač",
   "settings.app_configuration.subtitle": "Nastavit téma a další různé nastavení",
   "settings.app_configuration.title": "Nastavení aplikace",
   "settings.app_info.subtitle": "Zobrazit informace o aplikaci",

--- a/app/src/i18n/de.json
+++ b/app/src/i18n/de.json
@@ -249,6 +249,7 @@
   "rest.rest.label": "Pause",
   "rest.short.label": "Kurz",
   "rest.singular.label": "<em>{time}</em> Pause",
+  "rest.timer.stop.action": "Timer stoppen",
   "settings.app_configuration.subtitle": "Thema und sonstige Einstellungen anpassen",
   "settings.app_configuration.title": "App konfigurieren",
   "settings.app_info.subtitle": "Zeige App-Informationen an",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -312,6 +312,7 @@
   "rest.rest.label": "Rest",
   "rest.short.label": "Short",
   "rest.singular.label": "Rest <em>{time}</em>",
+  "rest.timer.stop.action": "Stop timer",
   "settings.app_configuration.subtitle": "Adjust theme and other misc. settings",
   "settings.app_configuration.title": "App configuration",
   "settings.app_info.subtitle": "Display app information",

--- a/app/src/i18n/es.json
+++ b/app/src/i18n/es.json
@@ -216,6 +216,7 @@
   "rest.notifications.title": "Notificaciones de descanso",
   "rest.short.label": "Corto",
   "rest.singular.label": "Descanse <em>{time}</em>",
+  "rest.timer.stop.action": "Detener temporizador",
   "settings.app_configuration.subtitle": "Ajustar tema y otros ajustes varios",
   "settings.app_configuration.title": "Configuración de la aplicación",
   "settings.app_info.subtitle": "Mostrar información de la aplicación",

--- a/app/src/i18n/fi.json
+++ b/app/src/i18n/fi.json
@@ -241,6 +241,7 @@
   "rest.notifications.title": "Lepoajan ilmoitukset",
   "rest.short.label": "Lyhyt",
   "rest.singular.label": "Lepää <em>{time}</em>",
+  "rest.timer.stop.action": "Pysäytä ajastin",
   "settings.app_configuration.subtitle": "Säädä teema ja muita asetuksia",
   "settings.app_configuration.title": "Sovelluksen asetukset",
   "settings.app_info.subtitle": "Näytä sovelluksen tiedot",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -200,6 +200,7 @@
   "rest.notifications.title": "Notifications de repos",
   "rest.short.label": "Court",
   "rest.singular.label": "Repos <em>{time}</em>",
+  "rest.timer.stop.action": "Arrêter le minuteur",
   "settings.app_configuration.subtitle": "Ajustez le thème et d'autres paramètres divers",
   "settings.app_configuration.title": "Configuration de l'application",
   "settings.app_info.subtitle": "Afficher les informations de l'application",

--- a/app/src/i18n/hu.json
+++ b/app/src/i18n/hu.json
@@ -93,5 +93,6 @@
   "feed.feed.title": "Hírcsatorna",
   "feed.shared_session.save_to_plan.button": "Mentés az edzéstervbe",
   "feed.shared_session.start_workout.button": "Edzés megkezdése",
-  "stats.bodyweight_change.label": "Testsúly"
+  "stats.bodyweight_change.label": "Testsúly",
+  "rest.timer.stop.action": "Időzítő leállítása"
 }

--- a/app/src/i18n/it.json
+++ b/app/src/i18n/it.json
@@ -199,6 +199,7 @@
   "rest.notifications.title": "Notifche recupero",
   "rest.short.label": "Corto",
   "rest.singular.label": "Recupero <em>{time}</em>",
+  "rest.timer.stop.action": "Ferma timer",
   "settings.app_configuration.subtitle": "Regola tema e altre impostazioni varie",
   "settings.app_configuration.title": "Configurazione app",
   "settings.app_info.subtitle": "Mostra le informazioni dell'app",

--- a/app/src/i18n/nl.json
+++ b/app/src/i18n/nl.json
@@ -216,6 +216,7 @@
     "rest.notifications.title": "Rust notificaties",
     "rest.short.label": "Kort",
     "rest.singular.label": "Rust <em>{time}</em>",
+    "rest.timer.stop.action": "Timer stoppen",
     "settings.app_configuration.subtitle": "Pas thema en overige instellingen aan",
     "settings.app_configuration.title": "App configuratie",
     "settings.app_info.subtitle": "Toon app informatie",

--- a/app/src/i18n/pl.json
+++ b/app/src/i18n/pl.json
@@ -320,5 +320,6 @@
   "workout.upcoming.title": "Nadchodzące treningi",
   "workout.update_existing.confirm.body": "Czy chcesz zaktualizować istniejący trening o nazwie <em>{name}</em> czy dodać nowy trening?",
   "workout.workout.label": "Trening",
-  "workout.workout_lowercase.label": "Trening"
+  "workout.workout_lowercase.label": "Trening",
+  "rest.timer.stop.action": "Zatrzymaj timer"
 }

--- a/app/src/i18n/pt.json
+++ b/app/src/i18n/pt.json
@@ -309,6 +309,7 @@
   "rest.rest.label": "Descanso",
   "rest.short.label": "Curto",
   "rest.singular.label": "Descanso <em>{time}</em>",
+  "rest.timer.stop.action": "Parar temporizador",
   "settings.app_configuration.subtitle": "Ajuste o tema e outras configurações diversas",
   "settings.app_configuration.title": "Configurações do app",
   "settings.app_info.subtitle": "Exibir informações do aplicativo",

--- a/app/src/i18n/ru.json
+++ b/app/src/i18n/ru.json
@@ -220,6 +220,7 @@
   "rest.notifications.title": "Уведомления об отдыхе",
   "rest.short.label": "Короткий",
   "rest.singular.label": "Отдых <em>{time}</em>",
+  "rest.timer.stop.action": "Остановить таймер",
   "settings.app_configuration.subtitle": "Настройка темы и других параметров",
   "settings.app_configuration.title": "Настройки приложения",
   "settings.app_info.subtitle": "Информация о приложении",

--- a/app/src/i18n/sr.json
+++ b/app/src/i18n/sr.json
@@ -233,6 +233,7 @@
   "rest.rest.label": "Odmor",
   "rest.short.label": "Kratki odmor",
   "rest.singular.label": "Odmor <em>{time}</em>",
+  "rest.timer.stop.action": "Zaustavi tajmer",
   "settings.app_configuration.subtitle": "Podesite temu i ostala podešavanja",
   "settings.app_configuration.title": "Podešavanja aplikacije",
   "settings.app_info.subtitle": "Prikaži informacije o aplikaciji",

--- a/app/src/i18n/sv.json
+++ b/app/src/i18n/sv.json
@@ -290,6 +290,7 @@
   "rest.rest.label": "Vila",
   "rest.short.label": "Kort",
   "rest.singular.label": "Vila <em>{time}</em>",
+  "rest.timer.stop.action": "Stoppa timer",
   "settings.app_configuration.subtitle": "Ändra tema och övriga inställningar",
   "settings.app_configuration.title": "Appinställningar",
   "settings.app_info.subtitle": "Visa appinfo",

--- a/app/src/i18n/tr.json
+++ b/app/src/i18n/tr.json
@@ -61,5 +61,6 @@
     "exercise.no_exercises_found.message": "Egzersiz bulunamadı.",
     "exercise.previous_sessions_for.title": "{exercise} için önceki çalışmalar",
     "exercise.remove.confirm.body": "Egzersiz bu çalışma planından çıkarılacak, diğer çalışma planları etkilenmeyecek.",
-    "exercise.remove.confirm.title": "Egzersizi sil?"
+    "exercise.remove.confirm.title": "Egzersizi sil?",
+    "rest.timer.stop.action": "Zamanlayıcıyı durdur"
 }

--- a/app/src/i18n/uk.json
+++ b/app/src/i18n/uk.json
@@ -217,6 +217,7 @@
   "rest.notifications.title": "Сповіщення про відпочинок",
   "rest.short.label": "Короткий",
   "rest.singular.label": "Відпочинок <em>{time}</em>",
+  "rest.timer.stop.action": "Зупинити таймер",
   "settings.app_configuration.subtitle": "Налаштувати тему та інші різні параметри",
   "settings.app_configuration.title": "Конфігурація застосунку",
   "settings.app_info.subtitle": "Показати інформацію про застосунок",

--- a/app/src/i18n/zh_Hans.json
+++ b/app/src/i18n/zh_Hans.json
@@ -312,6 +312,7 @@
     "rest.rest.label": "休息",
     "rest.short.label": "短",
     "rest.singular.label": "休息 <em>{time}</em>",
+    "rest.timer.stop.action": "停止计时器",
     "settings.app_configuration.subtitle": "调整主题及其他设置",
     "settings.app_configuration.title": "应用设置",
     "settings.app_info.subtitle": "显示应用信息",

--- a/app/src/models/session-models.ts
+++ b/app/src/models/session-models.ts
@@ -355,15 +355,20 @@ export class Session {
     }
 
     let result: RecordedExercise | undefined = undefined;
-    let maxEpochSecond = Number.MIN_VALUE;
+    let maxEpochMilli = Number.MIN_VALUE;
 
     for (const recordedExercise of recordedExercises) {
       if (!recordedExercise.isComplete) {
         const latestTime = recordedExercise.latestTime;
-        const epochSecond = latestTime?.toEpochSecond() ?? Number.MIN_VALUE;
+        const epochMilli =
+          latestTime?.toInstant().toEpochMilli() ?? Number.MIN_VALUE;
 
-        if (epochSecond > maxEpochSecond || !result) {
-          maxEpochSecond = epochSecond;
+        if (
+          epochMilli > maxEpochMilli ||
+          (latestTime && epochMilli === maxEpochMilli) ||
+          !result
+        ) {
+          maxEpochMilli = epochMilli;
           result = recordedExercise;
         }
       }

--- a/app/src/store/current-session/effects.ts
+++ b/app/src/store/current-session/effects.ts
@@ -17,6 +17,8 @@ import {
   setCurrentSession,
   setCurrentSessionFromBlueprint,
   setIsHydrated,
+  setWorkoutSessionRestTimerStoppedAt,
+  stopRestTimer,
 } from '@/store/current-session';
 import { AddEffectFn } from '@/store/store';
 import { fetchUpcomingSessions, selectActiveProgram } from '@/store/program';
@@ -30,11 +32,14 @@ import { addUnpublishedSessionId } from '@/store/feed';
 import { setStatsIsDirty } from '@/store/stats';
 import {
   getCardioTimerInfo,
+  getRestTimerExercise,
   getTimerInfo,
 } from '@/store/current-session/helpers';
 import { ProtobufToJsonV1Migrator } from '@/models/storage/versions/v1/protobuf-migrator';
+import { OffsetDateTime } from '@js-joda/core';
 
 const storageKey = 'CurrentSessionStateV1';
+const restTimerStoppedAtStorageKey = `${storageKey}-RestTimerStoppedAt`;
 export function applyCurrentSessionEffects(addEffect: AddEffectFn) {
   addEffect(
     initializeCurrentSessionStateSlice,
@@ -72,6 +77,14 @@ export function applyCurrentSessionEffects(addEffect: AddEffectFn) {
             currentSessionStateDao,
           );
           if (currentSessionState.workoutSession) {
+            const restoredRestTimerStoppedAt =
+              getState().currentSession.workoutSessionRestTimerStoppedAt ??
+              parseStoredOffsetDateTime(
+                await keyValueStore.getItem(restTimerStoppedAtStorageKey),
+              );
+            dispatch(
+              setWorkoutSessionRestTimerStoppedAt(restoredRestTimerStoppedAt),
+            );
             dispatch(
               setCurrentSession({
                 target: 'workoutSession',
@@ -144,12 +157,22 @@ export function applyCurrentSessionEffects(addEffect: AddEffectFn) {
               stateAfterReduce.currentSession.workoutSession,
             ),
           });
+          const restTimerStoppedAt =
+            stateAfterReduce.currentSession.workoutSessionRestTimerStoppedAt;
           const bytes =
             LiftLog.Ui.Models.CurrentSessionStateDao.CurrentSessionStateDaoV2.encode(
               currentSessionStateDao,
             ).finish();
           await keyValueStore.setItem(`${storageKey}-Version`, '2');
           await keyValueStore.setItem(storageKey, bytes);
+          if (restTimerStoppedAt) {
+            await keyValueStore.setItem(
+              restTimerStoppedAtStorageKey,
+              restTimerStoppedAt.toString(),
+            );
+          } else {
+            await keyValueStore.removeItem(restTimerStoppedAtStorageKey);
+          }
         } catch (e) {
           logger.error('Failed to persist current session state', e);
         }
@@ -249,26 +272,37 @@ export function applyCurrentSessionEffects(addEffect: AddEffectFn) {
     },
   );
 
+  addEffect(stopRestTimer, async (_, { extra: { notificationService } }) => {
+    await notificationService.clearSetTimerNotification();
+  });
+
   addEffect(
     notifySetTimer,
     async (_, { extra: { notificationService }, getState }) => {
       await notificationService.clearSetTimerNotification();
       const {
         settings: { restNotifications },
-        currentSession: { workoutSession: sessionPOJO },
+        currentSession: {
+          workoutSession: sessionPOJO,
+          workoutSessionLastSetTime,
+        },
       } = getState();
       if (!restNotifications) {
         return;
       }
       const session = Session.fromPOJO(sessionPOJO);
-      const lastExercise = session?.lastExercise;
+      const restTimerExercise = session
+        ? getRestTimerExercise(session, workoutSessionLastSetTime)
+        : undefined;
       if (
         session?.nextExercise &&
-        lastExercise &&
-        lastExercise.latestTime &&
-        lastExercise instanceof RecordedWeightedExercise
+        restTimerExercise &&
+        restTimerExercise.latestTime &&
+        restTimerExercise instanceof RecordedWeightedExercise
       ) {
-        await notificationService.scheduleNextSetNotification(lastExercise);
+        await notificationService.scheduleNextSetNotification(
+          restTimerExercise,
+        );
       }
     },
   );
@@ -315,4 +349,15 @@ export function fromCurrentSessionDao(
         ProtobufToJsonV1Migrator.migrateSession(dao.historySession),
       ),
   };
+}
+
+function parseStoredOffsetDateTime(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return OffsetDateTime.parse(value);
+  } catch {
+    return undefined;
+  }
 }

--- a/app/src/store/current-session/helpers.ts
+++ b/app/src/store/current-session/helpers.ts
@@ -66,27 +66,56 @@ export function getCardioTimerInfo(
   };
 }
 
+export function getRestTimerExercise(
+  session: Session,
+  lastSetTime: OffsetDateTime | undefined,
+): RecordedWeightedExercise | undefined {
+  const weightedExercises = session.recordedExercises
+    .map((exercise, index) => ({ exercise, index }))
+    .filter(
+      (
+        entry,
+      ): entry is { exercise: RecordedWeightedExercise; index: number } =>
+        entry.exercise instanceof RecordedWeightedExercise &&
+        !!entry.exercise.latestTime,
+    );
+
+  const matchingLastSetTime = lastSetTime
+    ? weightedExercises.filter((entry) =>
+        entry.exercise.latestTime?.toInstant().equals(lastSetTime.toInstant()),
+      )
+    : [];
+
+  return (matchingLastSetTime.length ? matchingLastSetTime : weightedExercises)
+    .sort((a, b) => {
+      const timeDiff =
+        a.exercise.latestTime!.toInstant().toEpochMilli() -
+        b.exercise.latestTime!.toInstant().toEpochMilli();
+      return timeDiff === 0 ? a.index - b.index : timeDiff;
+    })
+    .at(-1)?.exercise;
+}
+
 export function getTimerInfo(
   session: Session,
   lastSetTime: OffsetDateTime | undefined,
 ): RestTimerInfo | undefined {
-  const lastExercise = session.lastExercise;
+  const restTimerExercise = getRestTimerExercise(session, lastSetTime);
   const nextExercise = session.nextExercise;
   if (
     !lastSetTime ||
-    !lastExercise ||
+    !restTimerExercise ||
     !nextExercise ||
-    !(nextExercise instanceof RecordedWeightedExercise) ||
-    !(lastExercise instanceof RecordedWeightedExercise)
+    !(nextExercise instanceof RecordedWeightedExercise)
   ) {
     return undefined;
   }
 
-  const repsPerSet = lastExercise.blueprint.repsPerSet;
+  const repsPerSet = restTimerExercise.blueprint.repsPerSet;
   const { minRest, maxRest, failureRest } =
-    lastExercise.blueprint.restBetweenSets;
+    restTimerExercise.blueprint.restBetweenSets;
 
-  const rest = match(lastExercise.lastRecordedSet)
+  const rest = match(restTimerExercise.lastRecordedSet)
     .with({ set: { repsCompleted: P.when((x) => x >= repsPerSet) } }, () => ({
       partialRest: minRest,
       fullRest: maxRest,

--- a/app/src/store/current-session/index.spec.ts
+++ b/app/src/store/current-session/index.spec.ts
@@ -1,0 +1,203 @@
+import { LocalDate, OffsetDateTime } from '@js-joda/core';
+import BigNumber from 'bignumber.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Rest,
+  SessionBlueprint,
+  WeightedExerciseBlueprint,
+} from '@/models/blueprint-models';
+import {
+  PotentialSet,
+  RecordedSet,
+  RecordedWeightedExercise,
+  Session,
+} from '@/models/session-models';
+import {
+  currentSessionReducer,
+  setCurrentSession,
+  setWorkoutSessionLastSetTime,
+  stopRestTimer,
+} from '@/store/current-session';
+import { Weight } from '@/models/weight';
+import { getTimerInfo } from '@/store/current-session/helpers';
+
+vi.mock('@/utils/uuid', () => ({
+  uuid: () => '00000000-0000-4000-8000-000000000000',
+  uuidParse: (value: string) => value,
+  uuidStringify: (value: string) => value,
+}));
+
+describe('current session rest timer', () => {
+  it('stops the current rest timer without needing a session change', () => {
+    const lastSetTime = OffsetDateTime.parse('2026-05-13T10:00:00Z');
+
+    const runningState = currentSessionReducer(
+      undefined,
+      setWorkoutSessionLastSetTime(lastSetTime),
+    );
+
+    expect(runningState.workoutSessionLastSetTime).toBe(lastSetTime);
+
+    const stoppedState = currentSessionReducer(runningState, stopRestTimer());
+
+    expect(stoppedState.workoutSessionLastSetTime).toBeUndefined();
+    expect(stoppedState.workoutSession).toBe(runningState.workoutSession);
+  });
+
+  it('keeps a stopped rest timer suppressed when the workout session is rehydrated', () => {
+    const lastSetTime = OffsetDateTime.parse('2026-05-13T10:00:00Z');
+    const session = createWorkoutSession(lastSetTime);
+
+    const runningState = currentSessionReducer(
+      undefined,
+      setCurrentSession({
+        target: 'workoutSession',
+        session,
+      }),
+    );
+    expect(runningState.workoutSessionLastSetTime?.equals(lastSetTime)).toBe(
+      true,
+    );
+
+    const stoppedState = currentSessionReducer(runningState, stopRestTimer());
+    expect(stoppedState.workoutSessionLastSetTime).toBeUndefined();
+
+    const rehydratedState = currentSessionReducer(
+      stoppedState,
+      setCurrentSession({
+        target: 'workoutSession',
+        session,
+      }),
+    );
+
+    expect(rehydratedState.workoutSessionLastSetTime).toBeUndefined();
+  });
+
+  it('starts the rest timer again when a newer set is recorded after stopping it', () => {
+    const stoppedSetTime = OffsetDateTime.parse('2026-05-13T10:00:00Z');
+    const nextSetTime = OffsetDateTime.parse('2026-05-13T10:07:00Z');
+
+    const runningState = currentSessionReducer(
+      undefined,
+      setCurrentSession({
+        target: 'workoutSession',
+        session: createWorkoutSession(stoppedSetTime),
+      }),
+    );
+    const stoppedState = currentSessionReducer(runningState, stopRestTimer());
+
+    const nextSetState = currentSessionReducer(
+      stoppedState,
+      setCurrentSession({
+        target: 'workoutSession',
+        session: createWorkoutSession(nextSetTime),
+      }),
+    );
+
+    expect(nextSetState.workoutSessionLastSetTime?.equals(nextSetTime)).toBe(
+      true,
+    );
+    expect(nextSetState.workoutSessionRestTimerStoppedAt).toBeUndefined();
+  });
+
+  it('can suppress the timer when the stop action is received before session hydration', () => {
+    const stoppedSetTime = OffsetDateTime.parse('2026-05-13T10:00:00Z');
+
+    const stoppedBeforeHydrationState = currentSessionReducer(
+      undefined,
+      stopRestTimer(stoppedSetTime),
+    );
+
+    const hydratedState = currentSessionReducer(
+      stoppedBeforeHydrationState,
+      setCurrentSession({
+        target: 'workoutSession',
+        session: createWorkoutSession(stoppedSetTime),
+      }),
+    );
+
+    expect(hydratedState.workoutSessionLastSetTime).toBeUndefined();
+  });
+
+  it('uses the newly completed exercise for rest when set timestamps tie', () => {
+    const setTime = OffsetDateTime.parse('2026-05-13T10:00:00Z');
+    const session = createTwoExerciseWorkoutSession(setTime);
+
+    expect(session.nextExercise?.blueprint.name).toBe('Bench Press');
+
+    const timerInfo = getTimerInfo(session, setTime);
+
+    expect(
+      timerInfo?.partiallyEndAt.equals(
+        setTime.plus(Rest.long.minRest).toInstant(),
+      ),
+    ).toBe(true);
+  });
+});
+
+function createWorkoutSession(lastSetTime: OffsetDateTime) {
+  const exercise = WeightedExerciseBlueprint.empty().with({
+    name: 'Squat',
+    sets: 2,
+    repsPerSet: 10,
+    restBetweenSets: Rest.medium,
+    weightIncreaseOnSuccess: BigNumber(0),
+  });
+  return new Session(
+    'session-id',
+    new SessionBlueprint('Workout', [exercise], ''),
+    [
+      new RecordedWeightedExercise(
+        exercise,
+        [
+          new PotentialSet(new RecordedSet(10, lastSetTime), Weight.NIL),
+          new PotentialSet(undefined, Weight.NIL),
+        ],
+        undefined,
+      ),
+    ],
+    LocalDate.parse('2026-05-13'),
+    undefined,
+  );
+}
+
+function createTwoExerciseWorkoutSession(lastSetTime: OffsetDateTime) {
+  const squat = WeightedExerciseBlueprint.empty().with({
+    name: 'Squat',
+    sets: 2,
+    repsPerSet: 10,
+    restBetweenSets: Rest.short,
+    weightIncreaseOnSuccess: BigNumber(0),
+  });
+  const benchPress = WeightedExerciseBlueprint.empty().with({
+    name: 'Bench Press',
+    sets: 2,
+    repsPerSet: 10,
+    restBetweenSets: Rest.long,
+    weightIncreaseOnSuccess: BigNumber(0),
+  });
+  return new Session(
+    'session-id',
+    new SessionBlueprint('Workout', [squat, benchPress], ''),
+    [
+      new RecordedWeightedExercise(
+        squat,
+        [
+          new PotentialSet(new RecordedSet(10, lastSetTime), Weight.NIL),
+          new PotentialSet(undefined, Weight.NIL),
+        ],
+        undefined,
+      ),
+      new RecordedWeightedExercise(
+        benchPress,
+        [
+          new PotentialSet(new RecordedSet(10, lastSetTime), Weight.NIL),
+          new PotentialSet(undefined, Weight.NIL),
+        ],
+        undefined,
+      ),
+    ],
+    LocalDate.parse('2026-05-13'),
+    undefined,
+  );
+}

--- a/app/src/store/current-session/index.ts
+++ b/app/src/store/current-session/index.ts
@@ -38,6 +38,7 @@ interface CurrentSessionState {
   feedSession: SessionPOJO | undefined;
   sharedSession: SessionPOJO | undefined;
   workoutSessionLastSetTime: OffsetDateTime | undefined;
+  workoutSessionRestTimerStoppedAt: OffsetDateTime | undefined;
   currentPlanDiff: PlanDiff | undefined;
 }
 
@@ -56,6 +57,7 @@ const initialState: CurrentSessionState = {
   feedSession: undefined,
   sharedSession: undefined,
   workoutSessionLastSetTime: undefined,
+  workoutSessionRestTimerStoppedAt: undefined,
   currentPlanDiff: undefined,
 };
 
@@ -90,6 +92,36 @@ function targetedSessionAction<T>(
       );
     }
   };
+}
+
+function isSameInstant(
+  a: OffsetDateTime | undefined,
+  b: OffsetDateTime | undefined,
+) {
+  return !!a && !!b && a.toInstant().equals(b.toInstant());
+}
+
+function updateWorkoutSessionLastSetTime(
+  state: SafeDraft<CurrentSessionState>,
+) {
+  const latestTime = Session.fromPOJO(state.workoutSession)?.lastExercise
+    ?.latestTime;
+  if (!latestTime) {
+    state.workoutSessionLastSetTime = undefined;
+    state.workoutSessionRestTimerStoppedAt = undefined;
+    return;
+  }
+
+  if (
+    state.workoutSessionRestTimerStoppedAt &&
+    !isSameInstant(latestTime, state.workoutSessionRestTimerStoppedAt)
+  ) {
+    state.workoutSessionRestTimerStoppedAt = undefined;
+  }
+
+  state.workoutSessionLastSetTime = state.workoutSessionRestTimerStoppedAt
+    ? undefined
+    : latestTime;
 }
 
 const currentSessionSlice = createSlice({
@@ -190,10 +222,7 @@ const currentSessionSlice = createSlice({
         );
         weightedRecorded.potentialSets[action.setIndex].set = repCount;
         if (target === 'workoutSession') {
-          state.workoutSessionLastSetTime =
-            repCount?.completionDateTime === undefined
-              ? Session.fromPOJO(session).lastExercise?.latestTime
-              : action.time;
+          updateWorkoutSessionLastSetTime(state);
         }
       },
     ),
@@ -333,10 +362,7 @@ const currentSessionSlice = createSlice({
               };
 
         if (target === 'workoutSession') {
-          state.workoutSessionLastSetTime =
-            action.reps === undefined
-              ? Session.fromPOJO(session).lastExercise?.latestTime
-              : action.time;
+          updateWorkoutSessionLastSetTime(state);
         }
       },
     ),
@@ -385,8 +411,7 @@ const currentSessionSlice = createSlice({
       state[action.payload.target] =
         action.payload.session?.toPOJO() as unknown as WritableDraft<SessionPOJO>;
       if (action.payload.target === 'workoutSession') {
-        state.workoutSessionLastSetTime =
-          action.payload.session?.lastExercise?.latestTime;
+        updateWorkoutSessionLastSetTime(toSafeDraft(state));
       }
     },
 
@@ -409,7 +434,29 @@ const currentSessionSlice = createSlice({
       state,
       action: PayloadAction<OffsetDateTime | undefined>,
     ) {
+      state.workoutSessionRestTimerStoppedAt = undefined;
       state.workoutSessionLastSetTime = action.payload;
+    },
+
+    setWorkoutSessionRestTimerStoppedAt(
+      state,
+      action: PayloadAction<OffsetDateTime | undefined>,
+    ) {
+      state.workoutSessionRestTimerStoppedAt = action.payload;
+      if (state.workoutSession) {
+        updateWorkoutSessionLastSetTime(toSafeDraft(state));
+      } else {
+        state.workoutSessionLastSetTime = undefined;
+      }
+    },
+
+    stopRestTimer(state, action: PayloadAction<OffsetDateTime | undefined>) {
+      const safeState = toSafeDraft(state);
+      state.workoutSessionRestTimerStoppedAt =
+        action.payload ??
+        Session.fromPOJO(safeState.workoutSession)?.lastExercise?.latestTime ??
+        state.workoutSessionLastSetTime;
+      state.workoutSessionLastSetTime = undefined;
     },
 
     updateDurationForCardioExercise: targetedSessionAction(
@@ -605,6 +652,8 @@ export const {
   setCurrentPlanDiff,
   updateBodyweight,
   setWorkoutSessionLastSetTime,
+  setWorkoutSessionRestTimerStoppedAt,
+  stopRestTimer,
   updateDurationForCardioExercise,
   updateDistanceForCardioExercise,
   updateCurrentBlockStartTimeForCardioExercise,

--- a/app/test/setup.ts
+++ b/app/test/setup.ts
@@ -4,5 +4,15 @@ import { vi } from 'vitest';
 vi.mock('react-native', () => ({}));
 vi.mock('react-native-reanimated', () => ({}));
 vi.mock('react-native-gesture-handler', () => ({}));
+vi.mock('@sentry/react-native', () => ({
+  captureEvent: vi.fn(),
+  captureException: vi.fn(),
+  withScope: vi.fn(
+    (
+      callback: (scope: { setFingerprint: (value: string[]) => void }) => void,
+    ) => callback({ setFingerprint: vi.fn() }),
+  ),
+  wrap: <T>(component: T) => component,
+}));
 vi.mock('expo-localization', () => ({}));
 vi.mock('expo', () => ({}));


### PR DESCRIPTION
Adds an in-app stop button for active rest timers.

This change:
- lets users dismiss the current rest timer without changing any workout sets
- uses the app theme's primary color for the stop button
- keeps the timer dismissed when the workout screen/session is restored
- adds focused tests for the rest timer state

https://github.com/user-attachments/assets/ef4a2686-c1b3-4528-aa5b-a5f1c23e0002

