### PR TITLE
fix: drop unticketable checkboxes from bot welcome comments

### DIFF
--- a/.github/workflows/discussion-welcome-comment.yml
+++ b/.github/workflows/discussion-welcome-comment.yml
@@ -19,9 +19,11 @@ jobs:
 
             Please write in your own words. AI-generated summaries tend to be more verbose than necessary and [frustrating to read](https://www.seangoedecke.com/dont-feed-me-slop/).
 
-            - [ ] Written in your own words, describing the problem or idea clearly.
-            - [ ] Written in your original language. If you're not comfortable in English, write in your own language and it can be translated if needed.
-            - [ ] Searched existing [discussions](https://github.com/LiamMorrow/LiftLog/discussions) to check this hasn't already been raised.
+            A few things that help:
+
+            - Written in your own words, describing the problem or idea clearly.
+            - Written in your original language. If you're not comfortable in English, write in your own language and it can be translated if needed.
+            - Search existing [discussions](https://github.com/LiamMorrow/LiftLog/discussions) to check this hasn't already been raised.
 
             See the [Contributing guide](https://github.com/LiamMorrow/LiftLog/blob/main/CONTRIBUTING.md) for more.`;
             await github.graphql(`

--- a/.github/workflows/pr-template-comment.yml
+++ b/.github/workflows/pr-template-comment.yml
@@ -15,16 +15,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = `Thanks for opening a PR! Before this can be reviewed, please make sure you've done the following.
+            const body = `Thanks for opening a PR!
 
-            Please write in your own words. AI-generated summaries tend to be more verbose than necessary and [frustrating to read](https://www.seangoedecke.com/dont-feed-me-slop/).
+            A few things that help this get reviewed:
 
-            - [ ] Described your changes clearly in the PR description in your own words.
-            - [ ] Read the [AI Usage Policy](https://github.com/LiamMorrow/LiftLog/blob/main/CONTRIBUTING.md#ai-usage-policy)
-            - [ ] Attached screenshots of any visual changes.
-            - [ ] Confirmed this PR was raised after an issue/feature request was accepted as wanted for the project (see [Contributing](https://github.com/LiamMorrow/LiftLog/blob/main/CONTRIBUTING.md))
+            - Describe your changes clearly in the PR description, in your own words. AI-generated summaries tend to be more verbose than necessary and [frustrating to read](https://www.seangoedecke.com/dont-feed-me-slop/).
+            - Read the [AI Usage Policy](https://github.com/LiamMorrow/LiftLog/blob/main/CONTRIBUTING.md#ai-usage-policy).
+            - Attach screenshots of any visual changes.
+            - Make sure this PR follows an issue/feature request that's already been accepted as wanted (see [Contributing](https://github.com/LiamMorrow/LiftLog/blob/main/CONTRIBUTING.md)).
 
-            Tick each box above once done.`;
+            PRs that clearly don't follow these likely won't get reviewed in a reasonable timeframe.`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
We were asking users to check boxes which they could not check. This pr amends the comments about ai usage to be purely informational