### PR TITLE
fix: Retry Health Connect exports lost to app death or backgrounding

### DIFF
--- a/app/src/services/health-export-service.android.spec.ts
+++ b/app/src/services/health-export-service.android.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '@/models/session-models';
+
+const healthConnect = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  requestPermission: vi.fn(),
+  getGrantedPermissions: vi.fn(),
+  insertRecords: vi.fn(),
+  deleteRecordsByUuids: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({ Platform: { OS: 'android', Version: 35 } }));
+vi.mock('react-native-health-connect', () => ({
+  ...healthConnect,
+  ExerciseSegmentType: { WEIGHTLIFTING: 79, OTHER_WORKOUT: 0 },
+  ExerciseType: { WEIGHTLIFTING: 79 },
+}));
+
+import { HealthExportService } from './health-export-service.android';
+
+function startedWorkout(): Session {
+  return {
+    id: 'workout-id',
+    isStarted: true,
+    firstExercise: { earliestTime: '2026-07-31T10:00:00Z' },
+    lastExercise: { latestTime: '2026-07-31T11:00:00Z' },
+    recordedExercises: [],
+    blueprint: { name: 'Test workout' },
+  } as unknown as Session;
+}
+
+describe('Android HealthExportService permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    healthConnect.initialize.mockResolvedValue(true);
+    healthConnect.requestPermission.mockResolvedValue([]);
+    healthConnect.getGrantedPermissions.mockResolvedValue([]);
+    healthConnect.insertRecords.mockResolvedValue([]);
+    healthConnect.deleteRecordsByUuids.mockResolvedValue(undefined);
+  });
+
+  it('uses a non-interactive permission check when exporting', async () => {
+    healthConnect.getGrantedPermissions.mockResolvedValue([{ accessType: 'write', recordType: 'ExerciseSession' }]);
+
+    await new HealthExportService().exportWorkout(startedWorkout());
+
+    expect(healthConnect.getGrantedPermissions).toHaveBeenCalledOnce();
+    expect(healthConnect.requestPermission).not.toHaveBeenCalled();
+    expect(healthConnect.insertRecords).toHaveBeenCalledOnce();
+  });
+
+  it('requests permissions only when explicitly asked', async () => {
+    await new HealthExportService().requestPermission();
+
+    expect(healthConnect.requestPermission).toHaveBeenCalledWith([
+      { accessType: 'write', recordType: 'Weight' },
+      { accessType: 'write', recordType: 'ExerciseSession' },
+    ]);
+    expect(healthConnect.getGrantedPermissions).not.toHaveBeenCalled();
+  });
+
+  it('deletes only record types with write access', async () => {
+    healthConnect.getGrantedPermissions.mockResolvedValue([
+      { accessType: 'read', recordType: 'Weight' },
+      { accessType: 'write', recordType: 'ExerciseSession' },
+    ]);
+
+    await new HealthExportService().deleteWorkout('workout-id');
+
+    expect(healthConnect.deleteRecordsByUuids).toHaveBeenCalledOnce();
+    expect(healthConnect.deleteRecordsByUuids).toHaveBeenCalledWith('ExerciseSession', [], ['workout-id']);
+  });
+});

--- a/app/src/services/health-export-service.android.ts
+++ b/app/src/services/health-export-service.android.ts
@@ -4,6 +4,7 @@ import { RecordedCardioExercise, RecordedExercise, RecordedWeightedExercise, Ses
 import {
   initialize,
   requestPermission,
+  getGrantedPermissions,
   ExerciseSegmentType,
   ExerciseSessionRecord,
   ExerciseType,
@@ -25,11 +26,11 @@ export class HealthExportService implements HES {
     if (!this.canExport()) {
       return;
     }
-    const grantedPermissions = await this.requestPermissionInternal();
-    if (grantedPermissions.some((x) => x.recordType === 'Weight')) {
+    const grantedPermissions = await this.getGrantedPermissionsInternal();
+    if (grantedPermissions.some((x) => x.accessType === 'write' && x.recordType === 'Weight')) {
       await deleteRecordsByUuids('Weight', [], [workoutId]);
     }
-    if (grantedPermissions.some((x) => x.recordType === 'ExerciseSession')) {
+    if (grantedPermissions.some((x) => x.accessType === 'write' && x.recordType === 'ExerciseSession')) {
       await deleteRecordsByUuids('ExerciseSession', [], [workoutId]);
     }
   }
@@ -42,7 +43,9 @@ export class HealthExportService implements HES {
       return;
     }
 
-    const grantedPermissions = await this.requestPermissionInternal();
+    // Non-interactive on purpose: the permission activity round-trip can hang or die when the
+    // app backgrounds right after a workout. The interactive request runs from the settings toggle.
+    const grantedPermissions = await this.getGrantedPermissionsInternal();
 
     const exerciseSegments = workout.recordedExercises.filter((x) => x.isStarted).map(toExerciseSegment);
     const exerciseSessionRecord: ExerciseSessionRecord = {
@@ -56,13 +59,13 @@ export class HealthExportService implements HES {
       endTime: workout.lastExercise.latestTime!.toString(),
       title: workout.blueprint.name,
     };
-    if (grantedPermissions.some((x) => x.recordType === 'ExerciseSession')) {
+    if (grantedPermissions.some((x) => x.accessType === 'write' && x.recordType === 'ExerciseSession')) {
       await insertRecords([exerciseSessionRecord]);
     }
     if (
       workout.bodyweight &&
       workout.bodyweight.unit !== 'nil' &&
-      grantedPermissions.some((x) => x.recordType === 'Weight')
+      grantedPermissions.some((x) => x.accessType === 'write' && x.recordType === 'Weight')
     ) {
       await insertRecords([
         {
@@ -91,6 +94,12 @@ export class HealthExportService implements HES {
       { accessType: 'write', recordType: 'Weight' },
       { accessType: 'write', recordType: 'ExerciseSession' },
     ]);
+  }
+
+  private async getGrantedPermissionsInternal() {
+    await initialize();
+
+    return await getGrantedPermissions();
   }
 }
 


### PR DESCRIPTION
## Problem

The Health Connect export fires once, in foreground JS, at the moment the user taps Finish (`addStoredSession` effect), and `exportWorkout` starts with the **interactive** `requestPermission()` — an ActivityResult round-trip awaited with no timeout. If the user backgrounds the app or the process dies right after finishing (very common at the gym: tap Finish, pocket the phone), the await hangs or dies before `insertRecords` runs. Nothing is logged and there is no retry, so the workout silently never reaches Health Connect.

Field evidence from my device (Galaxy S21+, Android 15, LiftLog 4.12.0): only 1 of 4 workouts over three weeks landed in Health Connect. LiftLog's own persisted logs show all three lost workouts had `addStoredSession completed` followed by an app cold start 7–26 s later, and `Failed to sync to health aggregator` never appears — the insert didn't throw, it never completed.

## Fix

- **`health-export-service.android.ts`**: `exportWorkout`/`deleteWorkout` now check `getGrantedPermissions()` (non-interactive, no activity needed) instead of launching the permission UI. The interactive request still runs where it belongs — when the export toggle is switched on (`setExportToHealthAggregator` effect).
- **`stored-sessions/effects.ts`**: session ids are queued in the key-value store *before* each export attempt and cleared on success. Queued ids are re-exported after stored sessions hydrate on launch. Mutations of the queue key are serialized through a promise chain so the finish-time effect and the launch-time retry can't interleave a read-modify-write.

Re-exports are idempotent: Android inserts carry `clientRecordId` (upsert), iOS deletes-then-reinserts keyed on `workoutId` metadata, so retrying a write that actually landed cannot duplicate it. Sessions deleted while queued are dropped from the queue rather than retried forever.

## Tradeoffs to be aware of

- If Health Connect write permission is revoked, `exportWorkout` still resolves after skipping the insert (same silent-skip semantics as before), so the id is dequeued — the workout won't retry when permission returns. Keeping it queued would retry forever; happy to add a `logger.warn` there if you'd like.
- The retry runs once per launch (after hydration). Toggling the setting off and back on doesn't flush the queue until the next launch.

## Testing

- `npm test`: 633 passing (11 new tests in `stored-sessions/effects.spec.ts` covering queue-before-export ordering, failure retention, no double-queueing, launch retry, deleted-session dropout, and the disabled-toggle paths).
- `oxfmt --check`, `oxlint`/`eslint`: no new findings (the two pre-existing oxlint `no-unsafe-assignment` errors in `settings/effects.ts` are on `main` too).
- **Verified on device** (Galaxy S21+, Android 15, sideloaded build): finishing a workout in the foreground exports and drains the queue; and with the exported record deleted from Health Connect and the id seeded back into the queue (simulating death mid-export), the next launch re-created the record with the original workout timestamps and no duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
