### PR TITLE
Restore custom exercises from backups

### DIFF
--- a/app/src/models/backup.ts
+++ b/app/src/models/backup.ts
@@ -7,6 +7,7 @@ import {
   SessionUserEvent,
 } from '@/models/feed-models';
 import { Session } from '@/models/session-models';
+import { ExerciseDescriptor } from '@/models/exercise-models';
 
 export interface FeedBackupData {
   identity: FeedIdentity;
@@ -19,5 +20,6 @@ export interface FeedBackupData {
 export interface BackupData {
   workouts: Session[];
   programs: Record<string, ProgramBlueprint>;
+  exercises?: Record<string, ExerciseDescriptor>;
   feed?: FeedBackupData;
 }

--- a/app/src/store/settings/import-backup-effects.spec.ts
+++ b/app/src/store/settings/import-backup-effects.spec.ts
@@ -9,7 +9,7 @@ import { FeedIdentity } from '@/models/feed-models';
 import { ProgramBlueprint } from '@/models/blueprint-models';
 import { EmptySession, Session } from '@/models/session-models';
 import { uuid } from '@/utils/uuid';
-import { upsertStoredSessions } from '@/store/stored-sessions';
+import { upsertExercises, upsertStoredSessions } from '@/store/stored-sessions';
 import { upsertSavedPlans } from '@/store/program';
 import { showSnackbar } from '@/store/app';
 
@@ -35,6 +35,7 @@ describe('import-backup-effects', () => {
     expect(dispatchedImport.payload.workouts).toHaveLength(420);
     expect(dispatchedImport.payload.feed).toBeDefined();
     expect(Object.values(dispatchedImport.payload.programs)).toHaveLength(13);
+    expect(Object.values(dispatchedImport.payload.exercises ?? {})).toHaveLength(962);
     expect(dispatchedImport.payload.successMessage).toBe('Restore complete!');
   });
 
@@ -73,6 +74,18 @@ describe('import-backup-effects', () => {
 
     const mockWorkouts = [EmptySession, EmptySession.with({ id: uuid() })] as Session[];
     const mockPrograms = {} as Record<string, ProgramBlueprint>;
+    const mockExercises = {
+      custom: {
+        name: 'Custom exercise',
+        force: null,
+        level: '',
+        mechanic: null,
+        equipment: null,
+        muscles: [],
+        instructions: '',
+        category: '',
+      },
+    };
     const mockFeed: FeedBackupData = {
       identity: {} as FeedIdentity,
       feedItems: [],
@@ -85,6 +98,7 @@ describe('import-backup-effects', () => {
       importBackupData({
         workouts: mockWorkouts,
         programs: mockPrograms,
+        exercises: mockExercises,
         feed: mockFeed,
         successMessage: 'Restore complete!',
       }),
@@ -92,6 +106,7 @@ describe('import-backup-effects', () => {
 
     expect(testBed.getDispatchedAction(upsertStoredSessions).payload).toBe(mockWorkouts);
     expect(testBed.getDispatchedAction(upsertSavedPlans).payload).toBe(mockPrograms);
+    expect(testBed.getDispatchedAction(upsertExercises).payload).toBe(mockExercises);
     expect(testBed.getDispatchedAction(showSnackbar).payload.text).toBe('Restore complete!');
     expect(testBed.getDispatchedAction(beginFeedImport).payload).toBe(mockFeed);
   });

--- a/app/src/store/settings/import-backup-effects.ts
+++ b/app/src/store/settings/import-backup-effects.ts
@@ -4,7 +4,7 @@ import { showSnackbar } from '@/store/app';
 import { AddEffectFn } from '@/store/store';
 import { upsertSavedPlans } from '@/store/program';
 import { beginFeedImport, importBackupData, importData, importDataProto, importDataSql } from '@/store/settings';
-import { upsertStoredSessions } from '@/store/stored-sessions';
+import { upsertExercises, upsertStoredSessions } from '@/store/stored-sessions';
 import { streamToUint8Array, writeInChunks } from '@/utils/stream';
 import { sleep } from '@/utils/sleep';
 import { Session } from '@/models/session-models';
@@ -24,6 +24,7 @@ import { DatabaseMigrationService } from '@/services/database-migration-service'
 import { FeedBackupData } from '@/models/backup';
 import {
   dataMigrationsSchema,
+  exercisesSchema,
   feedFollowedUsersSchema,
   feedFollowerUsersSchema,
   feedFollowRequestsSchema,
@@ -41,11 +42,13 @@ import {
   sessionUserEventMigrations,
   followedFeedUserMigrations,
   followerFeedUserMigrations,
+  exerciseDescriptorMigrations,
   programBlueprintMigrations,
   sessionMigrations,
   pendingFeedUserMigrations,
 } from '@/models/storage/versions/migrations';
 import { FeedUserJSON } from '@/models/storage/versions/latest';
+import { fromExerciseDescriptorJSON } from '@/models/exercise-models';
 
 export function addImportBackupEffects(addEffect: AddEffectFn) {
   addEffect(importData, async (_, { dispatch, extra: { filePickerService, logger, tolgee } }) => {
@@ -81,9 +84,12 @@ export function addImportBackupEffects(addEffect: AddEffectFn) {
   });
 
   addEffect(importBackupData, async ({ payload }, { dispatch, extra: { db, databaseMigrationService } }) => {
-    const { workouts, programs, feed, successMessage } = payload;
+    const { workouts, programs, exercises, feed, successMessage } = payload;
     dispatch(upsertStoredSessions(workouts));
     dispatch(upsertSavedPlans(programs));
+    if (exercises) {
+      dispatch(upsertExercises(exercises));
+    }
     dispatch(
       showSnackbar({
         text: successMessage,
@@ -118,6 +124,13 @@ export function addImportBackupEffects(addEffect: AddEffectFn) {
         ),
         {},
       );
+      const exercises = (await drizzleBackupDb.select().from(exercisesSchema)).reduce(
+        toRecord(
+          (x) => x.id,
+          (x) => fromExerciseDescriptorJSON(exerciseDescriptorMigrations.migrate(x.payload)),
+        ),
+        {},
+      );
       const feedIdentityDb = (await drizzleBackupDb.select().from(feedIdentitySchema)).at(0);
 
       let feed: FeedBackupData | undefined;
@@ -146,6 +159,7 @@ export function addImportBackupEffects(addEffect: AddEffectFn) {
       dispatch(
         importBackupData({
           programs,
+          exercises,
           workouts,
           feed,
           successMessage: tolgee.t('Restore complete!'),

--- a/app/src/store/stored-sessions/effects.spec.ts
+++ b/app/src/store/stored-sessions/effects.spec.ts
@@ -12,12 +12,13 @@ import {
   sessionFinished,
   setActiveSessionId,
   setStoredSessions,
+  upsertExercises,
   upsertStoredSessions,
 } from '@/store/stored-sessions';
 import { addUnpublishedSessionId } from '@/store/feed';
 import { setStatsIsDirty } from '@/store/stats';
 import { createAddEffectTestBed } from '@/utils/__test__/add-effect-testbed';
-import { sessionsSchema } from '@/db/schema';
+import { exercisesSchema, sessionsSchema } from '@/db/schema';
 import { Session } from '@/models/session-models';
 import { toJsonString } from '@/models/storage/versions/latest';
 import type { RootState } from '@/store/store';
@@ -144,6 +145,25 @@ describe('stored-sessions effects', () => {
       const [row] = await db.select().from(sessionsSchema).where(eq(sessionsSchema.id, active.id));
       expect(row?.active).toBe(true);
     });
+  });
+
+  it('persists restored exercises', async () => {
+    const exercise = {
+      name: 'Custom exercise',
+      force: null,
+      level: '',
+      mechanic: null,
+      equipment: null,
+      muscles: [],
+      instructions: '',
+      category: '',
+    };
+    const testBed = bed({});
+
+    await testBed.dispatchHandled(upsertExercises({ custom: exercise }));
+
+    const [row] = await db.select().from(exercisesSchema).where(eq(exercisesSchema.id, 'custom'));
+    expect(row?.payload).toEqual(exercise);
   });
 
   describe('sessionFinished', () => {

--- a/app/src/store/stored-sessions/effects.ts
+++ b/app/src/store/stored-sessions/effects.ts
@@ -15,6 +15,7 @@ import {
   setStoredSessions,
   updateExercise,
   updateStoredSession,
+  upsertExercises,
   upsertStoredSessions,
 } from './index';
 import { fetchUpcomingSessions } from '@/store/program';
@@ -234,6 +235,25 @@ export function applyStoredSessionsEffects(addEffect: AddEffectFn) {
         id: action.payload.id,
         payload: toExerciseDescriptorJSON(action.payload.exercise),
       })
+      .onConflictDoUpdate({
+        target: exercisesSchema.id,
+        set: {
+          payload: sql.raw(`excluded.${exercisesSchema.payload.name}`),
+        },
+      });
+  });
+
+  addEffect(upsertExercises, async (action, { extra: { db } }) => {
+    const exercises = Object.entries(action.payload).map(([id, exercise]) => ({
+      id,
+      payload: toExerciseDescriptorJSON(exercise),
+    }));
+    if (!exercises.length) {
+      return;
+    }
+    await db
+      .insert(exercisesSchema)
+      .values(exercises)
       .onConflictDoUpdate({
         target: exercisesSchema.id,
         set: {

--- a/app/src/store/stored-sessions/index.spec.ts
+++ b/app/src/store/stored-sessions/index.spec.ts
@@ -20,6 +20,7 @@ import {
   setStoredSessions,
   deleteStoredSession,
   updateExercise,
+  upsertExercises,
   deleteExercise,
   restoreExercise,
   setExercises,
@@ -273,6 +274,15 @@ describe('storedSessions reducer', () => {
 
     state = storedSessionsReducer(state, setExercises({ '3': squat }));
     expect(Object.keys(state.savedExercises)).toEqual(['3']);
+  });
+
+  it('upserts restored exercises without replacing existing ones', () => {
+    const existing = exerciseDescriptor({ name: 'Existing' });
+    const restored = exerciseDescriptor({ name: 'Restored' });
+
+    const state = reduce(updateExercise({ id: 'existing', exercise: existing }), upsertExercises({ restored }));
+
+    expect(state.savedExercises).toEqual({ existing, restored });
   });
 
   it('merges built-in and saved exercises, with saved overriding by id and sorted by name', () => {

--- a/app/src/store/stored-sessions/index.ts
+++ b/app/src/store/stored-sessions/index.ts
@@ -134,6 +134,10 @@ const storedSessionsSlice = createSlice({
       state.savedExercises[action.payload.id] = action.payload.exercise;
       state.hiddenBuiltInIds = state.hiddenBuiltInIds.filter((x) => x !== action.payload.id);
     },
+    upsertExercises(state, action: PayloadAction<Record<string, ExerciseDescriptor>>) {
+      Object.assign(state.savedExercises, action.payload);
+      state.hiddenBuiltInIds = state.hiddenBuiltInIds.filter((x) => !action.payload[x]);
+    },
     deleteExercise(state, action: PayloadAction<string>) {
       if (state.builtInExercises[action.payload]) {
         // Deleting a built-in tombstones it (its override row, if any, is kept for undo).
@@ -236,6 +240,7 @@ export const {
   setActiveSessionId,
   deleteStoredSession,
   updateExercise,
+  upsertExercises,
   deleteExercise,
   restoreExercise,
   setExercises,


### PR DESCRIPTION
We were missing the custom exercise restoration from backups per issue: [https://github.com/LiamMorrow/LiftLog/issues/965](url)
Looked like this feature was intended since the custom exercise list was already part of the backup creation just not the restoration. Full disclosure this PR was created with ChatGPT. I only tested this on my Pixel 9 pro so android is likely fine but iOS is untested.

## Summary

- restore custom exercise descriptors from native SQLite backups
- merge restored exercises with exercises already saved on the destination device
- persist restored exercise rows through the existing stored-session effects

## Testing

- `npm test -- --run` — 74 test files and 1,228 tests passed
- changed files pass `oxfmt --check`
- manually verified on Android: create a custom exercise, export a backup, clear app data, restore the backup, and confirm the exercise appears in search

## Notes

Repository-wide typecheck and lint still report the same pre-existing failures present on unchanged `main`; this patch introduces no additional failures.